### PR TITLE
Add workspace component tests

### DIFF
--- a/packages/dtx-desktop/src/renderer/src/components/SubWorkspaceItem.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SubWorkspaceItem.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workspaceService } from '../services/workspaceService';
+
+vi.mock('../services/workspaceService', () => ({
+	workspaceService: {
+		setCurrentSubWorkspace: vi.fn()
+	}
+}));
+
+describe('SubWorkspaceItem Component Logic', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const handleSelectSubWorkspace = async (subWorkspace: string, isActive: boolean) => {
+		if (isActive) {
+			await workspaceService.setCurrentSubWorkspace(null);
+		} else {
+			await workspaceService.setCurrentSubWorkspace(subWorkspace);
+		}
+	};
+
+	it('selects sub-workspace when inactive', async () => {
+		await handleSelectSubWorkspace('DTXFiles.Test', false);
+		expect(workspaceService.setCurrentSubWorkspace).toHaveBeenCalledWith('DTXFiles.Test');
+	});
+
+	it('deselects sub-workspace when already active', async () => {
+		await handleSelectSubWorkspace('DTXFiles.Test', true);
+		expect(workspaceService.setCurrentSubWorkspace).toHaveBeenCalledWith(null);
+	});
+
+	it('computes display name without prefix', () => {
+		const subWorkspace = 'DTXFiles.MyFolder';
+		const displayName = subWorkspace.replace(/^DTXFiles\./, '');
+		expect(displayName).toBe('MyFolder');
+	});
+});

--- a/packages/dtx-desktop/src/renderer/src/components/Workspace.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/Workspace.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workspaceService } from '../services/workspaceService';
+import { workspaceStore } from '../stores/workspaceStore';
+import type { TreeNode } from '../stores/workspaceStore';
+
+vi.mock('../services/workspaceService', () => ({
+	workspaceService: {
+		selectWorkspace: vi.fn(),
+		loadSubWorkspaces: vi.fn(),
+		loadTreeStructure: vi.fn(),
+		clearWorkspace: vi.fn()
+	}
+}));
+
+vi.mock('../stores/workspaceStore', () => ({
+	workspaceStore: {
+		showNewSongForm: vi.fn()
+	}
+}));
+
+describe('Workspace Component Logic', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const handleSelectWorkspace = async () => {
+		await workspaceService.selectWorkspace();
+	};
+
+	const handleRefreshWorkspace = async () => {
+		await workspaceService.loadSubWorkspaces();
+		await workspaceService.loadTreeStructure();
+	};
+
+	const handleClearWorkspace = () => {
+		workspaceService.clearWorkspace();
+	};
+
+	const handleNewSong = () => {
+		workspaceStore.showNewSongForm();
+	};
+
+	const filterTreeNodes = (nodes: TreeNode[], query: string): TreeNode[] => {
+		if (!query.trim()) return nodes;
+
+		const searchTerm = query.toLowerCase();
+
+		const filterNode = (node: TreeNode): TreeNode | null => {
+			const nameMatches = node.name.toLowerCase().includes(searchTerm);
+			const songTitleMatches = node.songTitle?.toLowerCase().includes(searchTerm) || false;
+			const matches = nameMatches || songTitleMatches;
+
+			const filteredChildren = node.children
+				.map((child) => filterNode(child))
+				.filter((child): child is TreeNode => child !== null);
+
+			if (matches || filteredChildren.length > 0) {
+				return {
+					...node,
+					children: filteredChildren,
+					isExpanded: filteredChildren.length > 0 || node.isExpanded
+				};
+			}
+
+			return null;
+		};
+
+		return nodes
+			.map((node) => filterNode(node))
+			.filter((node): node is TreeNode => node !== null);
+	};
+
+	it('selects workspace through service', async () => {
+		await handleSelectWorkspace();
+		expect(workspaceService.selectWorkspace).toHaveBeenCalled();
+	});
+
+	it('refreshes workspace data', async () => {
+		await handleRefreshWorkspace();
+		expect(workspaceService.loadSubWorkspaces).toHaveBeenCalled();
+		expect(workspaceService.loadTreeStructure).toHaveBeenCalled();
+	});
+
+	it('clears workspace via service', () => {
+		handleClearWorkspace();
+		expect(workspaceService.clearWorkspace).toHaveBeenCalled();
+	});
+
+	it('opens new song form', () => {
+		handleNewSong();
+		expect(workspaceStore.showNewSongForm).toHaveBeenCalled();
+	});
+
+	it('filters tree nodes by query', () => {
+		const tree: TreeNode[] = [
+			{
+				name: 'Folder',
+				path: '/folder',
+				isExpanded: false,
+				isLoading: false,
+				children: [
+					{
+						name: 'Song1',
+						path: '/folder/song1',
+						isExpanded: false,
+						isLoading: false,
+						children: [],
+						hasChildren: false,
+						containsDtxFiles: true,
+						songTitle: 'Awesome Track'
+					}
+				],
+				hasChildren: true
+			},
+			{
+				name: 'Other',
+				path: '/other',
+				isExpanded: false,
+				isLoading: false,
+				children: [],
+				hasChildren: false
+			}
+		];
+
+		const result = filterTreeNodes(tree, 'awesome');
+		expect(result.length).toBe(1);
+		expect(result[0].name).toBe('Folder');
+		expect(result[0].isExpanded).toBe(true);
+		expect(result[0].children[0].name).toBe('Song1');
+	});
+
+	it('returns original tree when query empty', () => {
+		const tree: TreeNode[] = [
+			{
+				name: 'Folder',
+				path: '/folder',
+				isExpanded: false,
+				isLoading: false,
+				children: [],
+				hasChildren: false
+			}
+		];
+
+		expect(filterTreeNodes(tree, '')).toEqual(tree);
+	});
+
+	it('returns empty array when no nodes match', () => {
+		const tree: TreeNode[] = [
+			{
+				name: 'Folder',
+				path: '/folder',
+				isExpanded: false,
+				isLoading: false,
+				children: [],
+				hasChildren: false
+			}
+		];
+
+		expect(filterTreeNodes(tree, 'unknown')).toEqual([]);
+	});
+});

--- a/packages/dtx-desktop/src/renderer/src/components/WorkspaceTree.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/WorkspaceTree.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workspaceService } from '../services/workspaceService';
+import { linkingService } from '../services/linkingService';
+import type { TreeNode } from '../stores/workspaceStore';
+
+vi.mock('../services/workspaceService', () => ({
+	workspaceService: {
+		collapseTreeNode: vi.fn(),
+		expandTreeNode: vi.fn(),
+		selectSong: vi.fn()
+	}
+}));
+
+vi.mock('../services/linkingService', () => ({
+	linkingService: {
+		unlinkSimFileFromFolder: vi.fn()
+	}
+}));
+
+describe('WorkspaceTree Component Logic', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const handleSongSelect = (song: TreeNode) => {
+		workspaceService.selectSong(song);
+	};
+
+	const handleToggleNode = async (node: TreeNode) => {
+		if (node.isLoading) return;
+
+		if (node.containsDtxFiles) {
+			handleSongSelect(node);
+			return;
+		}
+
+		if (node.isExpanded) {
+			workspaceService.collapseTreeNode(node.path);
+		} else {
+			await workspaceService.expandTreeNode(node.path);
+		}
+	};
+
+	const handleUnlinkFolder = (event: Event, node: TreeNode) => {
+		event.stopPropagation();
+		linkingService.unlinkSimFileFromFolder(node.path);
+	};
+
+	const getIndentStyle = (level: number) => `padding-left: ${level * 20}px`;
+
+	it('does nothing when node is loading', async () => {
+		const node: TreeNode = {
+			name: 'Loading',
+			path: '/loading',
+			isExpanded: false,
+			isLoading: true,
+			children: [],
+			hasChildren: false,
+			containsDtxFiles: false
+		};
+
+		await handleToggleNode(node);
+		expect(workspaceService.expandTreeNode).not.toHaveBeenCalled();
+		expect(workspaceService.collapseTreeNode).not.toHaveBeenCalled();
+	});
+
+	it('selects song when node contains DTX files', async () => {
+		const node: TreeNode = {
+			name: 'Song',
+			path: '/song',
+			isExpanded: false,
+			isLoading: false,
+			children: [],
+			hasChildren: false,
+			containsDtxFiles: true
+		};
+
+		await handleToggleNode(node);
+		expect(workspaceService.selectSong).toHaveBeenCalledWith(node);
+	});
+
+	it('expands and collapses nodes', async () => {
+		const node: TreeNode = {
+			name: 'Folder',
+			path: '/folder',
+			isExpanded: false,
+			isLoading: false,
+			children: [],
+			hasChildren: false,
+			containsDtxFiles: false
+		};
+
+		await handleToggleNode(node);
+		expect(workspaceService.expandTreeNode).toHaveBeenCalledWith('/folder');
+
+		node.isExpanded = true;
+		await handleToggleNode(node);
+		expect(workspaceService.collapseTreeNode).toHaveBeenCalledWith('/folder');
+	});
+
+	it('handles song selection directly', () => {
+		const song: TreeNode = {
+			name: 'Song',
+			path: '/song',
+			isExpanded: false,
+			isLoading: false,
+			children: [],
+			hasChildren: false,
+			containsDtxFiles: true
+		};
+
+		handleSongSelect(song);
+		expect(workspaceService.selectSong).toHaveBeenCalledWith(song);
+	});
+
+	it('unlinks folder and stops propagation', () => {
+		const node: TreeNode = {
+			name: 'Song',
+			path: '/song',
+			isExpanded: false,
+			isLoading: false,
+			children: [],
+			hasChildren: false,
+			containsDtxFiles: true,
+			linkedSimFileId: '1'
+		} as TreeNode;
+		const event = { stopPropagation: vi.fn() } as unknown as Event;
+
+		handleUnlinkFolder(event, node);
+		expect(event.stopPropagation).toHaveBeenCalled();
+		expect(linkingService.unlinkSimFileFromFolder).toHaveBeenCalledWith('/song');
+	});
+
+	it('returns correct indentation style', () => {
+		expect(getIndentStyle(2)).toBe('padding-left: 40px');
+	});
+});


### PR DESCRIPTION
## Summary
- add logic-based tests for `SubWorkspaceItem` component
- add logic-based tests for `WorkspaceTree` component
- add logic-based tests for `Workspace` component
- extend filtering tests for unmatched queries
- remove try-catch blocks in workspace component tests

## Testing
- `npm test -w=dtx-desktop`
- `npm run lint` *(fails: 79 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68638d7e1a248332aae4d01ddf12fff8