### PR TITLE
chore: replace npm commands with bun across docs and config

### DIFF
--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -253,7 +253,7 @@ get_commands_for_language() {
             echo "cargo test && cargo clippy"
             ;;
         *"JavaScript"*|*"TypeScript"*)
-            echo "npm test \\&\\& npm run lint"
+            echo "bun run test \\&\\& bun run lint"
             ;;
         *)
             echo "# Add commands for $lang"

--- a/e2e/fixtures/README.md
+++ b/e2e/fixtures/README.md
@@ -21,20 +21,20 @@ This directory contains TypeScript-generated MIDI test fixtures for the Playwrig
 ### Generate Fixtures
 
 ```bash
-npm run fixtures:generate
+bun run fixtures:generate
 ```
 
 ### Verify Fixtures
 
 ```bash
-npm run fixtures:verify
+bun run fixtures:verify
 ```
 
 ### Run E2E Tests
 
 ```bash
-npm run e2e
-npm run e2e:ui  # Interactive UI mode
+bun run e2e
+bun run e2e:ui  # Interactive UI mode
 ```
 
 ## Technical Details

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -10,21 +10,21 @@ If you're seeing this, you've probably already done this step. Congrats!
 
 ```bash
 # create a new project in the current directory
-npx sv create
+bunx sv create
 
 # create a new project in my-app
-npx sv create my-app
+bunx sv create my-app
 ```
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `bun install`, start a development server:
 
 ```bash
-npm run dev
+bun run dev
 
 # or start the server and open the app in a new browser tab
-npm run dev -- --open
+bun run dev -- --open
 ```
 
 Everything inside `src/lib` is part of your library, everything inside `src/routes` can be used as a showcase or preview app.
@@ -34,16 +34,16 @@ Everything inside `src/lib` is part of your library, everything inside `src/rout
 To build your library:
 
 ```bash
-npm run package
+bun run package
 ```
 
 To create a production version of your showcase app:
 
 ```bash
-npm run build
+bun run build
 ```
 
-You can preview the production build with `npm run preview`.
+You can preview the production build with `bun run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
 
@@ -54,5 +54,5 @@ Go into the `package.json` and give your package the desired name through the `"
 To publish your library to [npm](https://www.npmjs.com):
 
 ```bash
-npm publish
+bun publish
 ```

--- a/packages/dtx-desktop/README.md
+++ b/packages/dtx-desktop/README.md
@@ -11,24 +11,24 @@ An Electron application with Svelte and TypeScript
 ### Install
 
 ```bash
-$ npm install
+$ bun install
 ```
 
 ### Development
 
 ```bash
-$ npm run dev
+$ bun run dev
 ```
 
 ### Build
 
 ```bash
 # For windows
-$ npm run build:win
+$ bun run build:win
 
 # For macOS
-$ npm run build:mac
+$ bun run build:mac
 
 # For Linux
-$ npm run build:linux
+$ bun run build:linux
 ```

--- a/packages/dtx-web/README.md
+++ b/packages/dtx-web/README.md
@@ -8,21 +8,21 @@ If you're seeing this, you've probably already done this step. Congrats!
 
 ```bash
 # create a new project in the current directory
-npm create svelte@latest
+bunx sv create
 
 # create a new project in my-app
-npm create svelte@latest my-app
+bunx sv create my-app
 ```
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `bun install`, start a development server:
 
 ```bash
-npm run dev
+bun run dev
 
 # or start the server and open the app in a new browser tab
-npm run dev -- --open
+bun run dev -- --open
 ```
 
 ## Building
@@ -30,9 +30,9 @@ npm run dev -- --open
 To create a production version of your app:
 
 ```bash
-npm run build
+bun run build
 ```
 
-You can preview the production build with `npm run preview`.
+You can preview the production build with `bun run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -4,8 +4,8 @@ Export-only Svelte UI library that houses shadcn-svelte components shared across
 
 ## Develop
 
-- Start dev preview: `bun run dev --filter=@dtx/ui-components`
-- Build package: `bun run build --filter=@dtx/ui-components`
+- Start dev preview: `bun run --filter=@dtx/ui-components dev`
+- Build package: `bun run --filter=@dtx/ui-components build`
 
 ## Add shadcn-svelte Components
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -4,8 +4,8 @@ Export-only Svelte UI library that houses shadcn-svelte components shared across
 
 ## Develop
 
-- Start dev preview: `npm run dev -w=@dtx/ui-components`
-- Build package: `npm run build -w=@dtx/ui-components`
+- Start dev preview: `bun run dev --filter=@dtx/ui-components`
+- Build package: `bun run build --filter=@dtx/ui-components`
 
 ## Add shadcn-svelte Components
 
@@ -14,13 +14,13 @@ This package is preconfigured with `components.json` so the shadcn-svelte CLI wr
 1. Initialize once (writes theme to `src/app.css`):
 
 ```
-npx shadcn-svelte@latest init --cwd packages/ui-components
+bunx shadcn-svelte@latest init --cwd packages/ui-components
 ```
 
 2. Add components (example: Button):
 
 ```
-npx shadcn-svelte@latest add button --cwd packages/ui-components
+bunx shadcn-svelte@latest add button --cwd packages/ui-components
 ```
 
 3. Re-export from `src/lib/components/index.ts` so consumers can import:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'npm run dev -w=dtx-web',
+		command: 'bun run dev --filter=dtx-web',
 		url: 'http://localhost:5173',
 		reuseExistingServer: !process.env.CI,
 		env: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'bun run dev --filter=dtx-web',
+		command: 'bun run --filter=dtx-web dev',
 		url: 'http://localhost:5173',
 		reuseExistingServer: !process.env.CI,
 		env: {


### PR DESCRIPTION
## Summary
- Replace all `npm`/`npx` references with `bun`/`bunx` equivalents across README files, playwright config, and agent context script
- Ensures documentation matches the project's bun-based toolchain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test and development workflow configuration to use Bun instead of npm for running development servers and executing test commands.

* **Documentation**
  * Updated command documentation across all project packages and modules to reflect Bun usage, including installation, project scaffolding, local development, building, and publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->