### PR TITLE
fix: use portal action in Modal and remove transform class from card wrapper

### DIFF
--- a/packages/dtx-desktop/tsconfig.web.json
+++ b/packages/dtx-desktop/tsconfig.web.json
@@ -8,7 +8,12 @@
 		"../ui-components/src/lib/**/*.svelte",
 		"../ui-components/src/lib/**/*.ts"
 	],
-	"exclude": ["**/*.test.ts", "**/*.spec.ts"],
+	"exclude": [
+		"**/*.test.ts",
+		"**/*.spec.ts",
+		"../ui-components/src/lib/**/*.test.ts",
+		"../ui-components/src/lib/**/*.spec.ts"
+	],
 	"compilerOptions": {
 		"verbatimModuleSyntax": true,
 		"useDefineForClassFields": true,

--- a/packages/dtx-web/src/lib/components/ChartList.svelte
+++ b/packages/dtx-web/src/lib/components/ChartList.svelte
@@ -511,7 +511,7 @@
 	<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 		{#each filteredItems as item (item.id)}
 			<div
-				class="relative z-0 transform transition-all duration-300 focus-within:z-30 hover:z-30 hover:scale-105"
+				class="relative z-0 transition-all duration-300 focus-within:z-30 hover:z-30 hover:scale-105"
 			>
 				{#if selectMode && isBlog && enableDownload && canBulkSelect(item)}
 					<label class="absolute top-3 left-3 z-10 cursor-pointer">

--- a/packages/dtx-web/src/lib/components/ChartListItem.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartListItem.test.ts
@@ -411,5 +411,29 @@ describe('ChartListItem Component Logic', () => {
 
 			expect(source).toContain('style="overflow: visible;"');
 		});
+
+		it('Modal uses portal action so fixed positioning is not trapped by card transforms', () => {
+			const modalSource = readFileSync(
+				path.resolve(
+					process.cwd(),
+					'../../packages/ui-components/src/lib/components/Modal.svelte'
+				),
+				'utf-8'
+			);
+
+			expect(modalSource).toContain('use:portal');
+			expect(modalSource).toContain('document.body.appendChild(node)');
+		});
+
+		it('card wrapper in ChartList does not have a standalone transform class', () => {
+			const source = readFileSync(
+				path.resolve(process.cwd(), 'src/lib/components/ChartList.svelte'),
+				'utf-8'
+			);
+
+			// The card grid wrapper should not have a bare "transform" class (which creates
+			// a CSS containing block that traps position:fixed children like the delete modal)
+			expect(source).not.toMatch(/class="[^"]*\btransform\b[^"]*hover:scale-105[^"]*"/);
+		});
 	});
 });

--- a/packages/dtx-web/src/lib/components/ChartListItem.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartListItem.test.ts
@@ -5,7 +5,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 vi.mock('svelte-i18n');
 vi.mock('@skeletonlabs/skeleton-svelte', async () => {
@@ -415,8 +418,8 @@ describe('ChartListItem Component Logic', () => {
 		it('Modal uses portal action so fixed positioning is not trapped by card transforms', () => {
 			const modalSource = readFileSync(
 				path.resolve(
-					process.cwd(),
-					'../../packages/ui-components/src/lib/components/Modal.svelte'
+					__dirname,
+					'../../../../ui-components/src/lib/components/Modal.svelte'
 				),
 				'utf-8'
 			);

--- a/packages/ui-components/src/lib/components/Modal.svelte
+++ b/packages/ui-components/src/lib/components/Modal.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			}
+		};
+	}
+
 	type ModalSize = 'sm' | 'md' | 'lg';
 	type ConfirmVariant = 'primary' | 'danger';
 
@@ -60,6 +69,7 @@
 
 {#if open}
 	<div
+		use:portal
 		class="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center bg-black backdrop-blur-sm"
 		onclick={handleBackdropClick}
 		onkeydown={handleKeydown}

--- a/packages/ui-components/src/lib/components/Modal.svelte
+++ b/packages/ui-components/src/lib/components/Modal.svelte
@@ -2,6 +2,9 @@
 	import type { Snippet } from 'svelte';
 
 	function portal(node: HTMLElement) {
+		if (typeof document === 'undefined') {
+			return { destroy() {} };
+		}
 		document.body.appendChild(node);
 		return {
 			destroy() {

--- a/packages/ui-components/src/lib/components/Modal.test.ts
+++ b/packages/ui-components/src/lib/components/Modal.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Modal from './Modal.svelte';
+
+describe('Modal', () => {
+	describe('visibility', () => {
+		it('renders content when open is true', () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+			expect(screen.getByText('Test Modal')).toBeInTheDocument();
+		});
+
+		it('does not render when open is false', () => {
+			render(Modal, {
+				props: {
+					open: false,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('close button', () => {
+		it('closes the modal when the X button is clicked', async () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			await fireEvent.click(screen.getByLabelText('Close modal'));
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Escape key', () => {
+		it('closes the modal when Escape is pressed', async () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			await fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+
+		it('does not close when a non-Escape key is pressed', async () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			await fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+		});
+	});
+
+	describe('backdrop click', () => {
+		it('closes the modal when backdrop is clicked directly', async () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			const backdrop = screen.getByRole('dialog');
+			await fireEvent.click(backdrop, { target: backdrop, currentTarget: backdrop });
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('confirm button', () => {
+		it('shows cancel and confirm buttons when onConfirm is provided', () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {},
+					onConfirm: vi.fn()
+				}
+			});
+
+			expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+		});
+
+		it('does not show confirm/cancel buttons when onConfirm is not provided', () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {}
+				}
+			});
+
+			expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
+		});
+
+		it('calls onConfirm and closes modal when confirm button is clicked', async () => {
+			const onConfirm = vi.fn();
+
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {},
+					onConfirm
+				}
+			});
+
+			await fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+			expect(onConfirm).toHaveBeenCalledOnce();
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+
+		it('closes modal when cancel button is clicked without calling onConfirm', async () => {
+			const onConfirm = vi.fn();
+
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {},
+					onConfirm
+				}
+			});
+
+			await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+			expect(onConfirm).not.toHaveBeenCalled();
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+
+		it('uses custom confirmText and cancelText', () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'Test Modal',
+					children: () => {},
+					onConfirm: vi.fn(),
+					confirmText: 'Delete',
+					cancelText: 'Go back'
+				}
+			});
+
+			expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Go back' })).toBeInTheDocument();
+		});
+	});
+
+	describe('size prop', () => {
+		it('applies sm size class', () => {
+			render(Modal, {
+				props: { open: true, title: 'T', children: () => {}, size: 'sm' }
+			});
+
+			const inner = screen.getByRole('dialog').querySelector('div');
+			expect(inner?.className).toContain('max-w-sm');
+		});
+
+		it('applies lg size class', () => {
+			render(Modal, {
+				props: { open: true, title: 'T', children: () => {}, size: 'lg' }
+			});
+
+			const inner = screen.getByRole('dialog').querySelector('div');
+			expect(inner?.className).toContain('max-w-lg');
+		});
+	});
+
+	describe('confirmVariant prop', () => {
+		it('applies danger variant class to confirm button', () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'T',
+					children: () => {},
+					onConfirm: vi.fn(),
+					confirmVariant: 'danger'
+				}
+			});
+
+			const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+			expect(confirmBtn.className).toContain('bg-red-600');
+		});
+
+		it('applies primary variant class to confirm button by default', () => {
+			render(Modal, {
+				props: {
+					open: true,
+					title: 'T',
+					children: () => {},
+					onConfirm: vi.fn()
+				}
+			});
+
+			const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+			expect(confirmBtn.className).toContain('bg-blue-600');
+		});
+	});
+});

--- a/packages/ui-components/src/lib/components/Modal.test.ts
+++ b/packages/ui-components/src/lib/components/Modal.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
+import type { Snippet } from 'svelte';
 import Modal from './Modal.svelte';
+
+const noopSnippet = (() => null) as unknown as Snippet;
 
 describe('Modal', () => {
 	describe('visibility', () => {
@@ -9,7 +12,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -22,7 +25,7 @@ describe('Modal', () => {
 				props: {
 					open: false,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -36,7 +39,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -52,7 +55,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -66,7 +69,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -82,7 +85,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -99,7 +102,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {},
+					children: noopSnippet,
 					onConfirm: vi.fn()
 				}
 			});
@@ -113,7 +116,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {}
+					children: noopSnippet
 				}
 			});
 
@@ -128,7 +131,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {},
+					children: noopSnippet,
 					onConfirm
 				}
 			});
@@ -146,7 +149,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {},
+					children: noopSnippet,
 					onConfirm
 				}
 			});
@@ -162,7 +165,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'Test Modal',
-					children: () => {},
+					children: noopSnippet,
 					onConfirm: vi.fn(),
 					confirmText: 'Delete',
 					cancelText: 'Go back'
@@ -177,7 +180,7 @@ describe('Modal', () => {
 	describe('size prop', () => {
 		it('applies sm size class', () => {
 			render(Modal, {
-				props: { open: true, title: 'T', children: () => {}, size: 'sm' }
+				props: { open: true, title: 'T', children: noopSnippet, size: 'sm' }
 			});
 
 			const inner = screen.getByRole('dialog').querySelector('div');
@@ -186,7 +189,7 @@ describe('Modal', () => {
 
 		it('applies lg size class', () => {
 			render(Modal, {
-				props: { open: true, title: 'T', children: () => {}, size: 'lg' }
+				props: { open: true, title: 'T', children: noopSnippet, size: 'lg' }
 			});
 
 			const inner = screen.getByRole('dialog').querySelector('div');
@@ -200,7 +203,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'T',
-					children: () => {},
+					children: noopSnippet,
 					onConfirm: vi.fn(),
 					confirmVariant: 'danger'
 				}
@@ -215,7 +218,7 @@ describe('Modal', () => {
 				props: {
 					open: true,
 					title: 'T',
-					children: () => {},
+					children: noopSnippet,
 					onConfirm: vi.fn()
 				}
 			});

--- a/packages/ui-components/src/tests/setup.ts
+++ b/packages/ui-components/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/ui-components/vitest.config.ts
+++ b/packages/ui-components/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+export default defineConfig({
+	plugins: [sveltekit()],
+	test: {
+		environment: 'jsdom',
+		globals: true,
+		setupFiles: ['./src/tests/setup.ts'],
+		pool: 'forks',
+		exclude: ['**/node_modules/**', '**/dist/**'],
+		server: {
+			deps: {
+				inline: [/^svelte/, /@testing-library\/svelte/],
+				external: ['svelte/server']
+			}
+		},
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html', 'lcov'],
+			exclude: [
+				'**/node_modules/**',
+				'**/dist/**',
+				'**/.svelte-kit/**',
+				'**/*.test.ts',
+				'**/*.spec.ts',
+				'**/vite.config.ts',
+				'**/vitest.config.ts',
+				'**/svelte.config.js'
+			],
+			include: ['src/**/*.{js,ts,svelte}'],
+			all: true
+		}
+	},
+	resolve: {
+		conditions: ['browser']
+	}
+});


### PR DESCRIPTION
## Summary

- Add a `portal` Svelte action to `Modal.svelte` that appends the modal to `document.body`, ensuring `position: fixed` renders relative to the viewport rather than a transformed ancestor
- Remove the standalone `transform` class from the card wrapper in `ChartList.svelte`, which was creating a CSS containing block that trapped fixed-position children (e.g., the delete confirmation modal)
- Add tests verifying the portal action usage and the absence of `transform` on the card wrapper

## Why

CSS `transform` on a parent element creates a new containing block, causing `position: fixed` children to be positioned relative to that parent instead of the viewport. This caused the delete confirmation modal to be clipped/mispositioned within chart cards.

## Test plan

- [x] New unit test: verifies `use:portal` is present in Modal.svelte
- [x] New unit test: verifies no standalone `transform` class on the card grid wrapper
- [ ] Manual: open a chart card's delete modal and confirm it renders over the full viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix modal layering by rendering dialogs at the document root to avoid overlay/positioning issues.
  * Removed a CSS transform utility that could cause unwanted hover/scale effects on chart cards.

* **Tests**
  * Added regression and interaction tests to verify modal behavior, backdrop/keyboard dismissal, and to prevent transform-related card regressions.
  * Test runner/config and test setup added for the UI components package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->