### PR TITLE
Add comprehensive test coverage for editor and UI components

### DIFF
--- a/packages/common/src/lib/components/editor/MainTab.test.ts
+++ b/packages/common/src/lib/components/editor/MainTab.test.ts
@@ -209,10 +209,13 @@ describe('MainTab', () => {
 		render(MainTab);
 
 		const titleInput = screen.getByLabelText('Title:');
+		mockStore.currentDtxFile.set.mockClear();
 		await fireEvent.input(titleInput, { target: { value: 'New Title' } });
 
 		await waitFor(() => {
-			expect(mockStore.currentDtxFile.set).toHaveBeenCalled();
+			expect(mockStore.currentDtxFile.set).toHaveBeenLastCalledWith(
+				expect.objectContaining({ title: 'New Title' })
+			);
 		});
 	});
 });

--- a/packages/common/src/lib/components/editor/MainTab.test.ts
+++ b/packages/common/src/lib/components/editor/MainTab.test.ts
@@ -51,7 +51,7 @@ vi.mock('@dtx/ui-components', () => ({
 	ToggleGroup: vi.fn()
 }));
 
-import { render, screen, fireEvent } from '@testing-library/svelte';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import MainTab from './MainTab.svelte';
 
 describe('MainTab', () => {
@@ -163,5 +163,56 @@ describe('MainTab', () => {
 		const input = screen.getByLabelText('Number of Measures:');
 		await fireEvent.change(input);
 		expect(mockStore.measureCount.set).toHaveBeenCalled();
+	});
+
+	it('syncs dtxFile properties to store when dtxFile is non-null', async () => {
+		const mockDtxFile = {
+			title: 'Test Title',
+			artist: 'Test Artist',
+			comment: 'Test Comment',
+			bpm: 130,
+			level: 7
+		};
+
+		mockStore.currentDtxFile.subscribe.mockImplementation(
+			(cb: (v: typeof mockDtxFile | null) => void) => {
+				cb(mockDtxFile);
+				return () => {};
+			}
+		);
+
+		render(MainTab);
+
+		await waitFor(() => {
+			expect(mockStore.currentDtxFile.set).toHaveBeenCalledWith(
+				expect.objectContaining({ title: 'Test Title', artist: 'Test Artist' })
+			);
+		});
+	});
+
+	it('updates dtxFile title property when title input changes', async () => {
+		const mockDtxFile = {
+			title: 'Original Title',
+			artist: 'Artist',
+			comment: '',
+			bpm: 120,
+			level: 0
+		};
+
+		mockStore.currentDtxFile.subscribe.mockImplementation(
+			(cb: (v: typeof mockDtxFile | null) => void) => {
+				cb(mockDtxFile);
+				return () => {};
+			}
+		);
+
+		render(MainTab);
+
+		const titleInput = screen.getByLabelText('Title:');
+		await fireEvent.input(titleInput, { target: { value: 'New Title' } });
+
+		await waitFor(() => {
+			expect(mockStore.currentDtxFile.set).toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/common/src/lib/components/editor/SoundTab.test.ts
+++ b/packages/common/src/lib/components/editor/SoundTab.test.ts
@@ -664,4 +664,45 @@ describe('SoundTab key binding', () => {
 		await fireEvent.change(inputs[1], { target: { value: '5' } });
 		expect(chip.position).toBe(5);
 	});
+
+	it('plays remote audio when chip.file is set as fallback (not in FileManager)', async () => {
+		const fallbackFile = new File(['audio'], 'snare.wav', { type: 'audio/wav' });
+		(URL as unknown as Record<string, unknown>).createObjectURL = vi.fn(() => 'blob:mock-url');
+		mockFileManager.getFile.mockReturnValue(undefined);
+
+		const chip = new MockSoundChip('snare', 1, 100, 0, 'snare.wav');
+		chip.file = fallbackFile;
+
+		mockStore.currentSoundChip.subscribe.mockImplementation(
+			(cb: (v: MockSoundChip[]) => void) => {
+				cb([chip]);
+				return () => {};
+			}
+		);
+
+		render(SoundTab, { props: { simfileID: 'sim-1', bucketUrl: 'https://cdn.example.com' } });
+		const fileBtn = screen.getByText('snare.wav');
+		await fireEvent.click(fileBtn);
+
+		expect(URL.createObjectURL).toHaveBeenCalledWith(fallbackFile);
+	});
+
+	it('shows warning toast when remote chip has no bucketUrl and file not loaded', async () => {
+		mockFileManager.getFile.mockReturnValue(undefined);
+		const chip = new MockSoundChip('snare', 1, 100, 0, 'snare.wav');
+		// No chip.file and no bucketUrl provided
+
+		mockStore.currentSoundChip.subscribe.mockImplementation(
+			(cb: (v: MockSoundChip[]) => void) => {
+				cb([chip]);
+				return () => {};
+			}
+		);
+
+		render(SoundTab, { props: { simfileID: 'sim-1' } });
+		await fireEvent.click(screen.getByText('snare.wav'));
+
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+		expect(screen.getByRole('alert').textContent).toContain('not yet loaded from remote');
+	});
 });

--- a/packages/common/src/lib/components/editor/SoundTab.test.ts
+++ b/packages/common/src/lib/components/editor/SoundTab.test.ts
@@ -667,7 +667,8 @@ describe('SoundTab key binding', () => {
 
 	it('plays remote audio when chip.file is set as fallback (not in FileManager)', async () => {
 		const fallbackFile = new File(['audio'], 'snare.wav', { type: 'audio/wav' });
-		(URL as unknown as Record<string, unknown>).createObjectURL = vi.fn(() => 'blob:mock-url');
+		const createObjectURLFn = vi.fn(() => 'blob:mock-url');
+		(URL as unknown as Record<string, unknown>).createObjectURL = createObjectURLFn;
 		mockFileManager.getFile.mockReturnValue(undefined);
 
 		const chip = new MockSoundChip('snare', 1, 100, 0, 'snare.wav');
@@ -684,7 +685,7 @@ describe('SoundTab key binding', () => {
 		const fileBtn = screen.getByText('snare.wav');
 		await fireEvent.click(fileBtn);
 
-		expect(URL.createObjectURL).toHaveBeenCalledWith(fallbackFile);
+		expect(createObjectURLFn).toHaveBeenCalledWith(fallbackFile);
 	});
 
 	it('shows warning toast when remote chip has no bucketUrl and file not loaded', async () => {

--- a/packages/dtx-web/src/lib/components/ChartList.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartList.test.ts
@@ -175,6 +175,78 @@ describe('ChartList helpers', () => {
 		expect(fetchFn).not.toHaveBeenCalled();
 	});
 
+	it('throws when validation response is not ok', async () => {
+		const handle = { createWritable: vi.fn() };
+		const saveFilePickerWindow = {
+			showSaveFilePicker: vi.fn().mockResolvedValue(handle)
+		};
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(createJsonResponse({ error: 'Validation failed' }, 400));
+
+		await expect(
+			chartListHelpers.startBulkDownload({
+				ids: [mockListedChart.id],
+				fetchFn,
+				saveFilePickerWindow
+			})
+		).rejects.toThrow('Validation failed');
+
+		expect(handle.createWritable).not.toHaveBeenCalled();
+	});
+
+	it('throws when validation data has ok !== true', async () => {
+		const handle = { createWritable: vi.fn() };
+		const saveFilePickerWindow = {
+			showSaveFilePicker: vi.fn().mockResolvedValue(handle)
+		};
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(createJsonResponse({ ok: false, error: 'No files found' }));
+
+		await expect(
+			chartListHelpers.startBulkDownload({
+				ids: [mockListedChart.id],
+				fetchFn,
+				saveFilePickerWindow
+			})
+		).rejects.toThrow('No files found');
+	});
+
+	it('throws with default message when validation data has no error string', async () => {
+		const handle = { createWritable: vi.fn() };
+		const saveFilePickerWindow = {
+			showSaveFilePicker: vi.fn().mockResolvedValue(handle)
+		};
+		const fetchFn = vi.fn().mockResolvedValue(createJsonResponse({ ok: true, fileCount: 0 }));
+
+		await expect(
+			chartListHelpers.startBulkDownload({
+				ids: [mockListedChart.id],
+				fetchFn,
+				saveFilePickerWindow
+			})
+		).rejects.toThrow('No uploaded files found for the selected charts');
+	});
+
+	it('throws when validation data fileCount is not a number', async () => {
+		const handle = { createWritable: vi.fn() };
+		const saveFilePickerWindow = {
+			showSaveFilePicker: vi.fn().mockResolvedValue(handle)
+		};
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(createJsonResponse({ ok: true, fileCount: 'invalid' }));
+
+		await expect(
+			chartListHelpers.startBulkDownload({
+				ids: [mockListedChart.id],
+				fetchFn,
+				saveFilePickerWindow
+			})
+		).rejects.toThrow('No uploaded files found for the selected charts');
+	});
+
 	it('creates a writable from a file handle only when the response is streamed', async () => {
 		const writable = {} as WritableStream<Uint8Array>;
 		const handle = {
@@ -259,6 +331,54 @@ describe('ChartList component bulk download behavior', () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+	});
+
+	it('shows error toast when trying to select beyond MAX_BULK_DOWNLOAD_CHARTS items', async () => {
+		// Render with MAX items already in the data, select all, then try to select another
+		const maxCharts = Array.from(
+			{ length: chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS },
+			(_, i) => ({
+				...mockListedChart,
+				id: i + 1,
+				title: `Song ${i + 1}`,
+				display_id: `D${i + 1}`
+			})
+		);
+		const extraChart = {
+			...mockListedChart,
+			id: chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS + 1,
+			title: 'Extra Song',
+			display_id: 'EX'
+		};
+		const allCharts = [...maxCharts, extraChart];
+
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(createJsonResponse({ data: allCharts, count: allCharts.length }))
+		);
+		Object.defineProperty(window, 'showSaveFilePicker', { configurable: true, value: vi.fn() });
+
+		render(ChartList, { props: { isBlog: true, enableDownload: true } });
+		await fireEvent.click(await screen.findByRole('button', { name: 'Select' }));
+
+		// Select all MAX items
+		const checkboxes = await screen.findAllByRole('checkbox');
+		for (const checkbox of checkboxes.slice(0, chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS)) {
+			await fireEvent.click(checkbox);
+		}
+
+		// Try to select one more beyond the limit
+		await fireEvent.click(checkboxes[chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS]);
+
+		await waitFor(() => {
+			expect(mockToastStore.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: expect.stringContaining(`${chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS}`)
+				})
+			);
+		});
 	});
 
 	it('treats AbortError as a no-op and preserves the current selection', async () => {

--- a/packages/dtx-web/src/lib/components/ChartList.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartList.test.ts
@@ -369,6 +369,14 @@ describe('ChartList component bulk download behavior', () => {
 			await fireEvent.click(checkbox);
 		}
 
+		// Exactly MAX should still be allowed — no error at the boundary
+		expect(mockToastStore.error).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole('button', {
+				name: new RegExp(`download \\(${chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS}\\)`, 'i')
+			})
+		).toBeInTheDocument();
+
 		// Try to select one more beyond the limit
 		await fireEvent.click(checkboxes[chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS]);
 

--- a/packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/page.render.test.ts
+++ b/packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/page.render.test.ts
@@ -534,7 +534,7 @@ describe('Editor Page – SoundLibraryModal onImportResult callback', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('onImportResult sets importResultMessage and shows import result modal (lines 720-722)', () => {
+	it('onImportResult sets importResultMessage and shows import result modal', () => {
 		render(EditorPage, { props: { data: defaultData } });
 		const soundLibProps = getLastMockProps<Record<string, (msg: string) => void>>(
 			vi.mocked(SoundLibraryModalModule)
@@ -652,7 +652,7 @@ describe('Editor Page – sound chip loading loop in onMount', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('fetches remote files for each sound chip when loading simfile (lines 519-549)', async () => {
+	it('fetches remote files for each sound chip when loading simfile', async () => {
 		const mockFetchRemote = vi.fn().mockResolvedValue(undefined);
 		const mockChip = { fileName: 'snare.xa', fetchRemote: mockFetchRemote, file: undefined };
 		(mockHighestDtx.parseSoundChips as ReturnType<typeof vi.fn>).mockReturnValue([mockChip]);
@@ -675,7 +675,7 @@ describe('Editor Page – sound chip loading loop in onMount', () => {
 		});
 	});
 
-	it('handles fetchRemote error gracefully without crashing (catch block lines 537-543)', async () => {
+	it('handles fetchRemote error gracefully without crashing', async () => {
 		const mockFetchRemote = vi.fn().mockRejectedValue(new Error('Remote fetch failed'));
 		const mockChip = { fileName: 'bass.xa', fetchRemote: mockFetchRemote, file: undefined };
 		(mockHighestDtx.parseSoundChips as ReturnType<typeof vi.fn>).mockReturnValue([mockChip]);
@@ -711,7 +711,7 @@ describe('Editor Page – importFile and importFolder via EditorNavigation props
 		vi.restoreAllMocks();
 	});
 
-	it('importFile creates a file input and triggers click (lines 96-101)', () => {
+	it('importFile creates a file input and triggers click', () => {
 		const mockInput = {
 			type: '',
 			accept: '',
@@ -736,7 +736,7 @@ describe('Editor Page – importFile and importFolder via EditorNavigation props
 		expect(mockInput.click).toHaveBeenCalled();
 	});
 
-	it('importFolder creates a directory input and triggers click (lines 104-112)', () => {
+	it('importFolder creates a directory input and triggers click', () => {
 		const mockInput = {
 			type: '',
 			accept: '',
@@ -774,7 +774,7 @@ describe('Editor Page – switchToWorkspace via WorkspaceManagerModal prop', () 
 		vi.restoreAllMocks();
 	});
 
-	it('switchToWorkspace emits STOP_PREVIEW and sets workspace (lines 196-215)', async () => {
+	it('switchToWorkspace emits STOP_PREVIEW and sets workspace', async () => {
 		render(EditorPage, { props: { data: defaultData } });
 		const wmProps = getLastMockProps<Record<string, (ws: unknown) => Promise<void>>>(
 			vi.mocked(WorkspaceManagerModalModule)
@@ -814,7 +814,7 @@ describe('Editor Page – currentActiveScene function via Main mock props', () =
 		vi.restoreAllMocks();
 	});
 
-	it('currentActiveScene calls getIsLoaded when scene key matches Editor (lines 83-86)', () => {
+	it('currentActiveScene calls getIsLoaded when scene key matches Editor', () => {
 		render(EditorPage, { props: { data: defaultData } });
 		// Main is mocked as default export from @dtx/common/game
 		const mainProps = getLastMockProps<Record<string, unknown>>(vi.mocked(MainModule));
@@ -859,7 +859,7 @@ describe('Editor Page – DTXSwitcherModal switchWorkspaceDTX prop', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('switchWorkspaceDTX resolves without error when phaserRef.scene is null (lines 152-155)', async () => {
+	it('switchWorkspaceDTX resolves without error when phaserRef.scene is null', async () => {
 		render(EditorPage, { props: { data: defaultData } });
 		const dtxProps = getLastMockProps<Record<string, () => Promise<void>>>(
 			vi.mocked(DTXSwitcherModalModule)
@@ -879,7 +879,7 @@ describe('Editor Page – handleFolderImport callback', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('processes imported folder files and shows result (lines 124-143)', async () => {
+	it('processes imported folder files and shows result', async () => {
 		const mockInput = {
 			type: '',
 			webkitdirectory: false,
@@ -919,7 +919,7 @@ describe('Editor Page – handleFolderImport callback', () => {
 		expect(workspaceService.getWorkspaces).toHaveBeenCalled();
 	});
 
-	it('returns early when files is null in folder import (lines 119-122)', async () => {
+	it('returns early when files is null in folder import', async () => {
 		const mockInput = {
 			type: '',
 			webkitdirectory: false,
@@ -969,7 +969,7 @@ describe('Editor Page – handleFolderImport callback', () => {
 		expect(workspaceService.importFolder).not.toHaveBeenCalled();
 	});
 
-	it('shows import error modal when folder import fails (lines 144-148)', async () => {
+	it('shows import error modal when folder import fails', async () => {
 		const mockInput = {
 			type: '',
 			webkitdirectory: false,
@@ -1012,7 +1012,7 @@ describe('Editor Page – handleFileImport callback', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('returns early when no file is selected (lines 224-225)', async () => {
+	it('returns early when no file is selected', async () => {
 		const mockInput = {
 			type: '',
 			accept: '',
@@ -1039,7 +1039,7 @@ describe('Editor Page – handleFileImport callback', () => {
 		expect(vi.mocked(decodeFileWithEncodingDetection)).not.toHaveBeenCalled();
 	});
 
-	it('processes imported DTX file successfully (lines 227-270)', async () => {
+	it('processes imported DTX file successfully', async () => {
 		const mockInput = {
 			type: '',
 			accept: '',
@@ -1093,7 +1093,7 @@ describe('Editor Page – handleFileImport callback', () => {
 		);
 	});
 
-	it('shows import error modal when DTX file decoding fails (lines 271-275)', async () => {
+	it('shows import error modal when DTX file decoding fails', async () => {
 		const mockInput = {
 			type: '',
 			accept: '',
@@ -1136,7 +1136,7 @@ describe('Editor Page – newFile and createNewFile branches', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('shows NewFileModal when TempChartStorage.exists returns true (line 286)', () => {
+	it('shows NewFileModal when TempChartStorage.exists returns true', () => {
 		vi.mocked(TempChartStorage.exists).mockReturnValue(true);
 
 		render(EditorPage, { props: { data: defaultData } });
@@ -1158,7 +1158,7 @@ describe('Editor Page – newFile and createNewFile branches', () => {
 		expect(newFileProps?.onCancel).toBeDefined();
 	});
 
-	it('NewFileModal onConfirm calls createNewFile (line 753)', () => {
+	it('NewFileModal onConfirm calls createNewFile', () => {
 		render(EditorPage, { props: { data: defaultData } });
 		vi.mocked(TempChartStorage.remove).mockClear();
 
@@ -1184,7 +1184,7 @@ describe('Editor Page – newFile and createNewFile branches', () => {
 		expect(TempChartStorage.remove).not.toHaveBeenCalled();
 	});
 
-	it('createNewFile calls goto when simfileID is set (lines 323-325)', () => {
+	it('createNewFile calls goto when simfileID is set', () => {
 		const data = {
 			simfileID: 'active-sim-id',
 			metadata: { title: 'Song', levels: { 25: { label: 'Basic', fileName: 'bas.dtx' } } }
@@ -1213,7 +1213,7 @@ describe('Editor Page – data.metadata null path (parseFromRemoteURL)', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('uses parseFromRemoteURL when data.metadata is null (lines 490-496)', async () => {
+	it('uses parseFromRemoteURL when data.metadata is null', async () => {
 		const { SimFile } = await import('@dtx/common');
 		const data = { simfileID: 'remote-no-metadata', metadata: null };
 
@@ -1238,7 +1238,7 @@ describe('Editor Page – getAvailableLevels with non-null simfile', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('returns formatted level list when simfile has levels (lines 418-425)', () => {
+	it('returns formatted level list when simfile has levels', () => {
 		vi.mocked(get).mockReturnValue(mockSimfile as never);
 
 		render(EditorPage, { props: { data: defaultData } });
@@ -1265,7 +1265,7 @@ describe('Editor Page – refreshSoundLibraryLinks additional branches', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('skips chip when chip.file is already set (lines 582-584)', async () => {
+	it('skips chip when chip.file is already set', async () => {
 		const existingFile = new File(['data'], 'kick.xa');
 		const mockChip = { fileName: 'kick.xa', file: existingFile };
 		vi.mocked(get).mockReturnValue([mockChip] as never);
@@ -1281,7 +1281,7 @@ describe('Editor Page – refreshSoundLibraryLinks additional branches', () => {
 		expect(store.currentSoundChip.set).toHaveBeenCalled();
 	});
 
-	it('catches error and sets error message in refreshSoundLibraryLinks (lines 628-632)', async () => {
+	it('catches error and sets error message in refreshSoundLibraryLinks', async () => {
 		const mockChip = { fileName: 'kick.xa', file: undefined };
 		vi.mocked(get).mockReturnValue([mockChip] as never);
 		vi.mocked(SoundLibrary.findByFileName).mockImplementation(() => {

--- a/packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/page.render.test.ts
+++ b/packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/page.render.test.ts
@@ -182,6 +182,7 @@ import SoundLibraryModalModule from '$lib/components/editor/modals/SoundLibraryM
 import DifficultyModalModule from '$lib/components/editor/modals/DifficultyModal.svelte';
 import DTXSwitcherModalModule from '$lib/components/editor/modals/DTXSwitcherModal.svelte';
 import WorkspaceManagerModalModule from '$lib/components/editor/modals/WorkspaceManagerModal.svelte';
+import NewFileModalModule from '$lib/components/editor/modals/NewFileModal.svelte';
 import MainModule from '@dtx/common/game';
 
 const defaultData = { simfileID: null, metadata: null };
@@ -866,5 +867,423 @@ describe('Editor Page – DTXSwitcherModal switchWorkspaceDTX prop', () => {
 		expect(dtxProps?.onSwitchDTX).toBeDefined();
 		// phaserRef.scene is null → if condition is false → early return
 		await expect(dtxProps!.onSwitchDTX()).resolves.toBeUndefined();
+	});
+});
+
+describe('Editor Page – handleFolderImport callback', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('processes imported folder files and shows result (lines 124-143)', async () => {
+		const mockInput = {
+			type: '',
+			webkitdirectory: false,
+			multiple: false,
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		const mockWorkspace = {
+			name: 'Test Workspace',
+			path: '/test',
+			dtxFiles: [{ name: 'song.dtx', content: '', path: '/test/song.dtx' }],
+			audioFiles: [{ name: 'kick.wav', path: '/test/kick.wav' }],
+			currentDTX: 'song.dtx',
+			lastModified: Date.now()
+		};
+		vi.mocked(workspaceService.importFolder).mockResolvedValue(mockWorkspace);
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFolder();
+		expect(mockInput.onchange).toBeTruthy();
+
+		const mockFiles = { length: 1, 0: new File(['dtx'], 'song.dtx') };
+		const mockEvent = { target: { files: mockFiles } } as unknown as Event;
+		await (mockInput.onchange as (e: Event) => Promise<void>)(mockEvent);
+
+		expect(workspaceService.importFolder).toHaveBeenCalledWith(mockFiles);
+		expect(workspaceService.setCurrentWorkspace).toHaveBeenCalledWith(mockWorkspace);
+	});
+
+	it('returns early when files is null in folder import (lines 119-122)', async () => {
+		const mockInput = {
+			type: '',
+			webkitdirectory: false,
+			multiple: false,
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFolder();
+
+		const mockEvent = { target: { files: null } } as unknown as Event;
+		await (mockInput.onchange as (e: Event) => Promise<void>)(mockEvent);
+
+		expect(workspaceService.importFolder).not.toHaveBeenCalled();
+	});
+
+	it('returns early when files list is empty in folder import', async () => {
+		const mockInput = {
+			type: '',
+			webkitdirectory: false,
+			multiple: false,
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFolder();
+
+		const mockEvent = { target: { files: { length: 0 } } } as unknown as Event;
+		await (mockInput.onchange as (e: Event) => Promise<void>)(mockEvent);
+
+		expect(workspaceService.importFolder).not.toHaveBeenCalled();
+	});
+
+	it('shows import error modal when folder import fails (lines 144-148)', async () => {
+		const mockInput = {
+			type: '',
+			webkitdirectory: false,
+			multiple: false,
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		vi.mocked(workspaceService.importFolder).mockRejectedValue(new Error('Import failed'));
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFolder();
+
+		const mockFiles = { length: 1, 0: new File(['dtx'], 'song.dtx') };
+		const mockEvent = { target: { files: mockFiles } } as unknown as Event;
+		// Should resolve without throwing despite the import error
+		await expect(
+			(mockInput.onchange as (e: Event) => Promise<void>)(mockEvent)
+		).resolves.toBeUndefined();
+
+		expect(workspaceService.importFolder).toHaveBeenCalled();
+	});
+});
+
+describe('Editor Page – handleFileImport callback', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns early when no file is selected (lines 224-225)', async () => {
+		const mockInput = {
+			type: '',
+			accept: '',
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFile();
+		expect(mockInput.onchange).toBeTruthy();
+
+		// files?.[0] is undefined → early return
+		const mockEvent = { target: { files: {} } } as unknown as Event;
+		await (mockInput.onchange as (e: Event) => Promise<void>)(mockEvent);
+
+		const { decodeFileWithEncodingDetection } = await import('@dtx/common');
+		expect(vi.mocked(decodeFileWithEncodingDetection)).not.toHaveBeenCalled();
+	});
+
+	it('processes imported DTX file successfully (lines 227-270)', async () => {
+		const mockInput = {
+			type: '',
+			accept: '',
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		const { decodeFileWithEncodingDetection, DTXFile } = await import('@dtx/common');
+		vi.mocked(decodeFileWithEncodingDetection).mockResolvedValue({
+			content: '#TITLE:Test\n#BPM:120',
+			encoding: 'utf-8'
+		} as never);
+
+		const mockDtxInstance = {
+			detectedEncoding: '',
+			parseFromText: vi.fn().mockResolvedValue(undefined),
+			parseNotes: vi.fn().mockReturnValue([]),
+			parseBPMChanges: vi.fn().mockReturnValue({}),
+			parseSoundChips: vi.fn().mockReturnValue([]),
+			export: vi.fn()
+		};
+		// onMount calls new DTXFile() once (via createNewFile); handleFileImport calls it again
+		vi.mocked(DTXFile).mockImplementationOnce(() => mockDtxInstance as never);
+		vi.mocked(DTXFile).mockImplementationOnce(() => mockDtxInstance as never);
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFile();
+
+		const mockFile = new File(['#TITLE:Test'], 'test.dtx');
+		const mockEvent = { target: { files: [mockFile] } } as unknown as Event;
+		await (mockInput.onchange as (e: Event) => Promise<void>)(mockEvent);
+
+		expect(vi.mocked(decodeFileWithEncodingDetection)).toHaveBeenCalledWith(
+			mockFile,
+			expect.any(Function),
+			expect.any(Array),
+			expect.any(String)
+		);
+		expect(store.currentDifficulty.set).toHaveBeenLastCalledWith('Imported');
+		expect(vi.mocked(EventBus.emit)).toHaveBeenCalledWith(
+			EventType.NOTE_IMPORT,
+			expect.any(Array),
+			expect.any(Object)
+		);
+	});
+
+	it('shows import error modal when DTX file decoding fails (lines 271-275)', async () => {
+		const mockInput = {
+			type: '',
+			accept: '',
+			onchange: null as ((e: Event) => void) | null,
+			click: vi.fn()
+		};
+
+		const { decodeFileWithEncodingDetection } = await import('@dtx/common');
+		vi.mocked(decodeFileWithEncodingDetection).mockRejectedValue(new Error('Decode failed'));
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+
+		vi.spyOn(document, 'createElement').mockReturnValueOnce(
+			mockInput as unknown as HTMLElement
+		);
+		navProps!.onImportFile();
+
+		const mockFile = new File(['content'], 'test.dtx');
+		const mockEvent = { target: { files: [mockFile] } } as unknown as Event;
+		// Should not throw – error caught internally
+		await expect(
+			(mockInput.onchange as (e: Event) => Promise<void>)(mockEvent)
+		).resolves.toBeUndefined();
+
+		expect(vi.mocked(decodeFileWithEncodingDetection)).toHaveBeenCalled();
+	});
+});
+
+describe('Editor Page – newFile and createNewFile branches', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('shows NewFileModal when TempChartStorage.exists returns true (line 286)', () => {
+		vi.mocked(TempChartStorage.exists).mockReturnValue(true);
+
+		render(EditorPage, { props: { data: defaultData } });
+		vi.mocked(TempChartStorage.remove).mockClear();
+
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+		navProps!.onNewFile();
+
+		// hasUnsavedChanges = true → showNewFileModal = true, createNewFile NOT called
+		expect(TempChartStorage.remove).not.toHaveBeenCalled();
+
+		// NewFileModal should have been rendered with onConfirm/onCancel bindings
+		const newFileProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(NewFileModalModule)
+		);
+		expect(newFileProps?.onConfirm).toBeDefined();
+		expect(newFileProps?.onCancel).toBeDefined();
+	});
+
+	it('NewFileModal onConfirm calls createNewFile (line 753)', () => {
+		render(EditorPage, { props: { data: defaultData } });
+		vi.mocked(TempChartStorage.remove).mockClear();
+
+		const newFileProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(NewFileModalModule)
+		);
+		expect(newFileProps?.onConfirm).toBeDefined();
+		newFileProps!.onConfirm();
+
+		// createNewFile → TempChartStorage.remove
+		expect(TempChartStorage.remove).toHaveBeenCalled();
+	});
+
+	it('NewFileModal onCancel closes the modal', () => {
+		render(EditorPage, { props: { data: defaultData } });
+		const newFileProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(NewFileModalModule)
+		);
+		expect(newFileProps?.onCancel).toBeDefined();
+		expect(() => newFileProps!.onCancel()).not.toThrow();
+	});
+
+	it('createNewFile calls goto when simfileID is set (lines 323-325)', () => {
+		const data = {
+			simfileID: 'active-sim-id',
+			metadata: { title: 'Song', levels: { 25: { label: 'Basic', fileName: 'bas.dtx' } } }
+		};
+
+		render(EditorPage, { props: { data } });
+		vi.mocked(TempChartStorage.remove).mockClear();
+
+		const navProps = getLastMockProps<Record<string, () => void>>(
+			vi.mocked(EditorNavigationModule)
+		);
+		// TempChartStorage.exists returns false (default) → createNewFile() runs
+		navProps!.onNewFile();
+
+		// simfileID = 'active-sim-id' in state → goto('/editor') called
+		expect(vi.mocked(workspaceService.getCurrentWorkspace)).toHaveBeenCalled();
+	});
+});
+
+describe('Editor Page – data.metadata null path (parseFromRemoteURL)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('uses parseFromRemoteURL when data.metadata is null (lines 490-496)', async () => {
+		const { SimFile } = await import('@dtx/common');
+		const data = { simfileID: 'remote-no-metadata', metadata: null };
+
+		render(EditorPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(vi.mocked(SimFile.parseFromRemoteURL)).toHaveBeenCalledWith(
+				'remote-no-metadata',
+				expect.any(String)
+			);
+		});
+	});
+});
+
+describe('Editor Page – getAvailableLevels with non-null simfile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.mocked(get).mockReturnValue(null as never);
+		vi.restoreAllMocks();
+	});
+
+	it('returns formatted level list when simfile has levels (lines 418-425)', () => {
+		vi.mocked(get).mockReturnValue(mockSimfile as never);
+
+		render(EditorPage, { props: { data: defaultData } });
+
+		// DifficultyModal receives the result of getAvailableLevels() as availableLevels prop
+		const diffProps = getLastMockProps<Record<string, unknown>>(
+			vi.mocked(DifficultyModalModule)
+		);
+		expect(diffProps?.availableLevels).toBeDefined();
+		expect(Array.isArray(diffProps?.availableLevels)).toBe(true);
+		const levels = diffProps!.availableLevels as Array<{ level: number; label: string }>;
+		expect(levels.length).toBeGreaterThan(0);
+		expect(levels[0]).toMatchObject({ level: 25, label: 'Basic' });
+	});
+});
+
+describe('Editor Page – refreshSoundLibraryLinks additional branches', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.mocked(get).mockReturnValue(null as never);
+		vi.restoreAllMocks();
+	});
+
+	it('skips chip when chip.file is already set (lines 582-584)', async () => {
+		const existingFile = new File(['data'], 'kick.xa');
+		const mockChip = { fileName: 'kick.xa', file: existingFile };
+		vi.mocked(get).mockReturnValue([mockChip] as never);
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => Promise<void>>>(
+			vi.mocked(EditorNavigationModule)
+		);
+		await navProps!.onRefreshSoundLibraryLinks();
+
+		// chip.file already set → SoundLibrary.findByFileName skipped
+		expect(SoundLibrary.findByFileName).not.toHaveBeenCalled();
+		expect(store.currentSoundChip.set).toHaveBeenCalled();
+	});
+
+	it('catches error and sets error message in refreshSoundLibraryLinks (lines 628-632)', async () => {
+		const mockChip = { fileName: 'kick.xa', file: undefined };
+		vi.mocked(get).mockReturnValue([mockChip] as never);
+		vi.mocked(SoundLibrary.findByFileName).mockImplementation(() => {
+			throw new Error('Library read error');
+		});
+
+		render(EditorPage, { props: { data: defaultData } });
+		const navProps = getLastMockProps<Record<string, () => Promise<void>>>(
+			vi.mocked(EditorNavigationModule)
+		);
+		// Should resolve without throwing – error caught internally
+		await expect(navProps!.onRefreshSoundLibraryLinks()).resolves.toBeUndefined();
 	});
 });

--- a/packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/page.render.test.ts
+++ b/packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/page.render.test.ts
@@ -915,6 +915,8 @@ describe('Editor Page – handleFolderImport callback', () => {
 
 		expect(workspaceService.importFolder).toHaveBeenCalledWith(mockFiles);
 		expect(workspaceService.setCurrentWorkspace).toHaveBeenCalledWith(mockWorkspace);
+		// availableWorkspaces is refreshed after import
+		expect(workspaceService.getWorkspaces).toHaveBeenCalled();
 	});
 
 	it('returns early when files is null in folder import (lines 119-122)', async () => {
@@ -996,6 +998,8 @@ describe('Editor Page – handleFolderImport callback', () => {
 		).resolves.toBeUndefined();
 
 		expect(workspaceService.importFolder).toHaveBeenCalled();
+		// error path: workspace was never persisted
+		expect(workspaceService.setCurrentWorkspace).not.toHaveBeenCalled();
 	});
 });
 
@@ -1118,6 +1122,8 @@ describe('Editor Page – handleFileImport callback', () => {
 		).resolves.toBeUndefined();
 
 		expect(vi.mocked(decodeFileWithEncodingDetection)).toHaveBeenCalled();
+		// error path: difficulty was never set to 'Imported'
+		expect(store.currentDifficulty.set).not.toHaveBeenLastCalledWith('Imported');
 	});
 });
 
@@ -1172,7 +1178,10 @@ describe('Editor Page – newFile and createNewFile branches', () => {
 			vi.mocked(NewFileModalModule)
 		);
 		expect(newFileProps?.onCancel).toBeDefined();
-		expect(() => newFileProps!.onCancel()).not.toThrow();
+		vi.mocked(TempChartStorage.remove).mockClear();
+		newFileProps!.onCancel();
+		// cancel should not trigger createNewFile
+		expect(TempChartStorage.remove).not.toHaveBeenCalled();
 	});
 
 	it('createNewFile calls goto when simfileID is set (lines 323-325)', () => {
@@ -1283,7 +1292,10 @@ describe('Editor Page – refreshSoundLibraryLinks additional branches', () => {
 		const navProps = getLastMockProps<Record<string, () => Promise<void>>>(
 			vi.mocked(EditorNavigationModule)
 		);
+		vi.mocked(store.currentSoundChip.set).mockClear();
 		// Should resolve without throwing – error caught internally
 		await expect(navProps!.onRefreshSoundLibraryLinks()).resolves.toBeUndefined();
+		// error path: chip store should not have been updated by refreshSoundLibraryLinks
+		expect(store.currentSoundChip.set).not.toHaveBeenCalled();
 	});
 });

--- a/packages/ui-components/src/lib/utils/cn.test.ts
+++ b/packages/ui-components/src/lib/utils/cn.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from './cn';
+
+describe('cn utility', () => {
+	it('returns an empty string with no arguments', () => {
+		expect(cn()).toBe('');
+	});
+
+	it('returns a single class name unchanged', () => {
+		expect(cn('foo')).toBe('foo');
+	});
+
+	it('joins multiple class names with a space', () => {
+		expect(cn('foo', 'bar', 'baz')).toBe('foo bar baz');
+	});
+
+	it('ignores falsy values', () => {
+		expect(cn('foo', undefined, null, false, 'bar')).toBe('foo bar');
+	});
+
+	it('merges conflicting Tailwind classes, keeping the last one', () => {
+		expect(cn('p-2', 'p-4')).toBe('p-4');
+		expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+	});
+
+	it('handles conditional classes via objects', () => {
+		expect(cn({ 'font-bold': true, italic: false })).toBe('font-bold');
+	});
+
+	it('handles array inputs', () => {
+		expect(cn(['foo', 'bar'], 'baz')).toBe('foo bar baz');
+	});
+
+	it('handles mixed conditional and unconditional classes', () => {
+		const isActive = true;
+		const isDisabled = false;
+		expect(cn('base', { active: isActive, disabled: isDisabled })).toBe('base active');
+	});
+
+	it('deduplicates identical class names via tailwind-merge', () => {
+		expect(cn('px-2 py-1', 'px-4')).toBe('py-1 px-4');
+	});
+});

--- a/packages/ui-components/vitest.config.ts
+++ b/packages/ui-components/vitest.config.ts
@@ -21,12 +21,15 @@ export default defineConfig({
 			exclude: [
 				'**/node_modules/**',
 				'**/dist/**',
+				'**/build/**',
 				'**/.svelte-kit/**',
+				'**/tests/**',
 				'**/*.test.ts',
 				'**/*.spec.ts',
 				'**/vite.config.ts',
 				'**/vitest.config.ts',
-				'**/svelte.config.js'
+				'**/svelte.config.js',
+				'**/tailwind.config.ts'
 			],
 			include: ['src/**/*.{js,ts,svelte}'],
 			all: true


### PR DESCRIPTION
## Summary
This PR significantly expands test coverage across the DTX editor and UI component packages by adding 400+ lines of new test cases and establishing a test infrastructure for the ui-components package.

## Key Changes

### Editor Page Tests (`packages/dtx-web/src/routes/(game)/editor/`)
- **Import functionality**: Added tests for `handleFolderImport` and `handleFileImport` callbacks covering:
  - Successful folder/file imports with workspace updates
  - Early returns when files are null or empty
  - Error handling and modal display on import failures
  - DTX file decoding with encoding detection
  
- **File creation**: Added tests for `newFile` and `createNewFile` branches:
  - NewFileModal display when unsaved changes exist
  - Modal confirmation/cancellation flows
  - Navigation behavior when creating new files with active simfileID
  
- **Data loading**: Added tests for edge cases:
  - `parseFromRemoteURL` when metadata is null
  - Level formatting in `getAvailableLevels`
  - Sound library link refresh with existing files and error handling

### ChartList Component Tests (`packages/dtx-web/src/lib/components/`)
- **Bulk download validation**: Added tests for validation response handling:
  - Non-ok HTTP responses with error messages
  - Invalid validation data (missing `ok` flag or error string)
  - Invalid fileCount types with fallback error messages
  
- **Selection limits**: Added test for MAX_BULK_DOWNLOAD_CHARTS limit enforcement with error toast display

### MainTab Component Tests (`packages/common/src/lib/components/editor/`)
- Added tests for dtxFile property synchronization to store
- Added test for title input change propagation to store

### SoundTab Component Tests (`packages/common/src/lib/components/editor/`)
- Added test for remote audio playback with fallback file
- Added test for warning toast when remote chip has no bucketUrl and file not loaded

### UI Components Test Infrastructure (`packages/ui-components/`)
- **New vitest configuration**: Added `vitest.config.ts` with jsdom environment, proper Svelte handling, and coverage settings
- **Test setup file**: Added `src/tests/setup.ts` with global test library mocks
- **Utility tests**: Added comprehensive tests for `cn` utility function covering:
  - Empty/single/multiple class names
  - Falsy value filtering
  - Tailwind class conflict resolution
  - Conditional classes via objects and arrays
  - Class deduplication

## Notable Implementation Details
- Tests use proper mocking patterns with `vi.mocked()` and `vi.fn()`
- Error scenarios are tested to ensure graceful handling without throwing
- Modal and callback flows are verified through prop inspection
- Coverage includes both happy paths and edge cases for robustness

https://claude.ai/code/session_01HgQ8mMMa4M2e9SxUd9S9eE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for editor flows (file import, new-file modal, title/artist updates, sound handling).
  * Added key tests for remote audio playback and remote-load warnings.
  * Added validation and limit tests for bulk downloads and chart selection.
  * Added tests for class-name utility behavior and updated test coverage exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->