### PR TITLE
feat: add next display_id API and auto-populate for new charts

### DIFF
--- a/e2e/next-display-id.spec.ts
+++ b/e2e/next-display-id.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { BASE_URL } from './constants';
+
+test.describe('GET /api/chart/next-display-id', () => {
+	test('returns 401 with JSON error when unauthenticated', async ({ request }) => {
+		const response = await request.get(`${BASE_URL}/api/chart/next-display-id`);
+
+		expect(response.status()).toBe(401);
+		expect(response.headers()['content-type']).toContain('application/json');
+
+		const body = await response.json();
+		expect(body).toEqual({ error: 'Unauthorized' });
+	});
+});

--- a/packages/dtx-desktop/src/main/index.test.ts
+++ b/packages/dtx-desktop/src/main/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
 import path from 'path';
 
@@ -96,6 +96,7 @@ const mockSimfileService = {
 	getSoundPreviewUrl: vi.fn(),
 	createSimfileRecord: vi.fn(),
 	parseDtxFiles: vi.fn(),
+	getNextDisplayId: vi.fn(),
 	CreateSimfileData: {}
 };
 
@@ -457,6 +458,15 @@ describe('index.ts IPC handlers', () => {
 			const result = await ipcHandlers['create-simfile-record']({}, data);
 			expect(mockSimfileService.createSimfileRecord).toHaveBeenCalledWith(data);
 			expect(result).toEqual({ id: 99 });
+		});
+	});
+
+	describe('get-next-display-id handler', () => {
+		it('delegates to getNextDisplayId', async () => {
+			mockSimfileService.getNextDisplayId.mockResolvedValue(42);
+			const result = await ipcHandlers['get-next-display-id']();
+			expect(mockSimfileService.getNextDisplayId).toHaveBeenCalled();
+			expect(result).toBe(42);
 		});
 	});
 

--- a/packages/dtx-desktop/src/main/index.ts
+++ b/packages/dtx-desktop/src/main/index.ts
@@ -16,7 +16,8 @@ import {
 	getSoundPreviewUrl,
 	createSimfileRecord,
 	CreateSimfileData,
-	parseDtxFiles
+	parseDtxFiles,
+	getNextDisplayId
 } from './simfile-service';
 import { loadTreeStructure, selectDirectory, readFile } from './filesystem';
 import { createWindow } from './window';
@@ -393,6 +394,11 @@ if (!gotTheLock) {
 		// Handle creating simfile record in database
 		ipcMain.handle('create-simfile-record', async (_event, simfileData: CreateSimfileData) => {
 			return await createSimfileRecord(simfileData);
+		});
+
+		// Handle fetching next display_id for the current user
+		ipcMain.handle('get-next-display-id', async () => {
+			return await getNextDisplayId();
 		});
 
 		// Handle searching cloud songs for autocomplete

--- a/packages/dtx-desktop/src/main/index.ts
+++ b/packages/dtx-desktop/src/main/index.ts
@@ -396,7 +396,6 @@ if (!gotTheLock) {
 			return await createSimfileRecord(simfileData);
 		});
 
-		// Handle fetching next display_id for the current user
 		ipcMain.handle('get-next-display-id', async () => {
 			return await getNextDisplayId();
 		});

--- a/packages/dtx-desktop/src/main/simfile-service.test.ts
+++ b/packages/dtx-desktop/src/main/simfile-service.test.ts
@@ -5,7 +5,8 @@ import {
 	getPreviewUrl,
 	getSoundPreviewUrl,
 	createSimfileRecord,
-	parseDtxFiles
+	parseDtxFiles,
+	getNextDisplayId
 } from './simfile-service';
 import { getSupabaseClient, ensureSupabaseAuth, getCurrentSession } from './auth';
 import { apiGet, apiPost } from './api-client';
@@ -288,6 +289,32 @@ describe('SimFile Service', () => {
 				throw new Error('Expected error result');
 			}
 			expect(result.error).toContain('Page fetch failed');
+		});
+	});
+
+	describe('getNextDisplayId', () => {
+		it('returns nextDisplayId from API', async () => {
+			(apiGet as Mock).mockResolvedValue({
+				success: true,
+				data: { nextDisplayId: 42 }
+			});
+
+			const result = await getNextDisplayId();
+
+			expect(result).toBe(42);
+			expect(apiGet).toHaveBeenCalledWith('/api/chart/next-display-id');
+		});
+
+		it('throws when authentication is not ready', async () => {
+			(ensureSupabaseAuth as Mock).mockResolvedValue(false);
+			await expect(getNextDisplayId()).rejects.toThrow(
+				'Authentication not available. Please log in first.'
+			);
+		});
+
+		it('throws when API call fails', async () => {
+			(apiGet as Mock).mockResolvedValue({ success: false, error: 'Server error' });
+			await expect(getNextDisplayId()).rejects.toThrow('Server error');
 		});
 	});
 

--- a/packages/dtx-desktop/src/main/simfile-service.test.ts
+++ b/packages/dtx-desktop/src/main/simfile-service.test.ts
@@ -316,6 +316,33 @@ describe('SimFile Service', () => {
 			(apiGet as Mock).mockResolvedValue({ success: false, error: 'Server error' });
 			await expect(getNextDisplayId()).rejects.toThrow('Server error');
 		});
+
+		it('throws when result.data is missing', async () => {
+			(apiGet as Mock).mockResolvedValue({ success: true, data: undefined });
+			await expect(getNextDisplayId()).rejects.toThrow(
+				'Invalid nextDisplayId in API response'
+			);
+		});
+
+		it('throws when nextDisplayId is not a finite number', async () => {
+			(apiGet as Mock).mockResolvedValue({
+				success: true,
+				data: { nextDisplayId: Infinity }
+			});
+			await expect(getNextDisplayId()).rejects.toThrow(
+				'Invalid nextDisplayId in API response'
+			);
+		});
+
+		it('throws when nextDisplayId is not a number', async () => {
+			(apiGet as Mock).mockResolvedValue({
+				success: true,
+				data: { nextDisplayId: 'not-a-number' }
+			});
+			await expect(getNextDisplayId()).rejects.toThrow(
+				'Invalid nextDisplayId in API response'
+			);
+		});
 	});
 
 	describe('preview url helpers', () => {

--- a/packages/dtx-desktop/src/main/simfile-service.ts
+++ b/packages/dtx-desktop/src/main/simfile-service.ts
@@ -87,6 +87,13 @@ export const getNextDisplayId = async (): Promise<number> => {
 	if (!result.success) {
 		throw new Error(result.error || 'Failed to fetch next display_id');
 	}
+	if (
+		!result.data ||
+		typeof result.data.nextDisplayId !== 'number' ||
+		!Number.isFinite(result.data.nextDisplayId)
+	) {
+		throw new Error('Invalid nextDisplayId in API response');
+	}
 	return result.data.nextDisplayId;
 };
 

--- a/packages/dtx-desktop/src/main/simfile-service.ts
+++ b/packages/dtx-desktop/src/main/simfile-service.ts
@@ -77,6 +77,19 @@ export async function fetchUserSimFiles(): Promise<SimFileServiceResult> {
 	}
 }
 
+export async function getNextDisplayId(): Promise<number> {
+	const isAuthReady = await ensureSupabaseAuth();
+	if (!isAuthReady) {
+		throw new Error('Authentication not available. Please log in first.');
+	}
+
+	const result = await apiGet<{ nextDisplayId: number }>('/api/chart/next-display-id');
+	if (!result.success) {
+		throw new Error(result.error || 'Failed to fetch next display_id');
+	}
+	return result.data.nextDisplayId;
+}
+
 export function getPreviewUrl(simfileId: number): string {
 	const bucketUrl = import.meta.env.PUBLIC_SIMFILE_BUCKET_URL;
 	if (!bucketUrl) {

--- a/packages/dtx-desktop/src/main/simfile-service.ts
+++ b/packages/dtx-desktop/src/main/simfile-service.ts
@@ -213,7 +213,7 @@ export interface CreateSimfileData {
 	title: string;
 	artist: string;
 	bpm: number;
-	displayId: number;
+	displayId: number | null;
 	isPublished: boolean;
 	publishDate: string;
 	downloadUrl: string;

--- a/packages/dtx-desktop/src/main/simfile-service.ts
+++ b/packages/dtx-desktop/src/main/simfile-service.ts
@@ -77,7 +77,7 @@ export async function fetchUserSimFiles(): Promise<SimFileServiceResult> {
 	}
 }
 
-export async function getNextDisplayId(): Promise<number> {
+export const getNextDisplayId = async (): Promise<number> => {
 	const isAuthReady = await ensureSupabaseAuth();
 	if (!isAuthReady) {
 		throw new Error('Authentication not available. Please log in first.');
@@ -88,7 +88,7 @@ export async function getNextDisplayId(): Promise<number> {
 		throw new Error(result.error || 'Failed to fetch next display_id');
 	}
 	return result.data.nextDisplayId;
-}
+};
 
 export function getPreviewUrl(simfileId: number): string {
 	const bucketUrl = import.meta.env.PUBLIC_SIMFILE_BUCKET_URL;

--- a/packages/dtx-desktop/src/preload/index.ts
+++ b/packages/dtx-desktop/src/preload/index.ts
@@ -41,7 +41,8 @@ const extendedElectronAPI = {
 				'search-cloud-songs',
 				'fetch-cloud-song',
 				'update-simfile-record',
-				'export-song-to-zip'
+				'export-song-to-zip',
+				'get-next-display-id'
 			];
 			if (validChannels.includes(channel)) {
 				return ipcRenderer.invoke(channel, ...args);

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -453,11 +453,15 @@
 			if (!Number.isSafeInteger(next)) {
 				throw new Error('Invalid next display_id response');
 			}
+			// Record that we fetched for this path even if user navigated away,
+			// to prevent duplicate calls if they navigate back
+			autoPopulatedForPaths.add(currentPath);
+			// Guard against stale responses: skip mutation if user switched songs
+			if (song.path !== currentPath) return;
 			if (displayId === 0) {
 				displayId = next;
 				autoPopulatedDisplayId = { path: currentPath, value: next };
 			}
-			autoPopulatedForPaths.add(currentPath);
 			displayIdAutoPopulateError = null;
 		} catch (error) {
 			console.warn('Failed to fetch next display_id:', error);

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -475,6 +475,8 @@
 			displayIdAutoPopulateError = null;
 		} catch (error) {
 			console.warn('Failed to fetch next display_id:', error);
+			// Guard against stale rejections: skip error mutation if user switched songs
+			if (song.path !== currentPath) return;
 			displayIdAutoPopulateError =
 				'Could not fetch the next display ID. You can enter it manually or retry.';
 		} finally {

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -708,11 +708,12 @@
 	});
 
 	// Auto-populate display_id for new (unlinked) charts with max(display_id) + 1
-	let autoPopulatedForPath = $state<string | null>(null);
+	// Track all previously processed paths to avoid re-fetching when navigating back
+	let autoPopulatedForPaths = $state<Set<string>>(new Set());
 	$effect(() => {
 		const currentPath = song.path;
 		if (!currentPath || song.linkedSimFile || !$authStore.isAuthenticated) return;
-		if (autoPopulatedForPath === currentPath) return;
+		if (autoPopulatedForPaths.has(currentPath)) return;
 
 		(async () => {
 			try {
@@ -720,7 +721,7 @@
 				if (displayId === 0 && Number.isSafeInteger(next)) {
 					displayId = next;
 				}
-				autoPopulatedForPath = currentPath;
+				autoPopulatedForPaths = new Set([...autoPopulatedForPaths, currentPath]);
 			} catch (error) {
 				console.warn('Failed to fetch next display_id:', error);
 			}

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -741,6 +741,17 @@
 		} satisfies Partial<SimfileWithDtx>;
 	});
 
+	// Reset auto-populate state when switching songs to prevent stale IDs
+	$effect(() => {
+		const currentPath = song.path;
+		// Access song.path to track changes, then reset auto-populate state
+		if (currentPath) {
+			displayId = 0;
+			autoPopulatedDisplayId = null;
+			displayIdAutoPopulateError = null;
+		}
+	});
+
 	// Initialize reactive form values from simfileData
 	$effect(() => {
 		const data = simfileData();

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -204,6 +204,10 @@
 	let uploadError = $state<string | null>(null);
 	let uploadSuccess = $state(false);
 	let uploadWarnings = $state<string[]>([]);
+	let displayIdAutoPopulateError = $state<string | null>(null);
+	let autoPopulatedDisplayId = $state<{ path: string; value: number } | null>(null);
+	const autoPopulatedForPaths = new Set<string>();
+	const autoPopulateInFlightPaths = new Set<string>();
 
 	// Reactive form values that mirror the ChartDetail component's state
 	let displayId = $state(0);
@@ -361,13 +365,20 @@
 		uploadWarnings = [];
 
 		try {
+			const submittedDisplayId = Number(displayId);
+			const displayIdForCreate =
+				submittedDisplayId === 0 ||
+				(autoPopulatedDisplayId?.path === song.path &&
+					autoPopulatedDisplayId.value === submittedDisplayId)
+					? null
+					: submittedDisplayId;
 			// Create plain object without any Svelte reactivity
 			const simfileData = JSON.parse(
 				JSON.stringify({
 					title: String(song.songTitle || song.name || ''),
 					artist: String(parsedLocalData.artist || ''),
 					bpm: Number(parsedLocalData.bpm || 0),
-					displayId: Number(displayId),
+					displayId: displayIdForCreate,
 					isPublished: Boolean(
 						event.detail.isPublished !== undefined
 							? event.detail.isPublished
@@ -427,6 +438,40 @@
 		} finally {
 			isUploading = false;
 		}
+	};
+
+	const populateNextDisplayId = async (currentPath: string) => {
+		if (autoPopulatedForPaths.has(currentPath) || autoPopulateInFlightPaths.has(currentPath)) {
+			return;
+		}
+
+		// Mark path synchronously before async call to prevent duplicate IPC invocations
+		autoPopulateInFlightPaths.add(currentPath);
+
+		try {
+			const next = await simFileService.getNextDisplayId();
+			if (!Number.isSafeInteger(next)) {
+				throw new Error('Invalid next display_id response');
+			}
+			if (displayId === 0) {
+				displayId = next;
+				autoPopulatedDisplayId = { path: currentPath, value: next };
+			}
+			autoPopulatedForPaths.add(currentPath);
+			displayIdAutoPopulateError = null;
+		} catch (error) {
+			console.warn('Failed to fetch next display_id:', error);
+			displayIdAutoPopulateError =
+				'Could not fetch the next display ID. You can enter it manually or retry.';
+		} finally {
+			autoPopulateInFlightPaths.delete(currentPath);
+		}
+	};
+
+	const handleRetryDisplayIdAutoPopulate = () => {
+		if (!song.path || song.linkedSimFile || !$authStore.isAuthenticated) return;
+		displayIdAutoPopulateError = null;
+		void populateNextDisplayId(song.path);
 	};
 
 	// Handle showing autocomplete popup
@@ -707,27 +752,10 @@
 		isPublished = data.is_published || false;
 	});
 
-	// Auto-populate display_id for new (unlinked) charts with max(display_id) + 1
-	// Track all previously processed paths to avoid re-fetching when navigating back
-	let autoPopulatedForPaths = $state<Set<string>>(new Set());
 	$effect(() => {
 		const currentPath = song.path;
 		if (!currentPath || song.linkedSimFile || !$authStore.isAuthenticated) return;
-		if (autoPopulatedForPaths.has(currentPath)) return;
-
-		// Mark path synchronously before async call to prevent duplicate IPC invocations
-		autoPopulatedForPaths = new Set([...autoPopulatedForPaths, currentPath]);
-
-		(async () => {
-			try {
-				const next = await simFileService.getNextDisplayId();
-				if (displayId === 0 && Number.isSafeInteger(next)) {
-					displayId = next;
-				}
-			} catch (error) {
-				console.warn('Failed to fetch next display_id:', error);
-			}
-		})();
+		void populateNextDisplayId(currentPath);
 	});
 </script>
 
@@ -1032,6 +1060,22 @@
 									<Search size={14} />
 									Link to Cloud
 								{/if}
+							</button>
+						</div>
+					</div>
+				{/if}
+
+				{#if displayIdAutoPopulateError && $authStore.isAuthenticated}
+					<div class="rounded-lg bg-yellow-50 p-3 dark:bg-yellow-900/20">
+						<div class="flex items-center justify-between gap-2">
+							<span class="text-sm text-yellow-800 dark:text-yellow-200">
+								{displayIdAutoPopulateError}
+							</span>
+							<button
+								class="rounded bg-yellow-200 px-3 py-1 text-sm font-medium text-yellow-900 hover:bg-yellow-300 focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 focus:outline-none dark:bg-yellow-800 dark:text-yellow-100 dark:hover:bg-yellow-700"
+								onclick={handleRetryDisplayIdAutoPopulate}
+							>
+								Retry
 							</button>
 						</div>
 					</div>

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -9,6 +9,7 @@
 	import type { SimfileWithDtx, DtxFileRow } from '@dtx/common';
 	import { onMount } from 'svelte';
 	import CloudSongAutocomplete from './CloudSongAutocomplete.svelte';
+	import { simFileService } from '../services/simFileService';
 
 	interface Props {
 		song: TreeNode;
@@ -704,6 +705,26 @@
 		downloadUrl = data.download_url || '';
 		videoPreviewUrl = data.video_preview_url || '';
 		isPublished = data.is_published || false;
+	});
+
+	// Auto-populate display_id for new (unlinked) charts with max(display_id) + 1
+	let autoPopulatedForPath = $state<string | null>(null);
+	$effect(() => {
+		const currentPath = song.path;
+		if (!currentPath || song.linkedSimFile || !$authStore.isAuthenticated) return;
+		if (autoPopulatedForPath === currentPath) return;
+
+		(async () => {
+			try {
+				const next = await simFileService.getNextDisplayId();
+				if (displayId === 0 && Number.isSafeInteger(next)) {
+					displayId = next;
+				}
+				autoPopulatedForPath = currentPath;
+			} catch (error) {
+				console.warn('Failed to fetch next display_id:', error);
+			}
+		})();
 	});
 </script>
 

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -206,7 +206,7 @@
 	let uploadWarnings = $state<string[]>([]);
 	let displayIdAutoPopulateError = $state<string | null>(null);
 	let autoPopulatedDisplayId = $state<{ path: string; value: number } | null>(null);
-	const autoPopulatedForPaths = new Set<string>();
+	const autoPopulatedForPaths = new Map<string, number>();
 	const autoPopulateInFlightPaths = new Set<string>();
 
 	// Reactive form values that mirror the ChartDetail component's state
@@ -441,7 +441,17 @@
 	};
 
 	const populateNextDisplayId = async (currentPath: string) => {
-		if (autoPopulatedForPaths.has(currentPath) || autoPopulateInFlightPaths.has(currentPath)) {
+		if (autoPopulateInFlightPaths.has(currentPath)) {
+			return;
+		}
+
+		// Restore cached value on revisit without re-fetching
+		const cachedId = autoPopulatedForPaths.get(currentPath);
+		if (cachedId !== undefined) {
+			if (displayId === 0) {
+				displayId = cachedId;
+				autoPopulatedDisplayId = { path: currentPath, value: cachedId };
+			}
 			return;
 		}
 
@@ -455,7 +465,7 @@
 			}
 			// Record that we fetched for this path even if user navigated away,
 			// to prevent duplicate calls if they navigate back
-			autoPopulatedForPaths.add(currentPath);
+			autoPopulatedForPaths.set(currentPath, next);
 			// Guard against stale responses: skip mutation if user switched songs
 			if (song.path !== currentPath) return;
 			if (displayId === 0) {

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -715,13 +715,15 @@
 		if (!currentPath || song.linkedSimFile || !$authStore.isAuthenticated) return;
 		if (autoPopulatedForPaths.has(currentPath)) return;
 
+		// Mark path synchronously before async call to prevent duplicate IPC invocations
+		autoPopulatedForPaths = new Set([...autoPopulatedForPaths, currentPath]);
+
 		(async () => {
 			try {
 				const next = await simFileService.getNextDisplayId();
 				if (displayId === 0 && Number.isSafeInteger(next)) {
 					displayId = next;
 				}
-				autoPopulatedForPaths = new Set([...autoPopulatedForPaths, currentPath]);
 			} catch (error) {
 				console.warn('Failed to fetch next display_id:', error);
 			}

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -749,5 +749,35 @@ describe('SongDetails', () => {
 			await tick();
 			expect(getNextDisplayIdCallCount()).toBe(callsAfterSongB);
 		});
+
+		it('resets auto-populated displayId when switching between unlinked songs', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			let nextDisplayId = 42;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') return nextDisplayId++;
+					return { files: [] };
+				});
+			}
+			const songA = makeNode('SongA', '/test/SongA');
+			const { rerender } = render(SongDetails, { props: { song: songA } });
+
+			// Wait for SongA to get display_id = 42
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				expect(props?.simfile?.display_id).toBe(42);
+			});
+
+			// Switch to SongB — displayId should reset and fetch a new value
+			const songB = makeNode('SongB', '/test/SongB');
+			await rerender({ props: { song: songB } });
+
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				// SongB should get display_id = 43, not the stale 42 from SongA
+				expect(props?.simfile?.display_id).toBe(43);
+			});
+		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -718,7 +718,7 @@ describe('SongDetails', () => {
 			expect(getNextDisplayIdCallCount()).toBe(callCountBefore);
 		});
 
-		it('does not re-trigger get-next-display-id when switching back to a previously populated song', async () => {
+		it('restores cached displayId and does not re-fetch when switching back to a previously populated song', async () => {
 			authState = { ...authState, isAuthenticated: true };
 			const invokeMock = window.electron?.ipcRenderer?.invoke;
 			if (vi.isMockFunction(invokeMock)) {
@@ -730,11 +730,15 @@ describe('SongDetails', () => {
 			const songA = makeNode('SongA', '/test/SongA');
 			const { rerender } = render(SongDetails, { props: { song: songA } });
 
-			// Wait for songA's get-next-display-id to fire
+			// Wait for songA's get-next-display-id to fire and displayId to be set
 			await waitFor(() => {
 				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
 					'get-next-display-id'
 				);
+			});
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				expect(props?.simfile?.display_id).toBe(42);
 			});
 			const callsAfterSongA = getNextDisplayIdCallCount();
 
@@ -745,8 +749,12 @@ describe('SongDetails', () => {
 			});
 			const callsAfterSongB = getNextDisplayIdCallCount();
 
+			// Switch back to SongA — should restore cached ID without re-fetching
 			await rerender({ props: { song: songA } });
-			await tick();
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				expect(props?.simfile?.display_id).toBe(42);
+			});
 			expect(getNextDisplayIdCallCount()).toBe(callsAfterSongB);
 		});
 

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -62,21 +62,19 @@ vi.mock('../stores/editorMappingStore', () => ({
 	}
 }));
 
+let authState = {
+	isAuthenticated: false,
+	isLoading: false,
+	user: null as null,
+	error: null as null
+};
+
 vi.mock('../stores/authStore', () => ({
 	authStore: {
-		subscribe: vi.fn(
-			(
-				cb: (s: {
-					isAuthenticated: boolean;
-					isLoading: boolean;
-					user: null;
-					error: null;
-				}) => void
-			) => {
-				cb({ isAuthenticated: false, isLoading: false, user: null, error: null });
-				return () => {};
-			}
-		)
+		subscribe: vi.fn((cb: (s: typeof authState) => void) => {
+			cb(authState);
+			return () => {};
+		})
 	}
 }));
 
@@ -119,6 +117,7 @@ describe('SongDetails', () => {
 	beforeEach(() => {
 		workspaceState = { ...initialWorkspaceState };
 		workspaceListeners.length = 0;
+		authState = { isAuthenticated: false, isLoading: false, user: null, error: null };
 		vi.clearAllMocks();
 		const invokeMock = window.electron?.ipcRenderer?.invoke;
 		if (vi.isMockFunction(invokeMock)) {
@@ -470,6 +469,82 @@ describe('SongDetails', () => {
 			});
 			render(SongDetails, { props: { song } });
 			expect(editorMappingStore.setMappingWithMetadata).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('auto-populate display_id', () => {
+		it('invokes get-next-display-id for unlinked songs when authenticated', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') return 42;
+					return { files: [] };
+				});
+			}
+			const song = makeNode('TestSong', '/test/TestSong');
+			render(SongDetails, { props: { song } });
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'get-next-display-id'
+				);
+			});
+		});
+
+		it('does not invoke get-next-display-id for linked songs', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const song = makeNode('TestSong', '/test/TestSong', {
+				linkedSimFile: makeLinkedSimFile(),
+				linkedSimFileId: '1'
+			});
+			render(SongDetails, { props: { song } });
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'list-files',
+					'/test/TestSong'
+				);
+			});
+			expect(window.electron.ipcRenderer.invoke).not.toHaveBeenCalledWith(
+				'get-next-display-id'
+			);
+		});
+
+		it('does not invoke get-next-display-id when not authenticated', async () => {
+			const song = makeNode('TestSong', '/test/TestSong');
+			render(SongDetails, { props: { song } });
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'list-files',
+					'/test/TestSong'
+				);
+			});
+			expect(window.electron.ipcRenderer.invoke).not.toHaveBeenCalledWith(
+				'get-next-display-id'
+			);
+		});
+
+		it('does not invoke get-next-display-id when song has no path', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const song = makeNode('TestSong', '');
+			render(SongDetails, { props: { song } });
+			// Wait a tick for any async effects
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(window.electron.ipcRenderer.invoke).not.toHaveBeenCalledWith(
+				'get-next-display-id'
+			);
+		});
+
+		it('handles get-next-display-id IPC error gracefully', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') throw new Error('IPC error');
+					return { files: [] };
+				});
+			}
+			const song = makeNode('TestSong', '/test/TestSong');
+			expect(() => render(SongDetails, { props: { song } })).not.toThrow();
 		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import type { TreeNode } from '../stores/workspaceStore';
 
 vi.mock('@lucide/svelte');
@@ -81,6 +82,7 @@ vi.mock('../stores/authStore', () => ({
 import SongDetails from './SongDetails.svelte';
 import { workspaceStore } from '../stores/workspaceStore';
 import { editorMappingStore } from '../stores/editorMappingStore';
+import { ChartDetail } from '@dtx/common/components';
 
 const makeNode = (
 	name: string,
@@ -109,9 +111,38 @@ const makeLinkedSimFile = () => ({
 	publish_date: '2024-01-01',
 	display_id: 1,
 	download_url: '',
+	preview_url: '',
 	video_preview_url: '',
 	dtx_files: []
 });
+
+const getLastProps = <T>(mockFn: ReturnType<typeof vi.fn>): T | undefined => {
+	const calls = mockFn.mock.calls;
+	const lastCall = calls[calls.length - 1];
+	return (lastCall?.[1] ?? lastCall?.[0]) as T | undefined;
+};
+
+type ChartDetailTestProps = {
+	simfile?: { display_id?: number | null };
+	$$events?: {
+		onSave?: (event: { detail: Record<string, unknown> }) => Promise<void> | void;
+	};
+};
+
+type ElectronInvokeMock = ReturnType<typeof vi.fn>;
+declare global {
+	interface Window {
+		electron: { ipcRenderer: { invoke: ElectronInvokeMock } };
+	}
+}
+
+type ElectronTestWindow = typeof window & {
+	electron: { ipcRenderer: { invoke: ElectronInvokeMock } };
+};
+
+const getInvokeMock = () => (window as ElectronTestWindow).electron.ipcRenderer.invoke;
+const getNextDisplayIdCallCount = () =>
+	getInvokeMock().mock.calls.filter(([channel]) => channel === 'get-next-display-id').length;
 
 describe('SongDetails', () => {
 	beforeEach(() => {
@@ -119,7 +150,7 @@ describe('SongDetails', () => {
 		workspaceListeners.length = 0;
 		authState = { isAuthenticated: false, isLoading: false, user: null, error: null };
 		vi.clearAllMocks();
-		const invokeMock = window.electron?.ipcRenderer?.invoke;
+		const invokeMock = getInvokeMock();
 		if (vi.isMockFunction(invokeMock)) {
 			invokeMock.mockResolvedValue({ files: [] });
 		}
@@ -509,6 +540,23 @@ describe('SongDetails', () => {
 			);
 		});
 
+		it('preserves a linked non-zero display_id instead of auto-populating over it', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const song = makeNode('TestSong', '/test/TestSong', {
+				linkedSimFile: { ...makeLinkedSimFile(), display_id: 7 },
+				linkedSimFileId: '1'
+			});
+			render(SongDetails, { props: { song } });
+			await waitFor(() => {
+				expect(vi.mocked(ChartDetail).mock.calls.length).toBeGreaterThan(0);
+			});
+			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+			expect(props?.simfile?.display_id).toBe(7);
+			expect(window.electron.ipcRenderer.invoke).not.toHaveBeenCalledWith(
+				'get-next-display-id'
+			);
+		});
+
 		it('does not invoke get-next-display-id when not authenticated', async () => {
 			const song = makeNode('TestSong', '/test/TestSong');
 			render(SongDetails, { props: { song } });
@@ -527,8 +575,7 @@ describe('SongDetails', () => {
 			authState = { ...authState, isAuthenticated: true };
 			const song = makeNode('TestSong', '');
 			render(SongDetails, { props: { song } });
-			// Wait a tick for any async effects
-			await new Promise((resolve) => setTimeout(resolve, 0));
+			await tick();
 			expect(window.electron.ipcRenderer.invoke).not.toHaveBeenCalledWith(
 				'get-next-display-id'
 			);
@@ -545,6 +592,95 @@ describe('SongDetails', () => {
 			}
 			const song = makeNode('TestSong', '/test/TestSong');
 			expect(() => render(SongDetails, { props: { song } })).not.toThrow();
+		});
+
+		it('retries get-next-display-id for a failed path when the song is reopened', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			let getNextCalls = 0;
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') {
+						getNextCalls += 1;
+						if (getNextCalls === 1) throw new Error('IPC error');
+						return 43;
+					}
+					return { files: [] };
+				});
+			}
+			const song = makeNode('TestSong', '/test/TestSong');
+			const { rerender } = render(SongDetails, { props: { song } });
+			await waitFor(() => {
+				expect(getNextCalls).toBe(1);
+			});
+
+			await rerender({ props: { song: makeNode('EmptySong', '') } });
+			await rerender({ props: { song } });
+			await waitFor(() => {
+				expect(getNextCalls).toBe(2);
+			});
+		});
+
+		it('sends null displayId when saving an auto-populated display_id', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') return 42;
+					if (channel === 'parse-dtx-files') {
+						return { bpm: 120, artist: 'Artist', levels: [{ label: 'EXT', level: 9 }] };
+					}
+					if (channel === 'create-simfile-record') {
+						return {
+							success: true,
+							simfileId: '99',
+							data: {
+								id: 99,
+								title: 'TestSong',
+								artist: 'Artist',
+								bpm: 120,
+								display_id: 42,
+								is_published: false,
+								publish_date: '2024-01-01',
+								download_url: '',
+								preview_url: '',
+								video_preview_url: '',
+								dtx_files: []
+							}
+						};
+					}
+					return { files: [] };
+				});
+			}
+			const song = makeNode('TestSong', '/test/TestSong', { containsDtxFiles: true });
+			render(SongDetails, { props: { song } });
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'get-next-display-id'
+				);
+			});
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				expect(props?.simfile?.display_id).toBe(42);
+			});
+
+			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+			await props?.$$events?.onSave?.({
+				detail: {
+					displayId: 42,
+					publishDate: '2024-01-01',
+					isPublished: false,
+					downloadUrl: '',
+					videoPreviewUrl: ''
+				}
+			});
+
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'create-simfile-record',
+					expect.objectContaining({ displayId: null })
+				);
+			});
 		});
 
 		it('does not duplicate get-next-display-id calls when effect re-triggers during in-flight request', async () => {
@@ -572,19 +708,14 @@ describe('SongDetails', () => {
 					'get-next-display-id'
 				);
 			});
-			const callCountBefore = invokeMock?.mock.calls.filter(
-				(call: string[]) => call[0] === 'get-next-display-id'
-			).length;
+			const callCountBefore = getNextDisplayIdCallCount();
 
-			// Resolve the in-flight request
 			resolveIpc?.();
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await waitFor(() => {
+				expect(getNextDisplayIdCallCount()).toBe(callCountBefore);
+			});
 
-			const callCountAfter = invokeMock?.mock.calls.filter(
-				(call: string[]) => call[0] === 'get-next-display-id'
-			).length;
-			// Should be exactly 1 call — no duplicates
-			expect(callCountAfter).toBe(callCountBefore);
+			expect(getNextDisplayIdCallCount()).toBe(callCountBefore);
 		});
 
 		it('does not re-trigger get-next-display-id when switching back to a previously populated song', async () => {
@@ -605,30 +736,18 @@ describe('SongDetails', () => {
 					'get-next-display-id'
 				);
 			});
-			const callsAfterSongA = invokeMock?.mock.calls.filter(
-				(call: string[]) => call[0] === 'get-next-display-id'
-			).length;
+			const callsAfterSongA = getNextDisplayIdCallCount();
 
-			// Switch to songB
 			const songB = makeNode('SongB', '/test/SongB');
-			rerender({ props: { song: songB } });
+			await rerender({ props: { song: songB } });
 			await waitFor(() => {
-				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
-					'get-next-display-id'
-				);
+				expect(getNextDisplayIdCallCount()).toBe(callsAfterSongA + 1);
 			});
-			const callsAfterSongB = invokeMock?.mock.calls.filter(
-				(call: string[]) => call[0] === 'get-next-display-id'
-			).length;
-			expect(callsAfterSongB).toBe(callsAfterSongA + 1);
+			const callsAfterSongB = getNextDisplayIdCallCount();
 
-			// Switch back to songA — should NOT trigger another get-next-display-id
-			rerender({ props: { song: songA } });
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			const callsAfterBackToA = invokeMock?.mock.calls.filter(
-				(call: string[]) => call[0] === 'get-next-display-id'
-			).length;
-			expect(callsAfterBackToA).toBe(callsAfterSongB);
+			await rerender({ props: { song: songA } });
+			await tick();
+			expect(getNextDisplayIdCallCount()).toBe(callsAfterSongB);
 		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -779,5 +779,58 @@ describe('SongDetails', () => {
 				expect(props?.simfile?.display_id).toBe(43);
 			});
 		});
+
+		it('ignores stale get-next-display-id response when user switches songs before resolution', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			let resolveSongA: ((value: number) => void) | undefined;
+			let resolveSongB: ((value: number) => void) | undefined;
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') {
+						// Determine which request this is based on in-flight state
+						// SongA's request is created first; once we resolve SongA's, SongB's is next
+						if (resolveSongA === undefined) {
+							return new Promise<number>((resolve) => {
+								resolveSongA = resolve;
+							});
+						}
+						return new Promise<number>((resolve) => {
+							resolveSongB = resolve;
+						});
+					}
+					return { files: [] };
+				});
+			}
+
+			const songA = makeNode('SongA', '/test/SongA');
+			const { rerender } = render(SongDetails, { props: { song: songA } });
+
+			// Wait for SongA's get-next-display-id IPC to start
+			await waitFor(() => {
+				expect(resolveSongA).toBeDefined();
+			});
+
+			// Switch to SongB while SongA's request is still in-flight
+			const songB = makeNode('SongB', '/test/SongB');
+			await rerender({ props: { song: songB } });
+
+			// Wait for SongB's get-next-display-id IPC to start
+			await waitFor(() => {
+				expect(resolveSongB).toBeDefined();
+			});
+
+			// Resolve SongA's stale request with value 99 (should be ignored)
+			resolveSongA!(99);
+
+			// Resolve SongB's request with value 50 (should be applied)
+			resolveSongB!(50);
+
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				// SongB should get 50, not the stale 99 from SongA
+				expect(props?.simfile?.display_id).toBe(50);
+			});
+		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -840,5 +840,58 @@ describe('SongDetails', () => {
 				expect(props?.simfile?.display_id).toBe(50);
 			});
 		});
+
+		it('does not show error banner when stale get-next-display-id request rejects after user switches songs', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			let rejectSongA: ((reason: unknown) => void) | undefined;
+			let resolveSongB: ((value: number) => void) | undefined;
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') {
+						if (rejectSongA === undefined) {
+							return new Promise<number>((_resolve, reject) => {
+								rejectSongA = reject;
+							});
+						}
+						return new Promise<number>((resolve) => {
+							resolveSongB = resolve;
+						});
+					}
+					return { files: [] };
+				});
+			}
+
+			const songA = makeNode('SongA', '/test/SongA');
+			const { rerender } = render(SongDetails, { props: { song: songA } });
+
+			// Wait for SongA's get-next-display-id IPC to start
+			await waitFor(() => {
+				expect(rejectSongA).toBeDefined();
+			});
+
+			// Switch to SongB while SongA's request is still in-flight
+			const songB = makeNode('SongB', '/test/SongB');
+			await rerender({ props: { song: songB } });
+
+			// Wait for SongB's get-next-display-id IPC to start
+			await waitFor(() => {
+				expect(resolveSongB).toBeDefined();
+			});
+
+			// Reject SongA's stale request (should NOT set error on SongB)
+			rejectSongA!(new Error('Network error'));
+
+			// Resolve SongB's request with value 50
+			resolveSongB!(50);
+
+			await waitFor(() => {
+				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
+				expect(props?.simfile?.display_id).toBe(50);
+			});
+
+			// No error banner should be visible for SongB
+			expect(screen.queryByText(/Could not fetch the next display ID/)).toBeNull();
+		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -546,5 +546,49 @@ describe('SongDetails', () => {
 			const song = makeNode('TestSong', '/test/TestSong');
 			expect(() => render(SongDetails, { props: { song } })).not.toThrow();
 		});
+
+		it('does not re-trigger get-next-display-id when switching back to a previously populated song', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') return 42;
+					return { files: [] };
+				});
+			}
+			const songA = makeNode('SongA', '/test/SongA');
+			const { rerender } = render(SongDetails, { props: { song: songA } });
+
+			// Wait for songA's get-next-display-id to fire
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'get-next-display-id'
+				);
+			});
+			const callsAfterSongA = invokeMock?.mock.calls.filter(
+				(call: string[]) => call[0] === 'get-next-display-id'
+			).length;
+
+			// Switch to songB
+			const songB = makeNode('SongB', '/test/SongB');
+			rerender({ props: { song: songB } });
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'get-next-display-id'
+				);
+			});
+			const callsAfterSongB = invokeMock?.mock.calls.filter(
+				(call: string[]) => call[0] === 'get-next-display-id'
+			).length;
+			expect(callsAfterSongB).toBe(callsAfterSongA + 1);
+
+			// Switch back to songA — should NOT trigger another get-next-display-id
+			rerender({ props: { song: songA } });
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			const callsAfterBackToA = invokeMock?.mock.calls.filter(
+				(call: string[]) => call[0] === 'get-next-display-id'
+			).length;
+			expect(callsAfterBackToA).toBe(callsAfterSongB);
+		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -547,6 +547,46 @@ describe('SongDetails', () => {
 			expect(() => render(SongDetails, { props: { song } })).not.toThrow();
 		});
 
+		it('does not duplicate get-next-display-id calls when effect re-triggers during in-flight request', async () => {
+			authState = { ...authState, isAuthenticated: true };
+			let resolveIpc: (() => void) | undefined;
+			const invokeMock = window.electron?.ipcRenderer?.invoke;
+			if (vi.isMockFunction(invokeMock)) {
+				invokeMock.mockImplementation(async (channel: string) => {
+					if (channel === 'get-next-display-id') {
+						// Hold the request open so we can observe duplicate calls
+						await new Promise<void>((resolve) => {
+							resolveIpc = resolve;
+						});
+						return 42;
+					}
+					return { files: [] };
+				});
+			}
+			const song = makeNode('TestSong', '/test/TestSong');
+			render(SongDetails, { props: { song } });
+
+			// Wait for the first IPC call to start
+			await waitFor(() => {
+				expect(window.electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+					'get-next-display-id'
+				);
+			});
+			const callCountBefore = invokeMock?.mock.calls.filter(
+				(call: string[]) => call[0] === 'get-next-display-id'
+			).length;
+
+			// Resolve the in-flight request
+			resolveIpc?.();
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			const callCountAfter = invokeMock?.mock.calls.filter(
+				(call: string[]) => call[0] === 'get-next-display-id'
+			).length;
+			// Should be exactly 1 call — no duplicates
+			expect(callCountAfter).toBe(callCountBefore);
+		});
+
 		it('does not re-trigger get-next-display-id when switching back to a previously populated song', async () => {
 			authState = { ...authState, isAuthenticated: true };
 			const invokeMock = window.electron?.ipcRenderer?.invoke;

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
@@ -202,4 +202,20 @@ describe('SimFileService', () => {
 			expect(url).toBe('');
 		});
 	});
+
+	describe('getNextDisplayId', () => {
+		it('returns the next display_id from IPC', async () => {
+			mockInvoke.mockResolvedValue(7);
+
+			const result = await simFileService.getNextDisplayId();
+
+			expect(mockInvoke).toHaveBeenCalledWith('get-next-display-id');
+			expect(result).toBe(7);
+		});
+
+		it('propagates IPC errors', async () => {
+			mockInvoke.mockRejectedValue(new Error('IPC failure'));
+			await expect(simFileService.getNextDisplayId()).rejects.toThrow('IPC failure');
+		});
+	});
 });

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
@@ -217,5 +217,12 @@ describe('SimFileService', () => {
 			mockInvoke.mockRejectedValue(new Error('IPC failure'));
 			await expect(simFileService.getNextDisplayId()).rejects.toThrow('IPC failure');
 		});
+
+		it('rejects invalid IPC response shapes', async () => {
+			mockInvoke.mockResolvedValue(undefined);
+			await expect(simFileService.getNextDisplayId()).rejects.toThrow(
+				'Invalid next display_id response'
+			);
+		});
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
@@ -138,11 +138,12 @@ class SimFileService {
 		return this.fetchUserSimFiles();
 	}
 
-	/**
-	 * Fetches the next display_id (max + 1) for the current user via main process
-	 */
 	async getNextDisplayId(): Promise<number> {
-		return (await window.electron.ipcRenderer.invoke('get-next-display-id')) as number;
+		const result = await window.electron.ipcRenderer.invoke('get-next-display-id');
+		if (typeof result !== 'number' || !Number.isSafeInteger(result)) {
+			throw new Error('Invalid next display_id response');
+		}
+		return result;
 	}
 
 	/**

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
@@ -139,6 +139,13 @@ class SimFileService {
 	}
 
 	/**
+	 * Fetches the next display_id (max + 1) for the current user via main process
+	 */
+	async getNextDisplayId(): Promise<number> {
+		return (await window.electron.ipcRenderer.invoke('get-next-display-id')) as number;
+	}
+
+	/**
 	 * Gets preview URL for a simFile via main process
 	 * Always constructs R2 URL: {BUCKET_URL}/{simfileId}/preview.jpg
 	 */

--- a/packages/dtx-web/src/lib/server/db.test.ts
+++ b/packages/dtx-web/src/lib/server/db.test.ts
@@ -615,6 +615,13 @@ describe('getNextDisplayId', () => {
 		await getNextDisplayId(db as unknown as D1Database, 'user-42');
 		expect(stmt.bind).toHaveBeenCalledWith('user-42');
 	});
+
+	it('throws when current + 1 overflows safe integer range', async () => {
+		const db = createMockDb(() => createMockStmt({ max_display_id: Number.MAX_SAFE_INTEGER }));
+		await expect(getNextDisplayId(db as unknown as D1Database, 'user-1')).rejects.toThrow(
+			'Invalid next display_id'
+		);
+	});
 });
 
 describe('createSimfile', () => {

--- a/packages/dtx-web/src/lib/server/db.test.ts
+++ b/packages/dtx-web/src/lib/server/db.test.ts
@@ -11,6 +11,7 @@ import {
 	getSimfileOwner,
 	listSimfiles,
 	searchSimfiles,
+	getNextDisplayId,
 	createSimfile,
 	updateSimfile,
 	deleteSimfile,
@@ -573,6 +574,36 @@ describe('searchSimfiles', () => {
 // ---------------------------------------------------------------------------
 // createSimfile
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// getNextDisplayId
+// ---------------------------------------------------------------------------
+describe('getNextDisplayId', () => {
+	it('returns max + 1 when user has existing simfiles', async () => {
+		const db = createMockDb(() => createMockStmt({ max_display_id: 7 }));
+		const result = await getNextDisplayId(db as unknown as D1Database, 'user-1');
+		expect(result).toBe(8);
+	});
+
+	it('returns 1 when user has no simfiles', async () => {
+		const db = createMockDb(() => createMockStmt({ max_display_id: null }));
+		const result = await getNextDisplayId(db as unknown as D1Database, 'user-1');
+		expect(result).toBe(1);
+	});
+
+	it('returns 1 when row lookup returns null', async () => {
+		const db = createMockDb(() => createMockStmt(null));
+		const result = await getNextDisplayId(db as unknown as D1Database, 'user-1');
+		expect(result).toBe(1);
+	});
+
+	it('binds the userId to the query', async () => {
+		const stmt = createMockStmt({ max_display_id: 3 });
+		const db = createMockDb(() => stmt);
+		await getNextDisplayId(db as unknown as D1Database, 'user-42');
+		expect(stmt.bind).toHaveBeenCalledWith('user-42');
+	});
+});
+
 describe('createSimfile', () => {
 	it('creates and returns simfile row', async () => {
 		const db = createMockDb(() => createMockStmt(baseSimfileRow));

--- a/packages/dtx-web/src/lib/server/db.test.ts
+++ b/packages/dtx-web/src/lib/server/db.test.ts
@@ -584,6 +584,19 @@ describe('getNextDisplayId', () => {
 		expect(result).toBe(8);
 	});
 
+	it('coerces string aggregate values from D1 before incrementing', async () => {
+		const db = createMockDb(() => createMockStmt({ max_display_id: '7' }));
+		const result = await getNextDisplayId(db as unknown as D1Database, 'user-1');
+		expect(result).toBe(8);
+	});
+
+	it('throws when max display_id cannot be coerced to a safe integer', async () => {
+		const db = createMockDb(() => createMockStmt({ max_display_id: 'not-a-number' }));
+		await expect(getNextDisplayId(db as unknown as D1Database, 'user-1')).rejects.toThrow(
+			'Invalid max display_id'
+		);
+	});
+
 	it('returns 1 when user has no simfiles', async () => {
 		const db = createMockDb(() => createMockStmt({ max_display_id: null }));
 		const result = await getNextDisplayId(db as unknown as D1Database, 'user-1');
@@ -612,6 +625,41 @@ describe('createSimfile', () => {
 			user_id: 'user-1'
 		});
 		expect(result).toEqual(baseSimfileRow);
+	});
+
+	it('allocates display_id inside the INSERT statement when display_id is null', async () => {
+		const stmt = createMockStmt({ ...baseSimfileRow, display_id: 8 });
+		const db = createMockDb(() => stmt);
+		await createSimfile(db as unknown as D1Database, {
+			bpm: 120,
+			user_id: 'user-1',
+			display_id: null
+		});
+
+		const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+		expect(sql).toContain(
+			'COALESCE((SELECT MAX(display_id) FROM simfiles WHERE user_id = ?), 0) + 1'
+		);
+		const bindArgs = stmt.bind.mock.calls[0];
+		expect(bindArgs[5]).toBeNull();
+		expect(bindArgs[6]).toBeNull();
+		expect(bindArgs[7]).toBe('user-1');
+		expect(bindArgs[8]).toBeNull();
+	});
+
+	it('passes explicit display_id through the INSERT statement for manual values', async () => {
+		const stmt = createMockStmt({ ...baseSimfileRow, display_id: 12 });
+		const db = createMockDb(() => stmt);
+		await createSimfile(db as unknown as D1Database, {
+			bpm: 120,
+			user_id: 'user-1',
+			display_id: 12
+		});
+
+		const bindArgs = stmt.bind.mock.calls[0];
+		expect(bindArgs[5]).toBe(12);
+		expect(bindArgs[6]).toBe(12);
+		expect(bindArgs[8]).toBe(12);
 	});
 
 	it('throws when insert returns null', async () => {

--- a/packages/dtx-web/src/lib/server/db.ts
+++ b/packages/dtx-web/src/lib/server/db.ts
@@ -295,17 +295,26 @@ export const getNextDisplayId = async (db: D1Database, userId: string): Promise<
 	const row = await db
 		.prepare('SELECT MAX(display_id) AS max_display_id FROM simfiles WHERE user_id = ?')
 		.bind(userId)
-		.first<{ max_display_id: number | null }>();
-	const current = row?.max_display_id ?? 0;
+		.first<{ max_display_id: number | string | null }>();
+	const current = Number(row?.max_display_id ?? 0);
+	if (!Number.isFinite(current) || !Number.isSafeInteger(current)) {
+		throw new Error('Invalid max display_id');
+	}
 	return current + 1;
 };
 
 export const createSimfile = async (db: D1Database, data: SimfileInsert): Promise<SimfileRow> => {
 	const now = new Date().toISOString();
+	const displayId = data.display_id ?? null;
 	const result = await db
 		.prepare(
 			`INSERT INTO simfiles (title, artist, bpm, user_id, is_published, display_id, download_url, preview_url, video_preview_url, publish_date, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 SELECT ?, ?, ?, ?, ?,
+				CASE
+					WHEN ? IS NULL OR ? = 0 THEN COALESCE((SELECT MAX(display_id) FROM simfiles WHERE user_id = ?), 0) + 1
+					ELSE ?
+				END,
+				?, ?, ?, ?, ?, ?
 			 RETURNING *`
 		)
 		.bind(
@@ -314,7 +323,10 @@ export const createSimfile = async (db: D1Database, data: SimfileInsert): Promis
 			data.bpm,
 			data.user_id,
 			data.is_published ?? 0,
-			data.display_id ?? null,
+			displayId,
+			displayId,
+			data.user_id,
+			displayId,
 			data.download_url ?? null,
 			data.preview_url ?? null,
 			data.video_preview_url ?? null,

--- a/packages/dtx-web/src/lib/server/db.ts
+++ b/packages/dtx-web/src/lib/server/db.ts
@@ -300,7 +300,11 @@ export const getNextDisplayId = async (db: D1Database, userId: string): Promise<
 	if (!Number.isFinite(current) || !Number.isSafeInteger(current)) {
 		throw new Error('Invalid max display_id');
 	}
-	return current + 1;
+	const next = current + 1;
+	if (!Number.isFinite(next) || !Number.isSafeInteger(next)) {
+		throw new Error('Invalid next display_id');
+	}
+	return next;
 };
 
 export const createSimfile = async (db: D1Database, data: SimfileInsert): Promise<SimfileRow> => {

--- a/packages/dtx-web/src/lib/server/db.ts
+++ b/packages/dtx-web/src/lib/server/db.ts
@@ -291,6 +291,15 @@ export const searchSimfiles = async (
 		.limit(limit);
 };
 
+export const getNextDisplayId = async (db: D1Database, userId: string): Promise<number> => {
+	const row = await db
+		.prepare('SELECT MAX(display_id) AS max_display_id FROM simfiles WHERE user_id = ?')
+		.bind(userId)
+		.first<{ max_display_id: number | null }>();
+	const current = row?.max_display_id ?? 0;
+	return current + 1;
+};
+
 export const createSimfile = async (db: D1Database, data: SimfileInsert): Promise<SimfileRow> => {
 	const now = new Date().toISOString();
 	const result = await db

--- a/packages/dtx-web/src/routes/api/chart/next-display-id/+server.ts
+++ b/packages/dtx-web/src/routes/api/chart/next-display-id/+server.ts
@@ -1,0 +1,18 @@
+import { json } from '@sveltejs/kit';
+import { getDb, getNextDisplayId } from '$lib/server/db';
+import logger from '$lib/server/logger';
+
+/** GET /api/chart/next-display-id — Next display_id for the current user */
+export const GET = async ({ platform, locals }: { platform: App.Platform; locals: App.Locals }) => {
+	const user = locals.user;
+	if (!user) return json({ error: 'Unauthorized' }, { status: 401 });
+
+	try {
+		const db = getDb(platform);
+		const nextDisplayId = await getNextDisplayId(db, user.id);
+		return json({ nextDisplayId });
+	} catch (error) {
+		logger.error('Error fetching next display_id:', error);
+		return json({ error: 'Failed to fetch next display_id' }, { status: 500 });
+	}
+};

--- a/packages/dtx-web/src/routes/api/chart/next-display-id/+server.ts
+++ b/packages/dtx-web/src/routes/api/chart/next-display-id/+server.ts
@@ -2,7 +2,6 @@ import { json } from '@sveltejs/kit';
 import { getDb, getNextDisplayId } from '$lib/server/db';
 import logger from '$lib/server/logger';
 
-/** GET /api/chart/next-display-id — Next display_id for the current user */
 export const GET = async ({ platform, locals }: { platform: App.Platform; locals: App.Locals }) => {
 	const user = locals.user;
 	if (!user) return json({ error: 'Unauthorized' }, { status: 401 });
@@ -12,7 +11,7 @@ export const GET = async ({ platform, locals }: { platform: App.Platform; locals
 		const nextDisplayId = await getNextDisplayId(db, user.id);
 		return json({ nextDisplayId });
 	} catch (error) {
-		logger.error('Error fetching next display_id:', error);
+		logger.error('Error fetching next display_id:', { userId: user.id, error });
 		return json({ error: 'Failed to fetch next display_id' }, { status: 500 });
 	}
 };

--- a/packages/dtx-web/src/routes/api/chart/next-display-id/server.test.ts
+++ b/packages/dtx-web/src/routes/api/chart/next-display-id/server.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './+server';
+import { getDb, getNextDisplayId } from '$lib/server/db';
+import type { D1Database } from '@cloudflare/workers-types';
+
+vi.mock('$lib/server/db');
+vi.mock('$lib/server/logger', () => ({
+	default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() }
+}));
+
+const mockUser = { id: 'user-1', email: 'test@example.com' };
+const mockPlatform = { env: { DB: {} } };
+
+describe('GET /api/chart/next-display-id', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getDb).mockReturnValue({} as D1Database);
+	});
+
+	it('returns 401 when unauthenticated', async () => {
+		const response = await GET({
+			platform: mockPlatform as App.Platform,
+			locals: { user: null } as App.Locals
+		});
+		expect(response.status).toBe(401);
+	});
+
+	it('returns the next display_id for the authenticated user', async () => {
+		vi.mocked(getNextDisplayId).mockResolvedValue(42);
+		const response = await GET({
+			platform: mockPlatform as App.Platform,
+			locals: { user: mockUser } as App.Locals
+		});
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(data).toEqual({ nextDisplayId: 42 });
+		expect(getNextDisplayId).toHaveBeenCalledWith(expect.anything(), 'user-1');
+	});
+
+	it('returns 500 on unexpected error', async () => {
+		vi.mocked(getNextDisplayId).mockRejectedValue(new Error('DB error'));
+		const response = await GET({
+			platform: mockPlatform as App.Platform,
+			locals: { user: mockUser } as App.Locals
+		});
+		expect(response.status).toBe(500);
+	});
+});

--- a/packages/dtx-web/src/routes/api/chart/next-display-id/server.test.ts
+++ b/packages/dtx-web/src/routes/api/chart/next-display-id/server.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from './+server';
 import { getDb, getNextDisplayId } from '$lib/server/db';
 import type { D1Database } from '@cloudflare/workers-types';
+import logger from '$lib/server/logger';
 
 vi.mock('$lib/server/db');
 vi.mock('$lib/server/logger', () => ({
@@ -38,11 +39,16 @@ describe('GET /api/chart/next-display-id', () => {
 	});
 
 	it('returns 500 on unexpected error', async () => {
-		vi.mocked(getNextDisplayId).mockRejectedValue(new Error('DB error'));
+		const error = new Error('DB error');
+		vi.mocked(getNextDisplayId).mockRejectedValue(error);
 		const response = await GET({
 			platform: mockPlatform as App.Platform,
 			locals: { user: mockUser } as App.Locals
 		});
 		expect(response.status).toBe(500);
+		expect(logger.error).toHaveBeenCalledWith('Error fetching next display_id:', {
+			userId: 'user-1',
+			error
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Adds a new API endpoint  to get the next available display_id for new charts
- Auto-populates display_id when creating new charts in the SongDetails component
- Includes various desktop bug fixes related to workspace bookmark path validation and error handling

## Changes
- **dtx-web**: Add  API endpoint with database query and e2e test
- **dtx-desktop**: Auto-populate display_id in SongDetails, fix bookmark path validation errors
- **Tests**: Add unit and e2e tests for the new API and service methods

## Test Plan
- [x] E2E tests pass for next display_id API
- [x] Unit tests pass for simfile service and SongDetails
- [x] Manual testing for new chart creation flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app auto-populates display IDs for unlinked songs (with caching, retry, and error banner) and omits the ID from uploads when appropriate.
  * New authenticated API endpoint to fetch the next available display ID; renderer and desktop layers now request it securely.

* **Tests**
  * Added extensive tests covering display ID allocation, IPC/renderer behavior, API route, and DB allocation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/DTXWeb/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->