### PR TITLE
feat(dtx-api): harden download & R2 enrichment pipeline

### DIFF
--- a/packages/dtx-api/src/context.ts
+++ b/packages/dtx-api/src/context.ts
@@ -19,6 +19,7 @@ export type Ctx = {
 	request: Request;
 	logger: WorkerLogger;
 	ownerByIdCache: Map<string, OwnerCacheEntry | null>;
+	hasUploadedFilesCache: Map<number, Promise<boolean>>;
 };
 
 export const createContext = async (request: Request, env: Env): Promise<Ctx> => {
@@ -32,6 +33,7 @@ export const createContext = async (request: Request, env: Env): Promise<Ctx> =>
 		kv: env.RATE_LIMIT_API,
 		request,
 		logger: workerLogger,
-		ownerByIdCache: new Map()
+		ownerByIdCache: new Map(),
+		hasUploadedFilesCache: new Map()
 	};
 };

--- a/packages/dtx-api/src/context.ts
+++ b/packages/dtx-api/src/context.ts
@@ -20,6 +20,7 @@ export type Ctx = {
 	logger: WorkerLogger;
 	ownerByIdCache: Map<string, OwnerCacheEntry | null>;
 	hasUploadedFilesCache: Map<number, Promise<boolean>>;
+	filesCache: Map<number, Promise<import('./services/r2Enrichment').R2FileEntry[]>>;
 };
 
 export const createContext = async (request: Request, env: Env): Promise<Ctx> => {
@@ -34,6 +35,7 @@ export const createContext = async (request: Request, env: Env): Promise<Ctx> =>
 		request,
 		logger: workerLogger,
 		ownerByIdCache: new Map(),
-		hasUploadedFilesCache: new Map()
+		hasUploadedFilesCache: new Map(),
+		filesCache: new Map()
 	};
 };

--- a/packages/dtx-api/src/index.test.ts
+++ b/packages/dtx-api/src/index.test.ts
@@ -167,6 +167,18 @@ describe('Phase 2 routes', () => {
 		expect(response.status).toBe(405);
 	});
 
+	it('400 on malformed /downloads/:id (non-numeric)', async () => {
+		const env = makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' });
+		const response = await worker.fetch(
+			new Request('http://api/downloads/abc', { method: 'GET' }),
+			env,
+			makeExecutionCtx()
+		);
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error: string };
+		expect(body.error).toBe('Invalid SimFile ID');
+	});
+
 	it('405 on GET /downloads/bulk', async () => {
 		const env = makeEnv();
 		const response = await worker.fetch(

--- a/packages/dtx-api/src/index.test.ts
+++ b/packages/dtx-api/src/index.test.ts
@@ -123,6 +123,8 @@ describe('worker fetch router', () => {
 
 describe('Phase 2 routes', () => {
 	it('GET /downloads/123 dispatches to downloadSimfile route', async () => {
+		const { getClientIp } = await import('@dtx/common/server');
+		vi.mocked(getClientIp).mockReturnValueOnce('1.2.3.4');
 		const env = makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' });
 		const response = await worker.fetch(
 			new Request('http://api/downloads/123', { method: 'GET' }),
@@ -131,6 +133,19 @@ describe('Phase 2 routes', () => {
 		);
 		expect(response.status).toBe(200);
 		expect(response.headers.get('content-type')).toBe('application/zip');
+	});
+
+	it('GET /downloads/123 returns 400 when client IP is unavailable', async () => {
+		// getClientIp is mocked to return null by default
+		const env = makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' });
+		const response = await worker.fetch(
+			new Request('http://api/downloads/123', { method: 'GET' }),
+			env,
+			makeExecutionCtx()
+		);
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error: string };
+		expect(body.error).toBe('Unable to determine client IP for rate limiting.');
 	});
 
 	it('POST /downloads/bulk dispatches to downloadBulk route', async () => {

--- a/packages/dtx-api/src/index.test.ts
+++ b/packages/dtx-api/src/index.test.ts
@@ -193,4 +193,31 @@ describe('Phase 2 routes', () => {
 			'https://pre-prod.dtx.hapadona.com'
 		);
 	});
+
+	it('CORS-wraps 500 when a route handler throws', async () => {
+		const { getSimfileOwner } = await import('@dtx/common/server');
+		vi.mocked(getSimfileOwner).mockRejectedValueOnce(new Error('R2 listing failed'));
+
+		const env = makeEnv({
+			PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true',
+			CORS_ALLOWED_ORIGINS: 'http://localhost:5173'
+		});
+		const response = await worker.fetch(
+			new Request('http://api/downloads/bulk', {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					Origin: 'http://localhost:5173'
+				},
+				body: JSON.stringify({ ids: [1] })
+			}),
+			env,
+			makeExecutionCtx()
+		);
+
+		expect(response.status).toBe(500);
+		expect(response.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173');
+		const body = (await response.json()) as { error: string };
+		expect(body.error).toBe('Internal Server Error');
+	});
 });

--- a/packages/dtx-api/src/index.test.ts
+++ b/packages/dtx-api/src/index.test.ts
@@ -149,7 +149,7 @@ describe('Phase 2 routes', () => {
 	});
 
 	it('POST /downloads/bulk dispatches to downloadBulk route', async () => {
-		const env = makeEnv();
+		const env = makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' });
 		const response = await worker.fetch(
 			new Request('http://api/downloads/bulk', {
 				method: 'POST',

--- a/packages/dtx-api/src/index.ts
+++ b/packages/dtx-api/src/index.ts
@@ -11,6 +11,19 @@ const downloadSimfilePattern = /^\/downloads\/(\d+)$/;
 const methodNotAllowed = (allow: string) =>
 	new Response('Method Not Allowed', { status: 405, headers: { Allow: allow } });
 
+const internalError = new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+	status: 500,
+	headers: { 'content-type': 'application/json' }
+});
+
+const safeRoute = async (fn: () => Promise<Response>): Promise<Response> => {
+	try {
+		return await fn();
+	} catch {
+		return internalError;
+	}
+};
+
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const preflight = handlePreflight(request, env);
@@ -30,26 +43,23 @@ export default {
 		}
 
 		if (url.pathname === '/downloads/bulk') {
-			return request.method === 'POST'
-				? withCors(await routeDownloadBulk(request, env), request, env)
-				: withCors(methodNotAllowed('POST'), request, env);
+			if (request.method !== 'POST') return withCors(methodNotAllowed('POST'), request, env);
+			return withCors(await safeRoute(() => routeDownloadBulk(request, env)), request, env);
 		}
 
 		const downloadMatch = downloadSimfilePattern.exec(url.pathname);
 		if (downloadMatch) {
-			return request.method === 'GET'
-				? withCors(
-						await routeDownloadSimfile(request, env, ctx, downloadMatch[1]),
-						request,
-						env
-					)
-				: withCors(methodNotAllowed('GET'), request, env);
+			if (request.method !== 'GET') return withCors(methodNotAllowed('GET'), request, env);
+			return withCors(
+				await safeRoute(() => routeDownloadSimfile(request, env, ctx, downloadMatch[1])),
+				request,
+				env
+			);
 		}
 
 		if (url.pathname === '/upload') {
-			return request.method === 'POST'
-				? withCors(await routeUpload(request, env, ctx), request, env)
-				: withCors(methodNotAllowed('POST'), request, env);
+			if (request.method !== 'POST') return withCors(methodNotAllowed('POST'), request, env);
+			return withCors(await safeRoute(() => routeUpload(request, env, ctx)), request, env);
 		}
 
 		return withCors(new Response('Not Found', { status: 404 }), request, env);

--- a/packages/dtx-api/src/index.ts
+++ b/packages/dtx-api/src/index.ts
@@ -11,16 +11,17 @@ const downloadSimfilePattern = /^\/downloads\/(\d+)$/;
 const methodNotAllowed = (allow: string) =>
 	new Response('Method Not Allowed', { status: 405, headers: { Allow: allow } });
 
-const internalError = new Response(JSON.stringify({ error: 'Internal Server Error' }), {
-	status: 500,
-	headers: { 'content-type': 'application/json' }
-});
+const internalError = () =>
+	new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+		status: 500,
+		headers: { 'content-type': 'application/json' }
+	});
 
 const safeRoute = async (fn: () => Promise<Response>): Promise<Response> => {
 	try {
 		return await fn();
 	} catch {
-		return internalError;
+		return internalError();
 	}
 };
 

--- a/packages/dtx-api/src/index.ts
+++ b/packages/dtx-api/src/index.ts
@@ -6,7 +6,7 @@ import { routeUpload } from './rest/upload';
 import { handlePreflight, withCors } from './lib/cors';
 import type { Env } from './env';
 
-const downloadSimfilePattern = /^\/downloads\/(\d+)$/;
+const downloadSimfilePattern = /^\/downloads\/([^/]+)$/;
 
 const methodNotAllowed = (allow: string) =>
 	new Response('Method Not Allowed', { status: 405, headers: { Allow: allow } });

--- a/packages/dtx-api/src/lib/sanitizeFilename.test.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.test.ts
@@ -23,6 +23,13 @@ describe('sanitizeFilename', () => {
 		expect(sanitizeFilename('../audio/song.wav')).toBe('audio/song.wav');
 	});
 
+	it('removes trailing parent-directory segments (foo/..)', () => {
+		expect(sanitizeFilename('foo/..')).toBe('foo');
+		expect(sanitizeFilename('audio/bar/..')).toBe('audio/bar');
+		expect(sanitizeFilename('foo\\..')).toBe('foo');
+		expect(sanitizeFilename('foo/bar/../..')).toBe('foo/bar');
+	});
+
 	it('removes path traversal sequences (..\\)', () => {
 		expect(sanitizeFilename('..\\secret.txt')).toBe('secret.txt');
 		expect(sanitizeFilename('audio\\..\\song.wav')).toBe('audio/song.wav');

--- a/packages/dtx-api/src/lib/sanitizeFilename.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.ts
@@ -9,6 +9,7 @@ export const sanitizeFilename = (filename: string): string => {
 		previousSanitized = sanitized;
 		sanitized = sanitized
 			.replace(/\.\.(?:\/|\\)/g, '')
+			.replace(/[/\\]\.\.$/, '')
 			.replace(/^[/\\]+/, '')
 			.replace(/[/\\]+$/, '');
 	} while (sanitized !== previousSanitized);

--- a/packages/dtx-api/src/rest/downloadBulk.test.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.test.ts
@@ -246,4 +246,15 @@ describe('POST /downloads/bulk', () => {
 			true
 		);
 	});
+
+	it('400 when client IP is unavailable', async () => {
+		const { getClientIp } = await import('@dtx/common/server');
+		vi.mocked(getClientIp).mockReturnValueOnce(null);
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		const response = await routeDownloadBulk(jsonReq({ ids: [1] }), makeEnv());
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: 'Unable to determine client IP for rate limiting.'
+		});
+	});
 });

--- a/packages/dtx-api/src/rest/downloadBulk.test.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.test.ts
@@ -61,6 +61,18 @@ const jsonReq = (body: unknown, search = '') =>
 		body: JSON.stringify(body)
 	});
 
+const formReq = (ids: (string | number)[], search = '') => {
+	const params = new URLSearchParams();
+	for (const id of ids) {
+		params.append('ids', String(id));
+	}
+	return new Request(`http://api/downloads/bulk${search}`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		body: params.toString()
+	});
+};
+
 beforeEach(() => {
 	mockedGetOwner.mockReset();
 	mockedRate.mockReset().mockResolvedValue({ allowed: true, remainingBytes: 0 });
@@ -128,6 +140,35 @@ describe('POST /downloads/bulk', () => {
 		expect(response.status).toBe(200);
 		const body = (await response.json()) as { ok: boolean; fileCount: number };
 		expect(body).toEqual({ ok: true, fileCount: 1 });
+		expect(mockedRate).toHaveBeenCalledWith(
+			expect.anything(),
+			'pre-prod:downloads:1.2.3.4',
+			100,
+			undefined,
+			false
+		);
+	});
+
+	it('429 on validate-only when rate limit exceeded', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedRate.mockResolvedValue({ allowed: false, remainingBytes: 0 });
+		const response = await routeDownloadBulk(jsonReq({ ids: [1] }, '?validate=1'), makeEnv());
+		expect(response.status).toBe(429);
+	});
+
+	it('accepts form-urlencoded body', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		const response = await routeDownloadBulk(formReq([1, 2]), makeEnv());
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toBe('application/zip');
+	});
+
+	it('accepts form-urlencoded body for validate-only', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		const response = await routeDownloadBulk(formReq([1], '?validate=1'), makeEnv());
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { ok: boolean; fileCount: number };
+		expect(body).toEqual({ ok: true, fileCount: 1 });
 	});
 
 	it('401 when anonymous and PUBLIC_ENABLE_BLOG_DOWNLOAD is false', async () => {
@@ -182,5 +223,17 @@ describe('POST /downloads/bulk', () => {
 		mockedRate.mockResolvedValue({ allowed: false, remainingBytes: 0 });
 		const response = await routeDownloadBulk(jsonReq({ ids: [1] }), makeEnv());
 		expect(response.status).toBe(429);
+	});
+
+	it('consumes rate limit for non-validate requests', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		await routeDownloadBulk(jsonReq({ ids: [1] }), makeEnv());
+		expect(mockedRate).toHaveBeenCalledWith(
+			expect.anything(),
+			'pre-prod:downloads:1.2.3.4',
+			100,
+			undefined,
+			true
+		);
 	});
 });

--- a/packages/dtx-api/src/rest/downloadBulk.test.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.test.ts
@@ -189,6 +189,21 @@ describe('POST /downloads/bulk', () => {
 		expect(mockedGetOwner).not.toHaveBeenCalled();
 	});
 
+	it('calls verifyToken only once when early auth succeeds (no blog download)', async () => {
+		const mockUser = { id: 'u1', email: 'a@b.com' };
+		mockedVerify.mockResolvedValue({ user: mockUser, session: {} as never });
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+
+		const response = await routeDownloadBulk(
+			jsonReq({ ids: [1] }, '?validate=1'),
+			makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'false' })
+		);
+		expect(response.status).toBe(200);
+		// verifyToken should be called exactly once — the early auth result
+		// is reused rather than making a second round trip.
+		expect(mockedVerify).toHaveBeenCalledTimes(1);
+	});
+
 	it('200 streams ZIP for accessible ids', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		const response = await routeDownloadBulk(jsonReq({ ids: [1, 2] }), makeEnv());

--- a/packages/dtx-api/src/rest/downloadBulk.test.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.test.ts
@@ -190,8 +190,10 @@ describe('POST /downloads/bulk', () => {
 	});
 
 	it('calls verifyToken only once when early auth succeeds (no blog download)', async () => {
-		const mockUser = { id: 'u1', email: 'a@b.com' };
-		mockedVerify.mockResolvedValue({ user: mockUser, session: {} as never });
+		mockedVerify.mockResolvedValue({
+			user: { id: 'u1', email: 'a@b.com' },
+			session: {}
+		} as Awaited<ReturnType<typeof verifyToken>>);
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 
 		const response = await routeDownloadBulk(

--- a/packages/dtx-api/src/rest/downloadBulk.test.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.test.ts
@@ -184,6 +184,9 @@ describe('POST /downloads/bulk', () => {
 			makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'false' })
 		);
 		expect(response.status).toBe(401);
+		// Verify auth was checked before body parsing — owner lookup should
+		// never be reached when the early auth gate rejects.
+		expect(mockedGetOwner).not.toHaveBeenCalled();
 	});
 
 	it('200 streams ZIP for accessible ids', async () => {

--- a/packages/dtx-api/src/rest/downloadBulk.test.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.test.ts
@@ -39,6 +39,9 @@ const mockedRate = vi.mocked(tryConsumeRateLimit);
 const mockedListAllR2Objects = vi.mocked(listAllR2Objects);
 const mockedVerify = vi.mocked(verifyToken);
 
+const { validateZipSources } = await import('@dtx/common/server');
+const mockedValidateZipSources = vi.mocked(validateZipSources);
+
 const makeEnv = (overrides: Partial<Env> = {}): Env => ({
 	DB: {} as Env['DB'],
 	DTXFILE_BUCKET: {} as R2Bucket,
@@ -80,6 +83,7 @@ beforeEach(() => {
 		.mockReset()
 		.mockResolvedValue([{ key: '1/song.dtx', size: 100, uploaded: new Date() }]);
 	mockedVerify.mockReset().mockResolvedValue(null);
+	mockedValidateZipSources.mockReset();
 });
 
 describe('POST /downloads/bulk', () => {
@@ -147,6 +151,8 @@ describe('POST /downloads/bulk', () => {
 			undefined,
 			false
 		);
+		// HEAD checks should NOT run for validate-only requests
+		expect(mockedValidateZipSources).not.toHaveBeenCalled();
 	});
 
 	it('429 on validate-only when rate limit exceeded', async () => {
@@ -200,6 +206,8 @@ describe('POST /downloads/bulk', () => {
 			ids: [2]
 		});
 		expect(mockedRate).not.toHaveBeenCalled();
+		// HEAD checks should NOT run when some charts have no files
+		expect(mockedValidateZipSources).not.toHaveBeenCalled();
 	});
 
 	it('reports empty accessible charts during validate-only requests', async () => {
@@ -223,6 +231,8 @@ describe('POST /downloads/bulk', () => {
 		mockedRate.mockResolvedValue({ allowed: false, remainingBytes: 0 });
 		const response = await routeDownloadBulk(jsonReq({ ids: [1] }), makeEnv());
 		expect(response.status).toBe(429);
+		// HEAD checks should NOT run when rate limit blocks the download
+		expect(mockedValidateZipSources).not.toHaveBeenCalled();
 	});
 
 	it('consumes rate limit for non-validate requests', async () => {

--- a/packages/dtx-api/src/rest/downloadBulk.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.ts
@@ -35,14 +35,28 @@ const parseIds = (raw: unknown): number[] | null => {
 	return out;
 };
 
+const parseRequestBody = async (request: Request): Promise<{ ids?: unknown }> => {
+	const contentType = request.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+
+	if (
+		contentType === 'application/x-www-form-urlencoded' ||
+		contentType === 'multipart/form-data'
+	) {
+		const formData = await request.formData();
+		return { ids: formData.getAll('ids') };
+	}
+
+	const body = await request.json();
+	if (!body || typeof body !== 'object' || Array.isArray(body)) {
+		throw new Error('Invalid request body');
+	}
+	return body as { ids?: unknown };
+};
+
 export const routeDownloadBulk = async (request: Request, env: Env): Promise<Response> => {
 	let payload: { ids?: unknown };
 	try {
-		const parsed = await request.json();
-		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-			return jsonError(400, 'Invalid request body');
-		}
-		payload = parsed as { ids?: unknown };
+		payload = await parseRequestBody(request);
 	} catch {
 		return jsonError(400, 'Invalid request body');
 	}
@@ -92,24 +106,26 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 		});
 	}
 
+	const ip = getClientIp(request);
+	if (ip) {
+		const { allowed } = await tryConsumeRateLimit(
+			env.RATE_LIMIT_API,
+			`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
+			estimatedBytes,
+			undefined,
+			!validateOnly
+		);
+		if (!allowed) {
+			return jsonError(429, 'Rate limit exceeded. Please try again later.');
+		}
+	}
+
 	if (validateOnly) {
 		return json({ ok: true, fileCount: sources.length });
 	}
 
 	if (sources.length === 0) {
 		return jsonError(404, 'No files found for the requested charts');
-	}
-
-	const ip = getClientIp(request);
-	if (ip) {
-		const { allowed } = await tryConsumeRateLimit(
-			env.RATE_LIMIT_API,
-			`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
-			estimatedBytes
-		);
-		if (!allowed) {
-			return jsonError(429, 'Rate limit exceeded. Please try again later.');
-		}
 	}
 
 	return response;

--- a/packages/dtx-api/src/rest/downloadBulk.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.ts
@@ -110,17 +110,18 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 	}
 
 	const ip = getClientIp(request);
-	if (ip) {
-		const { allowed } = await tryConsumeRateLimit(
-			env.RATE_LIMIT_API,
-			`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
-			estimatedBytes,
-			undefined,
-			!validateOnly
-		);
-		if (!allowed) {
-			return jsonError(429, 'Rate limit exceeded. Please try again later.');
-		}
+	if (!ip) {
+		return jsonError(400, 'Unable to determine client IP for rate limiting.');
+	}
+	const { allowed } = await tryConsumeRateLimit(
+		env.RATE_LIMIT_API,
+		`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
+		estimatedBytes,
+		undefined,
+		!validateOnly
+	);
+	if (!allowed) {
+		return jsonError(429, 'Rate limit exceeded. Please try again later.');
 	}
 
 	if (validateOnly) {

--- a/packages/dtx-api/src/rest/downloadBulk.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.ts
@@ -58,6 +58,17 @@ const parseRequestBody = async (request: Request): Promise<{ ids?: unknown }> =>
 };
 
 export const routeDownloadBulk = async (request: Request, env: Env): Promise<Response> => {
+	const blogDownloadEnabled = env.PUBLIC_ENABLE_BLOG_DOWNLOAD === 'true';
+
+	// When public downloads are disabled, reject anonymous requests before
+	// parsing the body to avoid wasting CPU/memory on large payloads.
+	if (!blogDownloadEnabled) {
+		const earlyAuth = await verifyToken(request, env);
+		if (!earlyAuth?.user) {
+			return jsonError(401, 'Unauthorized');
+		}
+	}
+
 	let payload: { ids?: unknown };
 	try {
 		payload = await parseRequestBody(request);
@@ -78,7 +89,7 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 	const auth = await verifyToken(request, env);
 	const user = auth?.user ?? null;
 
-	if (!user && env.PUBLIC_ENABLE_BLOG_DOWNLOAD !== 'true') {
+	if (!user && !blogDownloadEnabled) {
 		return jsonError(401, 'Unauthorized');
 	}
 

--- a/packages/dtx-api/src/rest/downloadBulk.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.ts
@@ -104,7 +104,7 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 	if (ip) {
 		const { allowed } = await tryConsumeRateLimit(
 			env.RATE_LIMIT_API,
-			`${env.RATE_LIMIT_ENV}:bulk:${ip}`,
+			`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
 			estimatedBytes
 		);
 		if (!allowed) {

--- a/packages/dtx-api/src/rest/downloadBulk.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.ts
@@ -1,6 +1,10 @@
 import { getClientIp, tryConsumeRateLimit } from '@dtx/common/server';
 import { verifyToken } from '../auth/verifyToken';
-import { resolveAccessibleSimfiles, buildSimfileZipResponse } from '../services/downloads';
+import {
+	resolveAccessibleSimfiles,
+	collectZipSources,
+	buildValidatedZipResponse
+} from '../services/downloads';
 import type { Env } from '../env';
 
 const MAX_BULK_IDS = 20;
@@ -90,10 +94,9 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 		return jsonError(404, 'Simfile not found', { ids: access.missing });
 	}
 
-	const { response, sources, sourcesBySimfile, estimatedBytes } = await buildSimfileZipResponse(
+	const { sources, sourcesBySimfile, estimatedBytes } = await collectZipSources(
 		env.DTXFILE_BUCKET,
-		access.accessible,
-		{ filename: 'drumery-charts.zip' }
+		access.accessible
 	);
 
 	const missingUploadIds = sourcesBySimfile
@@ -127,6 +130,10 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 	if (sources.length === 0) {
 		return jsonError(404, 'No files found for the requested charts');
 	}
+
+	const response = await buildValidatedZipResponse(env.DTXFILE_BUCKET, sources, {
+		filename: 'drumery-charts.zip'
+	});
 
 	return response;
 };

--- a/packages/dtx-api/src/rest/downloadBulk.ts
+++ b/packages/dtx-api/src/rest/downloadBulk.ts
@@ -62,9 +62,10 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 
 	// When public downloads are disabled, reject anonymous requests before
 	// parsing the body to avoid wasting CPU/memory on large payloads.
+	let auth: Awaited<ReturnType<typeof verifyToken>> | null = null;
 	if (!blogDownloadEnabled) {
-		const earlyAuth = await verifyToken(request, env);
-		if (!earlyAuth?.user) {
+		auth = await verifyToken(request, env);
+		if (!auth?.user) {
 			return jsonError(401, 'Unauthorized');
 		}
 	}
@@ -86,12 +87,13 @@ export const routeDownloadBulk = async (request: Request, env: Env): Promise<Res
 
 	const validateOnly = new URL(request.url).searchParams.get('validate') === '1';
 
-	const auth = await verifyToken(request, env);
-	const user = auth?.user ?? null;
-
-	if (!user && !blogDownloadEnabled) {
-		return jsonError(401, 'Unauthorized');
+	// Reuse the early auth result when available; only verify the token
+	// again when public downloads are enabled (anonymous access allowed,
+	// but a valid token grants access to the user's private charts too).
+	if (!auth) {
+		auth = await verifyToken(request, env);
 	}
+	const user = auth?.user ?? null;
 
 	const access = await resolveAccessibleSimfiles(env.DB, unique, user);
 

--- a/packages/dtx-api/src/rest/downloadSimfile.test.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.test.ts
@@ -31,6 +31,9 @@ const mockedRate = vi.mocked(tryConsumeRateLimit);
 const mockedCreateZipSources = vi.mocked(createZipSources);
 const mockedVerify = vi.mocked(verifyToken);
 
+const { validateZipSources } = await import('@dtx/common/server');
+const mockedValidateZipSources = vi.mocked(validateZipSources);
+
 const makeEnv = (overrides: Partial<Env> = {}): Env => ({
 	DB: {} as Env['DB'],
 	DTXFILE_BUCKET: {
@@ -59,6 +62,7 @@ beforeEach(() => {
 		.mockReset()
 		.mockReturnValue([{ objectKey: '42/a.dtx', size: 100, path: 'a.dtx' }]);
 	mockedVerify.mockReset().mockResolvedValue(null);
+	mockedValidateZipSources.mockReset();
 });
 
 const req = (headers: Record<string, string> = {}) =>
@@ -143,6 +147,8 @@ describe('GET /downloads/:id', () => {
 		expect(response.status).toBe(404);
 		expect(await response.json()).toEqual({ error: 'No files found for this chart' });
 		expect(mockedRate).not.toHaveBeenCalled();
+		// HEAD checks should NOT run when no files are found
+		expect(mockedValidateZipSources).not.toHaveBeenCalled();
 	});
 
 	it('429 on rate limit hit', async () => {
@@ -155,5 +161,7 @@ describe('GET /downloads/:id', () => {
 			'42'
 		);
 		expect(response.status).toBe(429);
+		// HEAD checks should NOT run when rate limit blocks the download
+		expect(mockedValidateZipSources).not.toHaveBeenCalled();
 	});
 });

--- a/packages/dtx-api/src/rest/downloadSimfile.test.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.test.ts
@@ -124,7 +124,11 @@ describe('GET /downloads/:id', () => {
 		expect(response.status).toBe(200);
 		expect(response.headers.get('content-type')).toBe('application/zip');
 		expect(response.headers.get('content-disposition')).toContain('chart-42.zip');
-		expect(mockedRate).toHaveBeenCalledWith(expect.anything(), 'pre-prod:single:1.2.3.4', 100);
+		expect(mockedRate).toHaveBeenCalledWith(
+			expect.anything(),
+			'pre-prod:downloads:1.2.3.4',
+			100
+		);
 	});
 
 	it('404 when accessible simfile has no downloadable files', async () => {

--- a/packages/dtx-api/src/rest/downloadSimfile.test.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.test.ts
@@ -164,4 +164,20 @@ describe('GET /downloads/:id', () => {
 		// HEAD checks should NOT run when rate limit blocks the download
 		expect(mockedValidateZipSources).not.toHaveBeenCalled();
 	});
+
+	it('400 when client IP is unavailable', async () => {
+		const { getClientIp } = await import('@dtx/common/server');
+		vi.mocked(getClientIp).mockReturnValueOnce(null);
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		const response = await routeDownloadSimfile(
+			req(),
+			makeEnv({ PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' }),
+			makeCtx(),
+			'42'
+		);
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: 'Unable to determine client IP for rate limiting.'
+		});
+	});
 });

--- a/packages/dtx-api/src/rest/downloadSimfile.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.ts
@@ -52,7 +52,7 @@ export const routeDownloadSimfile = async (
 	if (ip) {
 		const { allowed } = await tryConsumeRateLimit(
 			env.RATE_LIMIT_API,
-			`${env.RATE_LIMIT_ENV}:single:${ip}`,
+			`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
 			estimatedBytes
 		);
 		if (!allowed) {

--- a/packages/dtx-api/src/rest/downloadSimfile.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.ts
@@ -49,15 +49,16 @@ export const routeDownloadSimfile = async (
 	}
 
 	const ip = getClientIp(request);
-	if (ip) {
-		const { allowed } = await tryConsumeRateLimit(
-			env.RATE_LIMIT_API,
-			`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
-			estimatedBytes
-		);
-		if (!allowed) {
-			return jsonError(429, 'Rate limit exceeded. Please try again later.');
-		}
+	if (!ip) {
+		return jsonError(400, 'Unable to determine client IP for rate limiting.');
+	}
+	const { allowed } = await tryConsumeRateLimit(
+		env.RATE_LIMIT_API,
+		`${env.RATE_LIMIT_ENV}:downloads:${ip}`,
+		estimatedBytes
+	);
+	if (!allowed) {
+		return jsonError(429, 'Rate limit exceeded. Please try again later.');
 	}
 
 	const response = await buildValidatedZipResponse(env.DTXFILE_BUCKET, sources, {

--- a/packages/dtx-api/src/rest/downloadSimfile.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.ts
@@ -1,7 +1,11 @@
 import { getClientIp, tryConsumeRateLimit } from '@dtx/common/server';
 import type { ExecutionContext } from '@cloudflare/workers-types';
 import { verifyToken } from '../auth/verifyToken';
-import { resolveAccessibleSimfiles, buildSimfileZipResponse } from '../services/downloads';
+import {
+	resolveAccessibleSimfiles,
+	collectZipSources,
+	buildValidatedZipResponse
+} from '../services/downloads';
 import type { Env } from '../env';
 
 const jsonError = (status: number, message: string) =>
@@ -36,13 +40,7 @@ export const routeDownloadSimfile = async (
 	if (access.unauthorized.length > 0) return jsonError(401, 'Unauthorized');
 	if (access.forbidden.length > 0) return jsonError(403, 'Forbidden');
 
-	const { response, sources, estimatedBytes } = await buildSimfileZipResponse(
-		env.DTXFILE_BUCKET,
-		[id],
-		{
-			filename: `chart-${id}.zip`
-		}
-	);
+	const { sources, estimatedBytes } = await collectZipSources(env.DTXFILE_BUCKET, [id]);
 
 	if (sources.length === 0) {
 		return jsonError(404, 'No files found for this chart');
@@ -59,6 +57,10 @@ export const routeDownloadSimfile = async (
 			return jsonError(429, 'Rate limit exceeded. Please try again later.');
 		}
 	}
+
+	const response = await buildValidatedZipResponse(env.DTXFILE_BUCKET, sources, {
+		filename: `chart-${id}.zip`
+	});
 
 	return response;
 };

--- a/packages/dtx-api/src/rest/downloadSimfile.ts
+++ b/packages/dtx-api/src/rest/downloadSimfile.ts
@@ -40,7 +40,9 @@ export const routeDownloadSimfile = async (
 	if (access.unauthorized.length > 0) return jsonError(401, 'Unauthorized');
 	if (access.forbidden.length > 0) return jsonError(403, 'Forbidden');
 
-	const { sources, estimatedBytes } = await collectZipSources(env.DTXFILE_BUCKET, [id]);
+	const { sources, estimatedBytes } = await collectZipSources(env.DTXFILE_BUCKET, [id], {
+		flatSingle: true
+	});
 
 	if (sources.length === 0) {
 		return jsonError(404, 'No files found for this chart');

--- a/packages/dtx-api/src/rest/upload.test.ts
+++ b/packages/dtx-api/src/rest/upload.test.ts
@@ -87,6 +87,28 @@ describe('POST /upload', () => {
 		expect(ctx.waitUntil).toHaveBeenCalled();
 	});
 
+	it('URL-encodes R2 key segments for cache purge', async () => {
+		mockedVerify.mockResolvedValue({
+			user: { id: 'u1' },
+			session: {}
+		} as Awaited<ReturnType<typeof verifyToken>>);
+		mockedUpload.mockResolvedValue(
+			new Response(JSON.stringify({ file: { key: '42/my song file.dtx' } }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+		const ctx = makeCtx();
+		await routeUpload(multipartReq(), makeEnv(), ctx);
+		expect(ctx.waitUntil).toHaveBeenCalled();
+		// purgeCacheForFile should be called with URL-encoded path
+		expect(mockedPurge).toHaveBeenCalledWith(
+			expect.anything(),
+			'https://files.example/42/my%20song%20file.dtx',
+			expect.anything()
+		);
+	});
+
 	it('400 when form is missing required parts', async () => {
 		mockedVerify.mockResolvedValue({
 			user: { id: 'u1' },

--- a/packages/dtx-api/src/rest/upload.ts
+++ b/packages/dtx-api/src/rest/upload.ts
@@ -40,7 +40,10 @@ export const routeUpload = async (
 			const key = body.file?.key;
 			if (key && env.PUBLIC_SIMFILE_BUCKET_URL) {
 				const base = env.PUBLIC_SIMFILE_BUCKET_URL.replace(/\/$/, '');
-				const fileUrl = `${base}/${key}`;
+				// Encode each path segment so special characters (spaces, #, ?, non-ASCII)
+				// match the URL clients actually request from the public bucket.
+				const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+				const fileUrl = `${base}/${encodedKey}`;
 				ctx.waitUntil(
 					purgeCacheForFile(env, fileUrl, workerLogger).catch((err: unknown) => {
 						workerLogger.error('Unexpected error in cache purge', {

--- a/packages/dtx-api/src/schema/auth.test.ts
+++ b/packages/dtx-api/src/schema/auth.test.ts
@@ -64,6 +64,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	request: new Request('http://test', { headers: { 'cf-connecting-ip': '5.6.7.8' } }),
 	logger: workerLogger,
 	ownerByIdCache: new Map(),
+	hasUploadedFilesCache: new Map(),
 	...overrides
 });
 

--- a/packages/dtx-api/src/schema/auth.test.ts
+++ b/packages/dtx-api/src/schema/auth.test.ts
@@ -65,6 +65,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	logger: workerLogger,
 	ownerByIdCache: new Map(),
 	hasUploadedFilesCache: new Map(),
+	filesCache: new Map(),
 	...overrides
 });
 

--- a/packages/dtx-api/src/schema/builder.test.ts
+++ b/packages/dtx-api/src/schema/builder.test.ts
@@ -38,6 +38,7 @@ const baseCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	logger: workerLogger,
 	ownerByIdCache: new Map<string, OwnerCacheEntry | null>(),
 	hasUploadedFilesCache: new Map(),
+	filesCache: new Map(),
 	...overrides
 });
 

--- a/packages/dtx-api/src/schema/builder.test.ts
+++ b/packages/dtx-api/src/schema/builder.test.ts
@@ -37,6 +37,7 @@ const baseCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	request: new Request('http://test'),
 	logger: workerLogger,
 	ownerByIdCache: new Map<string, OwnerCacheEntry | null>(),
+	hasUploadedFilesCache: new Map(),
 	...overrides
 });
 

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -533,6 +533,33 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedBatchFiles).toHaveBeenCalledWith(expect.anything(), [1, 2]);
 		// Per-row enrichment should NOT be called (batch handled it)
 		expect(mockedFiles).not.toHaveBeenCalled();
+		// hasUploadedFiles batch should NOT be called (field not selected)
+		expect(mockedBatchHasUploaded).not.toHaveBeenCalled();
+	});
+
+	it('does not call hasUploadedFiles batch when field is not selected', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		mockedList.mockResolvedValue({ data: [sim1], count: 1 });
+
+		await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 1) { data { id title } count } }'
+		});
+
+		expect(mockedBatchHasUploaded).not.toHaveBeenCalled();
+		expect(mockedBatchFiles).not.toHaveBeenCalled();
+	});
+
+	it('does not call files batch when only hasUploadedFiles is selected', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		mockedList.mockResolvedValue({ data: [sim1], count: 1 });
+		mockedBatchHasUploaded.mockResolvedValue(new Map([[1, true]]));
+
+		await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 1) { data { hasUploadedFiles } count } }'
+		});
+
+		expect(mockedBatchHasUploaded).toHaveBeenCalledWith(expect.anything(), [1]);
+		expect(mockedBatchFiles).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -56,6 +56,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	logger: workerLogger,
 	ownerByIdCache: new Map(),
 	hasUploadedFilesCache: new Map(),
+	filesCache: new Map(),
 	...overrides
 });
 
@@ -415,20 +416,23 @@ describe('Mutation.createSimfile', () => {
 vi.mock('../services/r2Enrichment', () => ({
 	enrichFiles: vi.fn(),
 	enrichHasUploadedFiles: vi.fn(),
-	batchEnrichHasUploadedFiles: vi.fn(async () => new Map())
+	batchEnrichHasUploadedFiles: vi.fn(async () => new Map()),
+	batchEnrichFiles: vi.fn(async () => new Map())
 }));
 
-const { enrichFiles, enrichHasUploadedFiles, batchEnrichHasUploadedFiles } =
+const { enrichFiles, enrichHasUploadedFiles, batchEnrichHasUploadedFiles, batchEnrichFiles } =
 	await import('../services/r2Enrichment');
 const mockedFiles = vi.mocked(enrichFiles);
 const mockedHasUploaded = vi.mocked(enrichHasUploadedFiles);
 const mockedBatchHasUploaded = vi.mocked(batchEnrichHasUploadedFiles);
+const mockedBatchFiles = vi.mocked(batchEnrichFiles);
 
 describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 	beforeEach(() => {
 		mockedFiles.mockReset();
 		mockedHasUploaded.mockReset();
 		mockedBatchHasUploaded.mockReset().mockResolvedValue(new Map());
+		mockedBatchFiles.mockReset().mockResolvedValue(new Map());
 	});
 
 	it('does not call enrichFiles when files is not selected', async () => {
@@ -501,6 +505,34 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedBatchHasUploaded).toHaveBeenCalledWith(expect.anything(), [1, 2]);
 		// Per-row enrichment should NOT be called (batch handled it)
 		expect(mockedHasUploaded).not.toHaveBeenCalled();
+	});
+
+	it('uses batch enrichment for files in list queries', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		const sim2 = { ...publishedSimfile, id: 2 };
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchFiles.mockResolvedValue(
+			new Map<number, Array<{ key: string; size: number; uploaded: string }>>([
+				[1, [{ key: '1/a.dtx', size: 10, uploaded: '2026-05-19T00:00:00Z' }]],
+				[2, []]
+			])
+		);
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { files { key size uploaded } } } }'
+		});
+
+		const simfilesResult = result.data?.simfiles as
+			| { data: Array<{ files: Array<{ key: string; size: number; uploaded: string }> }> }
+			| undefined;
+		expect(simfilesResult?.data).toEqual([
+			{ files: [{ key: '1/a.dtx', size: 10, uploaded: '2026-05-19T00:00:00Z' }] },
+			{ files: [] }
+		]);
+		// Batch enrichment should be called once with all simfile IDs
+		expect(mockedBatchFiles).toHaveBeenCalledWith(expect.anything(), [1, 2]);
+		// Per-row enrichment should NOT be called (batch handled it)
+		expect(mockedFiles).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -169,6 +169,41 @@ describe('Query.simfile', () => {
 		});
 		expect(result.errors?.[0]?.extensions?.code).toBe('BAD_USER_INPUT');
 	});
+
+	it('returns null when scope passes but fetched row is private and unowned (TOCTOU)', async () => {
+		// Simulate race: publicOrOwner scope saw null (simfile missing → passes),
+		// but by the time the resolver reads the full row, a private simfile
+		// owned by someone else exists.  The defense-in-depth check must
+		// return null instead of leaking the private data.
+		mockedGetOwner.mockResolvedValue(null);
+		mockedGetSimfile.mockResolvedValue({
+			...publishedSimfile,
+			is_published: false,
+			user_id: 'attacker'
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { id } }'
+		});
+		expect(result.data?.simfile).toBeNull();
+		expect(result.errors).toBeUndefined();
+	});
+
+	it('returns null when scope passes (missing) and fetched row is private, even for authed user', async () => {
+		// Same TOCTOU scenario but with an authenticated non-owner.
+		mockedGetOwner.mockResolvedValue(null);
+		mockedGetSimfile.mockResolvedValue({
+			...publishedSimfile,
+			is_published: false,
+			user_id: 'attacker'
+		});
+
+		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
+			query: '{ simfile(id: "42") { id } }'
+		});
+		expect(result.data?.simfile).toBeNull();
+		expect(result.errors).toBeUndefined();
+	});
 });
 
 describe('Query.nextDisplayId', () => {

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -736,7 +736,7 @@ describe('Mutation.deleteSimfile', () => {
 		expect(mockedDelete).not.toHaveBeenCalled();
 	});
 
-	it('throws INTERNAL when some R2 deletes fail', async () => {
+	it('continues DB deletion after partial R2 delete failures', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
 		mockedGetSimfile.mockResolvedValue({ id: 42 } as never);
 		const listMock = vi.fn(async () => ({
@@ -749,11 +749,12 @@ describe('Mutation.deleteSimfile', () => {
 			if (deleteCall === 2) throw new Error('R2 delete failed');
 		});
 		const r2 = { list: listMock, delete: deleteMock } as unknown as R2Bucket;
+		mockedDelete.mockResolvedValue(undefined as never);
 
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'], r2 }), {
 			query: 'mutation { deleteSimfile(id: "42") { id deleted } }'
 		});
-		expect(result.errors?.[0]?.extensions?.code).toBe('INTERNAL');
-		expect(mockedDelete).not.toHaveBeenCalled();
+		expect(result.data?.deleteSimfile).toEqual({ id: '42', deleted: true });
+		expect(mockedDelete).toHaveBeenCalledWith(expect.anything(), 42);
 	});
 });

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -437,6 +437,17 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedHasUploaded).toHaveBeenCalledWith(expect.anything(), 42);
 		expect(result.data?.simfile).toEqual({ hasUploadedFiles: true });
 	});
+
+	it('returns false for hasUploadedFiles when R2 enrichment fails', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+		mockedHasUploaded.mockRejectedValue(new Error('R2 listing failed'));
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { hasUploadedFiles } }'
+		});
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({ hasUploadedFiles: false });
+	});
 });
 
 const { updateSimfile } = await import('@dtx/common/server');

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -469,7 +469,10 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { hasUploadedFiles } } }'
 		});
 
-		expect(result.data?.simfiles.data).toEqual([
+		const simfilesResult = result.data?.simfiles as
+			| { data: Array<{ hasUploadedFiles: boolean }> }
+			| undefined;
+		expect(simfilesResult?.data).toEqual([
 			{ hasUploadedFiles: true },
 			{ hasUploadedFiles: false }
 		]);

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -479,6 +479,19 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(result.data?.simfile).toEqual({ hasUploadedFiles: false });
 	});
 
+	it('propagates R2 errors for files instead of returning empty array', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+		mockedFiles.mockRejectedValue(new Error('R2 listing failed'));
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { files { key size uploaded } } }'
+		});
+		// The files field should error (not silently return []) so the client
+		// can distinguish a transient R2 failure from a chart with no files.
+		expect(result.errors).toBeDefined();
+		expect(result.errors?.[0]?.message).toContain('R2 listing failed');
+	});
+
 	it('uses batch enrichment for hasUploadedFiles in list queries', async () => {
 		const sim1 = { ...publishedSimfile, id: 1 };
 		const sim2 = { ...publishedSimfile, id: 2 };

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -289,6 +289,27 @@ describe('Query.simfileSearch', () => {
 			limit: 8
 		});
 	});
+
+	it('trims whitespace from the query before forwarding', async () => {
+		mockedSearch.mockResolvedValue([]);
+		await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
+			query: '{ simfileSearch(query: "  test  ") { id } }'
+		});
+		expect(mockedSearch).toHaveBeenCalledWith(expect.anything(), {
+			query: 'test',
+			userId: 'u1',
+			excludeIds: [],
+			limit: 8
+		});
+	});
+
+	it('returns empty array for whitespace-only query without calling service', async () => {
+		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
+			query: '{ simfileSearch(query: "   ") { id } }'
+		});
+		expect(result.data?.simfileSearch).toEqual([]);
+		expect(mockedSearch).not.toHaveBeenCalled();
+	});
 });
 
 vi.mock('../services/createSimfile', () => ({
@@ -577,6 +598,7 @@ describe('Mutation.updateSimfile', () => {
 
 	it('rejects invalid publishDate with BAD_USER_INPUT', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
 			query: 'mutation { updateSimfile(id: "42", input: { publishDate: "not-a-date" }) { id } }'
 		});
@@ -585,6 +607,7 @@ describe('Mutation.updateSimfile', () => {
 
 	it('rejects empty input with BAD_USER_INPUT', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
 			query: 'mutation { updateSimfile(id: "42", input: {}) { id } }'
 		});
@@ -593,6 +616,7 @@ describe('Mutation.updateSimfile', () => {
 
 	it('NOT_FOUND when updateSimfile throws Simfile not found', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedUpdate.mockRejectedValue(new Error('Simfile not found'));
 
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
@@ -619,13 +643,28 @@ describe('Mutation.updateSimfile', () => {
 			user_id: 'u1'
 		};
 		mockedUpdate.mockResolvedValue(updatedRow as Awaited<ReturnType<typeof updateSimfile>>);
-		mockedGetSimfile.mockResolvedValue(null);
+		// First call: ownership recheck returns the simfile (user_id matches).
+		// Second call: re-read returns null (concurrent delete between update and read).
+		mockedGetSimfile.mockResolvedValueOnce(publishedSimfile).mockResolvedValueOnce(null);
 
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
 			query: 'mutation { updateSimfile(id: "42", input: { title: "Updated" }) { id title } }'
 		});
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.updateSimfile).toEqual({ id: '42', title: 'Updated' });
+	});
+
+	it('FORBIDDEN when owner scope passes but simfile belongs to another user (TOCTOU)', async () => {
+		// Simulate race: owner scope saw null (simfile didn't exist → scope passes),
+		// but by the time the resolver runs, a simfile exists owned by someone else.
+		mockedGetOwner.mockResolvedValue(null);
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, user_id: 'attacker' });
+
+		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'] }), {
+			query: 'mutation { updateSimfile(id: "42", input: { title: "X" }) { id } }'
+		});
+		expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+		expect(mockedUpdate).not.toHaveBeenCalled();
 	});
 });
 
@@ -683,7 +722,7 @@ describe('Mutation.deleteSimfile', () => {
 
 	it('lists + deletes R2 objects and the DB row', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
-		mockedGetSimfile.mockResolvedValue({ id: 42 } as never);
+		mockedGetSimfile.mockResolvedValue({ id: 42, user_id: 'u1' } as never);
 		const r2 = makeR2([{ key: '42/a.dtx' }, { key: '42/b.dtx' }]);
 		mockedDelete.mockResolvedValue(undefined as never);
 
@@ -729,7 +768,7 @@ describe('Mutation.deleteSimfile', () => {
 
 	it('walks multiple R2 pages via cursor before deleting the DB row', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
-		mockedGetSimfile.mockResolvedValue({ id: 42 } as never);
+		mockedGetSimfile.mockResolvedValue({ id: 42, user_id: 'u1' } as never);
 		const r2 = makeR2Pages([
 			{ objects: [{ key: '42/a.dtx' }], truncated: true, cursor: 'p2' },
 			{ objects: [{ key: '42/b.dtx' }], truncated: false }
@@ -747,7 +786,7 @@ describe('Mutation.deleteSimfile', () => {
 
 	it('throws INTERNAL when the stalled-cursor guard fires', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
-		mockedGetSimfile.mockResolvedValue({ id: 42 } as never);
+		mockedGetSimfile.mockResolvedValue({ id: 42, user_id: 'u1' } as never);
 		const r2 = makeR2Pages([{ objects: [{ key: '42/a.dtx' }], truncated: true }]);
 
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'], r2 }), {
@@ -759,7 +798,7 @@ describe('Mutation.deleteSimfile', () => {
 
 	it('throws INTERNAL when R2 list() rejects', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
-		mockedGetSimfile.mockResolvedValue({ id: 42 } as never);
+		mockedGetSimfile.mockResolvedValue({ id: 42, user_id: 'u1' } as never);
 		const r2 = makeR2ListFailure();
 
 		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'], r2 }), {
@@ -771,7 +810,7 @@ describe('Mutation.deleteSimfile', () => {
 
 	it('continues DB deletion after partial R2 delete failures', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
-		mockedGetSimfile.mockResolvedValue({ id: 42 } as never);
+		mockedGetSimfile.mockResolvedValue({ id: 42, user_id: 'u1' } as never);
 		const listMock = vi.fn(async () => ({
 			objects: [{ key: '42/a.dtx' }, { key: '42/b.dtx' }],
 			truncated: false
@@ -789,5 +828,20 @@ describe('Mutation.deleteSimfile', () => {
 		});
 		expect(result.data?.deleteSimfile).toEqual({ id: '42', deleted: true });
 		expect(mockedDelete).toHaveBeenCalledWith(expect.anything(), 42);
+	});
+
+	it('FORBIDDEN when owner scope passes but simfile belongs to another user (TOCTOU)', async () => {
+		// Simulate race: owner scope saw null (simfile didn't exist → scope passes),
+		// but by the time the resolver runs, a simfile exists owned by someone else.
+		mockedGetOwner.mockResolvedValue(null);
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, user_id: 'attacker' } as never);
+		const r2 = makeR2([]);
+
+		const result = await runQuery(makeCtx({ user: { id: 'u1' } as Ctx['user'], r2 }), {
+			query: 'mutation { deleteSimfile(id: "42") { id deleted } }'
+		});
+		expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+		expect(r2.list).not.toHaveBeenCalled();
+		expect(mockedDelete).not.toHaveBeenCalled();
 	});
 });

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -561,6 +561,34 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedBatchHasUploaded).toHaveBeenCalledWith(expect.anything(), [1]);
 		expect(mockedBatchFiles).not.toHaveBeenCalled();
 	});
+
+	it('does not trigger batch enrichment when __typename is in selection but files/hasUploadedFiles are not', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		mockedList.mockResolvedValue({ data: [sim1], count: 1 });
+
+		await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 1) { data { id title __typename } count } }'
+		});
+
+		expect(mockedBatchHasUploaded).not.toHaveBeenCalled();
+		expect(mockedBatchFiles).not.toHaveBeenCalled();
+	});
+
+	it('resolves fields selected via fragment spread for batch enrichment', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		mockedList.mockResolvedValue({ data: [sim1], count: 1 });
+		mockedBatchHasUploaded.mockResolvedValue(new Map([[1, true]]));
+
+		await runQuery(makeCtx(), {
+			query: `
+				fragment SimFields on Simfile { id hasUploadedFiles }
+				{ simfiles(scope: PUBLISHED, pageSize: 1) { data { ...SimFields } count } }
+			`
+		});
+
+		expect(mockedBatchHasUploaded).toHaveBeenCalledWith(expect.anything(), [1]);
+		expect(mockedBatchFiles).not.toHaveBeenCalled();
+	});
 });
 
 const { updateSimfile } = await import('@dtx/common/server');

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -55,6 +55,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	request: new Request('http://test'),
 	logger: workerLogger,
 	ownerByIdCache: new Map(),
+	hasUploadedFilesCache: new Map(),
 	...overrides
 });
 
@@ -392,17 +393,21 @@ describe('Mutation.createSimfile', () => {
 
 vi.mock('../services/r2Enrichment', () => ({
 	enrichFiles: vi.fn(),
-	enrichHasUploadedFiles: vi.fn()
+	enrichHasUploadedFiles: vi.fn(),
+	batchEnrichHasUploadedFiles: vi.fn(async () => new Map())
 }));
 
-const { enrichFiles, enrichHasUploadedFiles } = await import('../services/r2Enrichment');
+const { enrichFiles, enrichHasUploadedFiles, batchEnrichHasUploadedFiles } =
+	await import('../services/r2Enrichment');
 const mockedFiles = vi.mocked(enrichFiles);
 const mockedHasUploaded = vi.mocked(enrichHasUploadedFiles);
+const mockedBatchHasUploaded = vi.mocked(batchEnrichHasUploadedFiles);
 
 describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 	beforeEach(() => {
 		mockedFiles.mockReset();
 		mockedHasUploaded.mockReset();
+		mockedBatchHasUploaded.mockReset().mockResolvedValue(new Map());
 	});
 
 	it('does not call enrichFiles when files is not selected', async () => {
@@ -447,6 +452,31 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.simfile).toEqual({ hasUploadedFiles: false });
+	});
+
+	it('uses batch enrichment for hasUploadedFiles in list queries', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		const sim2 = { ...publishedSimfile, id: 2 };
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchHasUploaded.mockResolvedValue(
+			new Map([
+				[1, true],
+				[2, false]
+			])
+		);
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { hasUploadedFiles } } }'
+		});
+
+		expect(result.data?.simfiles.data).toEqual([
+			{ hasUploadedFiles: true },
+			{ hasUploadedFiles: false }
+		]);
+		// Batch enrichment should be called once with all simfile IDs
+		expect(mockedBatchHasUploaded).toHaveBeenCalledWith(expect.anything(), [1, 2]);
+		// Per-row enrichment should NOT be called (batch handled it)
+		expect(mockedHasUploaded).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -1,4 +1,4 @@
-import { GraphQLError, type GraphQLResolveInfo, type FieldNode } from 'graphql';
+import { GraphQLError, type GraphQLResolveInfo, type SelectionNode } from 'graphql';
 import {
 	getSimfile,
 	getNextDisplayId,
@@ -22,17 +22,34 @@ import { createSimfileWithDtx } from '../services/createSimfile';
  * Checks whether a given field name appears in the selection set of the
  * current field's return type. Used to gate expensive batched R2 lookups
  * so they only fire when the client actually requests the field.
+ *
+ * Resolves fragment spreads and inline fragments recursively so that fields
+ * selected via fragments are detected. `__typename` is explicitly skipped
+ * to avoid false positives from auto-injected introspection fields.
  */
 const isFieldSelected = (info: GraphQLResolveInfo, fieldName: string): boolean => {
 	const fieldNodes = info.fieldNodes;
 	if (!fieldNodes.length) return false;
 	const selectionSet = fieldNodes[0].selectionSet;
 	if (!selectionSet) return false;
-	return selectionSet.selections.some(
-		(sel): sel is FieldNode =>
-			sel.kind === 'Field' &&
-			(sel.name.value === fieldName || sel.name.value === '__typename')
-	);
+
+	const checkSelections = (selections: readonly SelectionNode[]): boolean =>
+		selections.some((sel) => {
+			switch (sel.kind) {
+				case 'Field':
+					return sel.name.value === fieldName;
+				case 'FragmentSpread': {
+					const fragment = info.fragments[sel.name.value];
+					return fragment ? checkSelections(fragment.selectionSet.selections) : false;
+				}
+				case 'InlineFragment':
+					return checkSelections(sel.selectionSet.selections);
+				default:
+					return false;
+			}
+		});
+
+	return checkSelections(selectionSet.selections);
 };
 
 // --- enums ---

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -13,7 +13,8 @@ import { builder } from './builder';
 import {
 	enrichFiles,
 	enrichHasUploadedFiles,
-	batchEnrichHasUploadedFiles
+	batchEnrichHasUploadedFiles,
+	batchEnrichFiles
 } from '../services/r2Enrichment';
 import { createSimfileWithDtx } from '../services/createSimfile';
 
@@ -60,7 +61,18 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		dtxFiles: t.field({ type: [DtxFile], resolve: (s) => s.dtx_files }),
 		files: t.field({
 			type: [R2File],
-			resolve: (s, _args, ctx) => enrichFiles(ctx.r2, s.id)
+			resolve: async (s, _args, ctx) => {
+				// Check request-scoped cache first (populated by connection-level
+				// batch for list queries, or by a previous per-row call).
+				const cached = ctx.filesCache.get(s.id);
+				if (cached) {
+					return cached;
+				}
+				// Single simfile query or cache miss: resolve individually.
+				const promise = enrichFiles(ctx.r2, s.id).catch(() => []);
+				ctx.filesCache.set(s.id, promise);
+				return promise;
+			}
 		}),
 		hasUploadedFiles: t.boolean({
 			resolve: async (s, _args, ctx) => {
@@ -108,6 +120,19 @@ export const SimfileConnectionRef = builder
 							ctx.hasUploadedFilesCache.set(
 								s.id,
 								batchPromise.then((map) => map.get(s.id) ?? false)
+							);
+						}
+
+						// Pre-populate filesCache with batched R2 lookups, same
+						// bounded-concurrency pattern as hasUploadedFiles above.
+						const filesBatchPromise = batchEnrichFiles(
+							ctx.r2,
+							c.data.map((s) => s.id)
+						);
+						for (const s of c.data) {
+							ctx.filesCache.set(
+								s.id,
+								filesBatchPromise.then((map) => map.get(s.id) ?? [])
 							);
 						}
 					}

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -10,7 +10,11 @@ import {
 	type SimfileWithDtxFiles
 } from '@dtx/common/server';
 import { builder } from './builder';
-import { enrichFiles, enrichHasUploadedFiles } from '../services/r2Enrichment';
+import {
+	enrichFiles,
+	enrichHasUploadedFiles,
+	batchEnrichHasUploadedFiles
+} from '../services/r2Enrichment';
 import { createSimfileWithDtx } from '../services/createSimfile';
 
 // --- enums ---
@@ -60,11 +64,20 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		}),
 		hasUploadedFiles: t.boolean({
 			resolve: async (s, _args, ctx) => {
-				try {
-					return await enrichHasUploadedFiles(ctx.r2, s.id);
-				} catch {
-					return false;
+				// Check request-scoped cache first (populated by connection-level
+				// batch for list queries, or by a previous per-row call).
+				const cached = ctx.hasUploadedFilesCache.get(s.id);
+				if (cached) {
+					try {
+						return await cached;
+					} catch {
+						return false;
+					}
 				}
+				// Single simfile query or cache miss: resolve individually.
+				const promise = enrichHasUploadedFiles(ctx.r2, s.id).catch(() => false);
+				ctx.hasUploadedFilesCache.set(s.id, promise);
+				return promise;
 			}
 		})
 	})
@@ -74,7 +87,33 @@ export const SimfileConnectionRef = builder
 	.objectRef<{ data: SimfileWithDtxFiles[]; count: number }>('SimfileConnection')
 	.implement({
 		fields: (t) => ({
-			data: t.field({ type: [SimfileRef], resolve: (c) => c.data }),
+			data: t.field({
+				type: [SimfileRef],
+				resolve: async (c, _args, ctx) => {
+					// Pre-populate hasUploadedFilesCache with batched R2 lookups.
+					// Uses bounded concurrency (MAX_CONCURRENT_R2_LIST=4) to avoid
+					// unbounded R2 fan-out when resolving large pages. Per-row
+					// resolvers read from ctx.hasUploadedFilesCache.
+					//
+					// NOTE: This always fires the batch even when hasUploadedFiles
+					// is not selected. The trade-off is simpler code vs. a small
+					// overhead on list queries that don't select the field. If this
+					// becomes a problem, use GraphQL resolve info to conditionally batch.
+					if (c.data.length > 0) {
+						const batchPromise = batchEnrichHasUploadedFiles(
+							ctx.r2,
+							c.data.map((s) => s.id)
+						);
+						for (const s of c.data) {
+							ctx.hasUploadedFilesCache.set(
+								s.id,
+								batchPromise.then((map) => map.get(s.id) ?? false)
+							);
+						}
+					}
+					return c.data;
+				}
+			}),
 			count: t.exposeInt('count')
 		})
 	});

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -252,11 +252,13 @@ builder.queryField('simfileSearch', (t) =>
 		},
 		authScopes: { user: true },
 		resolve: async (_root, args, ctx) => {
+			const trimmed = args.query.trim();
+			if (!trimmed) return [];
 			const excludeIds = (args.excludeIds ?? [])
 				.map((id) => Number(id))
 				.filter((n) => Number.isSafeInteger(n) && n > 0);
 			return searchSimfiles(ctx.db, {
-				query: args.query,
+				query: trimmed,
 				userId: ctx.user!.id,
 				excludeIds,
 				limit: args.limit ?? 8 // defaultValue may not narrow to non-null in this Pothos version
@@ -317,6 +319,21 @@ builder.mutationField('updateSimfile', (t) =>
 				throw new GraphQLError('Invalid simfile id', {
 					extensions: { code: 'BAD_USER_INPUT' }
 				});
+			}
+
+			// Defense-in-depth: re-verify the row exists and belongs to the
+			// authenticated user.  The owner scope intentionally passes for
+			// missing simfiles so the resolver can return NOT_FOUND, but that
+			// opens a theoretical TOCTOU window.  Re-reading the row here
+			// closes it.
+			const existing = await getSimfile(ctx.db, numeric);
+			if (!existing) {
+				throw new GraphQLError('Simfile not found', {
+					extensions: { code: 'NOT_FOUND' }
+				});
+			}
+			if (existing.user_id !== ctx.user!.id) {
+				throw new GraphQLError('Forbidden', { extensions: { code: 'FORBIDDEN' } });
 			}
 
 			const updateData: Record<string, unknown> = {};
@@ -385,15 +402,19 @@ builder.mutationField('deleteSimfile', (t) =>
 				});
 			}
 
-			// Verify the DB row exists before touching R2 objects.
-			// The owner scope intentionally passes for missing simfiles so the
-			// resolver can return NOT_FOUND, but we must not delete R2 objects
-			// until we know the row is present (and the user was authorized).
+			// Verify the DB row exists AND belongs to the caller before
+			// touching R2 objects.  The owner scope intentionally passes for
+			// missing simfiles so the resolver can return NOT_FOUND, but that
+			// opens a theoretical TOCTOU window.  Re-reading here closes it
+			// and ensures we never act on a row the user doesn't own.
 			const existing = await getSimfile(ctx.db, numeric);
 			if (!existing) {
 				throw new GraphQLError('Simfile not found', {
 					extensions: { code: 'NOT_FOUND' }
 				});
+			}
+			if (existing.user_id !== ctx.user!.id) {
+				throw new GraphQLError('Forbidden', { extensions: { code: 'FORBIDDEN' } });
 			}
 
 			// Port of dtx-web's cursor-paginated R2 list+delete.

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -248,7 +248,16 @@ builder.queryField('simfile', (t) =>
 					extensions: { code: 'BAD_USER_INPUT' }
 				});
 			}
-			return getSimfile(ctx.db, numeric);
+			const row = await getSimfile(ctx.db, numeric);
+			if (!row) return null;
+			// Defense-in-depth: re-verify visibility after fetch.  If the
+			// simfile was inserted between the publicOrOwner scope check and
+			// here (scope passed because the row was missing), enforce the
+			// same is_published / ownership rules on the actual row.
+			if (!row.is_published && row.user_id !== ctx.user?.id) {
+				return null;
+			}
+			return row;
 		}
 	})
 );

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -521,19 +521,25 @@ builder.mutationField('deleteSimfile', (t) =>
 				}
 			}
 
-			// Phase 2: delete collected keys. Log failures but always remove the
-			// DB row — a simfile with missing backing files is worse than a clean delete.
-			if (allKeys.length > 0) {
-				const results = await Promise.allSettled(allKeys.map((key) => ctx.r2.delete(key)));
+			// Phase 2: delete collected keys in bounded chunks to avoid exhausting
+			// Worker memory or R2 subrequest concurrency. Log failures but always
+			// remove the DB row — a simfile with missing backing files is worse
+			// than a clean delete.
+			const DELETE_CHUNK_SIZE = 50;
+			const allFailures: string[] = [];
+			for (let i = 0; i < allKeys.length; i += DELETE_CHUNK_SIZE) {
+				const chunk = allKeys.slice(i, i + DELETE_CHUNK_SIZE);
+				const results = await Promise.allSettled(chunk.map((key) => ctx.r2.delete(key)));
 				const failed = results
-					.map((r, i) => (r.status === 'rejected' ? allKeys[i] : null))
+					.map((r, j) => (r.status === 'rejected' ? chunk[j] : null))
 					.filter((k): k is string => k !== null);
-				if (failed.length > 0) {
-					ctx.logger.error('R2 delete failed for some objects while deleting simfile', {
-						simfileId: numeric,
-						failedKeys: failed
-					});
-				}
+				allFailures.push(...failed);
+			}
+			if (allFailures.length > 0) {
+				ctx.logger.error('R2 delete failed for some objects while deleting simfile', {
+					simfileId: numeric,
+					failedKeys: allFailures
+				});
 			}
 
 			try {

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError, type GraphQLResolveInfo, type FieldNode } from 'graphql';
 import {
 	getSimfile,
 	getNextDisplayId,
@@ -17,6 +17,23 @@ import {
 	batchEnrichFiles
 } from '../services/r2Enrichment';
 import { createSimfileWithDtx } from '../services/createSimfile';
+
+/**
+ * Checks whether a given field name appears in the selection set of the
+ * current field's return type. Used to gate expensive batched R2 lookups
+ * so they only fire when the client actually requests the field.
+ */
+const isFieldSelected = (info: GraphQLResolveInfo, fieldName: string): boolean => {
+	const fieldNodes = info.fieldNodes;
+	if (!fieldNodes.length) return false;
+	const selectionSet = fieldNodes[0].selectionSet;
+	if (!selectionSet) return false;
+	return selectionSet.selections.some(
+		(sel): sel is FieldNode =>
+			sel.kind === 'Field' &&
+			(sel.name.value === fieldName || sel.name.value === '__typename')
+	);
+};
 
 // --- enums ---
 
@@ -101,39 +118,30 @@ export const SimfileConnectionRef = builder
 		fields: (t) => ({
 			data: t.field({
 				type: [SimfileRef],
-				resolve: async (c, _args, ctx) => {
-					// Pre-populate hasUploadedFilesCache with batched R2 lookups.
-					// Uses bounded concurrency (MAX_CONCURRENT_R2_LIST=4) to avoid
-					// unbounded R2 fan-out when resolving large pages. Per-row
-					// resolvers read from ctx.hasUploadedFilesCache.
-					//
-					// NOTE: This always fires the batch even when hasUploadedFiles
-					// is not selected. The trade-off is simpler code vs. a small
-					// overhead on list queries that don't select the field. If this
-					// becomes a problem, use GraphQL resolve info to conditionally batch.
+				resolve: async (c, _args, ctx, info) => {
 					if (c.data.length > 0) {
-						const batchPromise = batchEnrichHasUploadedFiles(
-							ctx.r2,
-							c.data.map((s) => s.id)
-						);
-						for (const s of c.data) {
-							ctx.hasUploadedFilesCache.set(
-								s.id,
-								batchPromise.then((map) => map.get(s.id) ?? false)
-							);
+						const ids = c.data.map((s) => s.id);
+
+						// Only batch-enrich hasUploadedFiles when the client selected it.
+						if (isFieldSelected(info, 'hasUploadedFiles')) {
+							const batchPromise = batchEnrichHasUploadedFiles(ctx.r2, ids);
+							for (const s of c.data) {
+								ctx.hasUploadedFilesCache.set(
+									s.id,
+									batchPromise.then((map) => map.get(s.id) ?? false)
+								);
+							}
 						}
 
-						// Pre-populate filesCache with batched R2 lookups, same
-						// bounded-concurrency pattern as hasUploadedFiles above.
-						const filesBatchPromise = batchEnrichFiles(
-							ctx.r2,
-							c.data.map((s) => s.id)
-						);
-						for (const s of c.data) {
-							ctx.filesCache.set(
-								s.id,
-								filesBatchPromise.then((map) => map.get(s.id) ?? [])
-							);
+						// Only batch-enrich files when the client selected it.
+						if (isFieldSelected(info, 'files')) {
+							const filesBatchPromise = batchEnrichFiles(ctx.r2, ids);
+							for (const s of c.data) {
+								ctx.filesCache.set(
+									s.id,
+									filesBatchPromise.then((map) => map.get(s.id) ?? [])
+								);
+							}
 						}
 					}
 					return c.data;

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -103,7 +103,7 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 					return cached;
 				}
 				// Single simfile query or cache miss: resolve individually.
-				const promise = enrichFiles(ctx.r2, s.id).catch(() => []);
+				const promise = enrichFiles(ctx.r2, s.id);
 				ctx.filesCache.set(s.id, promise);
 				return promise;
 			}

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -360,10 +360,13 @@ builder.mutationField('deleteSimfile', (t) =>
 			// Port of dtx-web's cursor-paginated R2 list+delete.
 			// Hard cap iterations so a misbehaving R2 (or test mock) can't loop us
 			// into the Worker CPU limit; 1000 pages × 1000 keys = 1M objects max.
+			// Phase 1: collect all keys before deleting anything so a later list
+			// failure doesn't leave a partially-deleted prefix with a live DB row.
 			const MAX_PAGES = 1000;
 			let cursor: string | undefined;
 			let truncated = true;
 			let pages = 0;
+			const allKeys: string[] = [];
 			while (truncated) {
 				if (++pages > MAX_PAGES) {
 					ctx.logger.error('R2 pagination exceeded MAX_PAGES while deleting', {
@@ -390,25 +393,8 @@ builder.mutationField('deleteSimfile', (t) =>
 					});
 				}
 				const objects = listResult.objects ?? [];
-				if (objects.length > 0) {
-					const results = await Promise.allSettled(
-						objects.map((obj) => ctx.r2.delete(obj.key))
-					);
-					const failed = results
-						.map((r, i) => (r.status === 'rejected' ? objects[i]?.key : null))
-						.filter((k): k is string => k !== null);
-					if (failed.length > 0) {
-						ctx.logger.error(
-							'R2 delete failed for some objects while deleting simfile',
-							{
-								simfileId: numeric,
-								failedKeys: failed
-							}
-						);
-						throw new GraphQLError('Failed to delete some files', {
-							extensions: { code: 'INTERNAL' }
-						});
-					}
+				for (const obj of objects) {
+					allKeys.push(obj.key);
 				}
 				truncated = listResult.truncated === true;
 				if (truncated) {
@@ -422,6 +408,21 @@ builder.mutationField('deleteSimfile', (t) =>
 						});
 					}
 					cursor = nextCursor;
+				}
+			}
+
+			// Phase 2: delete collected keys. Log failures but always remove the
+			// DB row — a simfile with missing backing files is worse than a clean delete.
+			if (allKeys.length > 0) {
+				const results = await Promise.allSettled(allKeys.map((key) => ctx.r2.delete(key)));
+				const failed = results
+					.map((r, i) => (r.status === 'rejected' ? allKeys[i] : null))
+					.filter((k): k is string => k !== null);
+				if (failed.length > 0) {
+					ctx.logger.error('R2 delete failed for some objects while deleting simfile', {
+						simfileId: numeric,
+						failedKeys: failed
+					});
 				}
 			}
 

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -59,7 +59,13 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 			resolve: (s, _args, ctx) => enrichFiles(ctx.r2, s.id)
 		}),
 		hasUploadedFiles: t.boolean({
-			resolve: (s, _args, ctx) => enrichHasUploadedFiles(ctx.r2, s.id)
+			resolve: async (s, _args, ctx) => {
+				try {
+					return await enrichHasUploadedFiles(ctx.r2, s.id);
+				} catch {
+					return false;
+				}
+			}
 		})
 	})
 });

--- a/packages/dtx-api/src/schema/user.test.ts
+++ b/packages/dtx-api/src/schema/user.test.ts
@@ -48,6 +48,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	logger: workerLogger,
 	ownerByIdCache: new Map(),
 	hasUploadedFilesCache: new Map(),
+	filesCache: new Map(),
 	...overrides
 });
 

--- a/packages/dtx-api/src/schema/user.test.ts
+++ b/packages/dtx-api/src/schema/user.test.ts
@@ -47,6 +47,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	request: new Request('http://test'),
 	logger: workerLogger,
 	ownerByIdCache: new Map(),
+	hasUploadedFilesCache: new Map(),
 	...overrides
 });
 

--- a/packages/dtx-api/src/services/downloads.test.ts
+++ b/packages/dtx-api/src/services/downloads.test.ts
@@ -92,4 +92,32 @@ describe('collectZipSources', () => {
 			'chart-2'
 		);
 	});
+
+	it('limits concurrent R2 list calls', async () => {
+		// Use slow mocks to observe concurrency. Track max concurrent calls.
+		let inFlight = 0;
+		let maxInFlight = 0;
+		mockedListAll.mockImplementation(async () => {
+			inFlight++;
+			if (inFlight > maxInFlight) maxInFlight = inFlight;
+			// Yield to let other calls start
+			await new Promise((r) => setTimeout(r, 10));
+			inFlight--;
+			return [{ key: '1/a.dtx', size: 50, uploaded: new Date() }];
+		});
+		mockedCreateZipSources.mockReturnValue([{ objectKey: '1/a.dtx', size: 50, path: 'a.dtx' }]);
+
+		// 8 IDs but concurrency should be capped at 4
+		await collectZipSources({} as R2Bucket, [1, 2, 3, 4, 5, 6, 7, 8]);
+		expect(maxInFlight).toBeLessThanOrEqual(4);
+		expect(mockedListAll).toHaveBeenCalledTimes(8);
+	});
+
+	it('returns empty result for empty simfileIds', async () => {
+		const result = await collectZipSources({} as R2Bucket, []);
+		expect(result.sources).toEqual([]);
+		expect(result.sourcesBySimfile).toEqual([]);
+		expect(result.estimatedBytes).toBe(0);
+		expect(mockedListAll).not.toHaveBeenCalled();
+	});
 });

--- a/packages/dtx-api/src/services/downloads.test.ts
+++ b/packages/dtx-api/src/services/downloads.test.ts
@@ -1,16 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { resolveAccessibleSimfiles } from './downloads';
-import type { D1Database } from '@cloudflare/workers-types';
+import { resolveAccessibleSimfiles, collectZipSources } from './downloads';
+import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
 
 vi.mock('@dtx/common/server', async () => {
 	const actual = await vi.importActual<typeof import('@dtx/common/server')>('@dtx/common/server');
-	return { ...actual, getSimfileOwner: vi.fn() };
+	return {
+		...actual,
+		getSimfileOwner: vi.fn(),
+		listAllR2Objects: vi.fn(),
+		createZipSources: vi.fn()
+	};
 });
 
-const { getSimfileOwner } = await import('@dtx/common/server');
+const { getSimfileOwner, listAllR2Objects, createZipSources } = await import('@dtx/common/server');
 const mockedGetOwner = vi.mocked(getSimfileOwner);
+const mockedListAll = vi.mocked(listAllR2Objects);
+const mockedCreateZipSources = vi.mocked(createZipSources);
 
-beforeEach(() => mockedGetOwner.mockReset());
+beforeEach(() => {
+	mockedGetOwner.mockReset();
+	mockedListAll.mockReset();
+	mockedCreateZipSources.mockReset();
+});
 
 describe('resolveAccessibleSimfiles', () => {
 	it('classifies all four statuses correctly', async () => {
@@ -41,5 +52,44 @@ describe('resolveAccessibleSimfiles', () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'someone', is_published: 1 });
 		const result = await resolveAccessibleSimfiles({} as D1Database, [6], null);
 		expect(result.accessible).toEqual([6]);
+	});
+});
+
+describe('collectZipSources', () => {
+	const fakeObjects = [{ key: '42/a.dtx', size: 100, uploaded: new Date() }];
+
+	beforeEach(() => {
+		mockedListAll.mockResolvedValue(fakeObjects);
+		mockedCreateZipSources.mockReturnValue([
+			{ objectKey: '42/a.dtx', size: 100, path: 'a.dtx' }
+		]);
+	});
+
+	it('uses chart-{id} prefix by default for single simfile (bulk behavior)', async () => {
+		await collectZipSources({} as R2Bucket, [42]);
+		expect(mockedCreateZipSources).toHaveBeenCalledWith(fakeObjects, '42/', 'chart-42');
+	});
+
+	it('uses empty prefix when flatSingle is true and single simfile', async () => {
+		await collectZipSources({} as R2Bucket, [42], { flatSingle: true });
+		expect(mockedCreateZipSources).toHaveBeenCalledWith(fakeObjects, '42/', '');
+	});
+
+	it('uses chart-{id} prefix for multiple simfiles even with flatSingle', async () => {
+		mockedListAll.mockResolvedValue([{ key: '1/a.dtx', size: 50, uploaded: new Date() }]);
+		await collectZipSources({} as R2Bucket, [1, 2], { flatSingle: true });
+		expect(mockedCreateZipSources).toHaveBeenCalledTimes(2);
+		expect(mockedCreateZipSources).toHaveBeenNthCalledWith(
+			1,
+			expect.anything(),
+			'1/',
+			'chart-1'
+		);
+		expect(mockedCreateZipSources).toHaveBeenNthCalledWith(
+			2,
+			expect.anything(),
+			'2/',
+			'chart-2'
+		);
 	});
 });

--- a/packages/dtx-api/src/services/downloads.ts
+++ b/packages/dtx-api/src/services/downloads.ts
@@ -62,6 +62,15 @@ export type CollectedZipSources = {
 	estimatedBytes: number;
 };
 
+export type CollectZipSourcesOptions = {
+	/**
+	 * When true and only one simfile is selected, omit the `chart-{id}/` prefix
+	 * so files sit at the ZIP root. The bulk endpoint should NOT set this — it
+	 * always nests under `chart-{id}/` for consistent layout regardless of count.
+	 */
+	flatSingle?: boolean;
+};
+
 /**
  * Phase 1: List R2 objects and collect ZIP sources.
  * This issues R2 list calls (one per simfile) but does NOT validate
@@ -70,7 +79,8 @@ export type CollectedZipSources = {
  */
 export const collectZipSources = async (
 	bucket: R2Bucket,
-	simfileIds: number[]
+	simfileIds: number[],
+	opts: CollectZipSourcesOptions = {}
 ): Promise<CollectedZipSources> => {
 	const objectsPerSimfile = await Promise.all(
 		simfileIds.map((id) => listAllR2Objects(bucket, `${id}/`))
@@ -81,7 +91,7 @@ export const collectZipSources = async (
 		sources: createZipSources(
 			objectsPerSimfile[i],
 			`${id}/`,
-			simfileIds.length === 1 ? '' : `chart-${id}`
+			opts.flatSingle && simfileIds.length === 1 ? '' : `chart-${id}`
 		)
 	}));
 

--- a/packages/dtx-api/src/services/downloads.ts
+++ b/packages/dtx-api/src/services/downloads.ts
@@ -72,19 +72,42 @@ export type CollectZipSourcesOptions = {
 };
 
 /**
+ * Maximum number of concurrent R2 list calls when collecting ZIP sources.
+ * Keeps R2 fan-out bounded even if the caller passes many simfile IDs.
+ */
+const MAX_CONCURRENT_R2_LIST = 4;
+
+/**
  * Phase 1: List R2 objects and collect ZIP sources.
- * This issues R2 list calls (one per simfile) but does NOT validate
- * individual objects with HEAD requests — callers can check rate limits,
- * validation-only mode, etc. before committing to HEAD checks.
+ * This issues R2 list calls (one per simfile) with bounded concurrency
+ * but does NOT validate individual objects with HEAD requests — callers
+ * can check rate limits, validation-only mode, etc. before committing
+ * to HEAD checks.
  */
 export const collectZipSources = async (
 	bucket: R2Bucket,
 	simfileIds: number[],
 	opts: CollectZipSourcesOptions = {}
 ): Promise<CollectedZipSources> => {
-	const objectsPerSimfile = await Promise.all(
-		simfileIds.map((id) => listAllR2Objects(bucket, `${id}/`))
+	const objectsPerSimfile: Awaited<ReturnType<typeof listAllR2Objects>>[] = new Array(
+		simfileIds.length
 	);
+
+	if (simfileIds.length > 0) {
+		let nextIndex = 0;
+		const worker: () => Promise<void> = async () => {
+			while (nextIndex < simfileIds.length) {
+				const idx = nextIndex++;
+				objectsPerSimfile[idx] = await listAllR2Objects(bucket, `${simfileIds[idx]}/`);
+			}
+		};
+
+		await Promise.all(
+			Array.from({ length: Math.min(MAX_CONCURRENT_R2_LIST, simfileIds.length) }, () =>
+				worker()
+			)
+		);
+	}
 
 	const sourcesBySimfile = simfileIds.map((id, i) => ({
 		simfileId: id,

--- a/packages/dtx-api/src/services/downloads.ts
+++ b/packages/dtx-api/src/services/downloads.ts
@@ -56,16 +56,22 @@ export type SimfileZipSources = {
 	sources: ZipSource[];
 };
 
-export const buildSimfileZipResponse = async (
-	bucket: R2Bucket,
-	simfileIds: number[],
-	opts: ZipStreamOptions
-): Promise<{
-	response: Response;
+export type CollectedZipSources = {
 	sources: ZipSource[];
 	sourcesBySimfile: SimfileZipSources[];
 	estimatedBytes: number;
-}> => {
+};
+
+/**
+ * Phase 1: List R2 objects and collect ZIP sources.
+ * This issues R2 list calls (one per simfile) but does NOT validate
+ * individual objects with HEAD requests — callers can check rate limits,
+ * validation-only mode, etc. before committing to HEAD checks.
+ */
+export const collectZipSources = async (
+	bucket: R2Bucket,
+	simfileIds: number[]
+): Promise<CollectedZipSources> => {
 	const objectsPerSimfile = await Promise.all(
 		simfileIds.map((id) => listAllR2Objects(bucket, `${id}/`))
 	);
@@ -83,19 +89,49 @@ export const buildSimfileZipResponse = async (
 
 	const estimatedBytes = sources.reduce((sum, s) => sum + s.size, 0);
 
-	await validateZipSources(bucket, sources);
+	return { sources, sourcesBySimfile, estimatedBytes };
+};
 
-	// Sanitize filename for Content-Disposition header to prevent injection.
-	const safeName = opts.filename.replace(/[\r\n"]/g, '').trim();
-	const fallbackName = safeName || `download_${Date.now()}.zip`;
-	const response = new Response(buildZipStream(bucket, sources), {
-		status: 200,
-		headers: {
-			'Content-Type': 'application/zip',
-			'Content-Disposition': `attachment; filename="${fallbackName}"`,
-			'Cache-Control': 'private, no-store'
-		}
+/**
+ * Phase 2: Validate sources with HEAD checks and build the streaming Response.
+ * Only call this when the download is actually allowed — after rate limit
+ * checks, validation-only exits, etc.
+ */
+export const buildValidatedZipResponse = (
+	bucket: R2Bucket,
+	sources: ZipSource[],
+	opts: ZipStreamOptions
+): Promise<Response> => {
+	return validateZipSources(bucket, sources).then(() => {
+		// Sanitize filename for Content-Disposition header to prevent injection.
+		const safeName = opts.filename.replace(/[\r\n"]/g, '').trim();
+		const fallbackName = safeName || `download_${Date.now()}.zip`;
+		return new Response(buildZipStream(bucket, sources), {
+			status: 200,
+			headers: {
+				'Content-Type': 'application/zip',
+				'Content-Disposition': `attachment; filename="${fallbackName}"`,
+				'Cache-Control': 'private, no-store'
+			}
+		});
 	});
+};
 
-	return { response, sources, sourcesBySimfile, estimatedBytes };
+/**
+ * Convenience wrapper: collect + validate + respond in one call.
+ * Use this when you don't need cheap-exit checks between phases.
+ */
+export const buildSimfileZipResponse = async (
+	bucket: R2Bucket,
+	simfileIds: number[],
+	opts: ZipStreamOptions
+): Promise<{
+	response: Response;
+	sources: ZipSource[];
+	sourcesBySimfile: SimfileZipSources[];
+	estimatedBytes: number;
+}> => {
+	const collected = await collectZipSources(bucket, simfileIds);
+	const response = await buildValidatedZipResponse(bucket, collected.sources, opts);
+	return { response, ...collected };
 };

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -30,7 +30,7 @@ describe('enrichFiles', () => {
 		]);
 	});
 
-	it('excludes preview files from results', async () => {
+	it('includes preview files in results for asset management', async () => {
 		const bucket = makeBucket([
 			[
 				{ key: '42/song.dtx', size: 1024, uploaded: new Date('2026-05-19T00:00:00Z') },
@@ -40,7 +40,9 @@ describe('enrichFiles', () => {
 		]);
 		const files = await enrichFiles(bucket, 42);
 		expect(files).toEqual([
-			{ key: '42/song.dtx', size: 1024, uploaded: '2026-05-19T00:00:00.000Z' }
+			{ key: '42/song.dtx', size: 1024, uploaded: '2026-05-19T00:00:00.000Z' },
+			{ key: '42/preview.jpg', size: 256, uploaded: '2026-05-19T00:00:00.000Z' },
+			{ key: '42/preview.mp3', size: 128, uploaded: '2026-05-19T00:00:00.000Z' }
 		]);
 	});
 

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { enrichFiles, enrichHasUploadedFiles, batchEnrichHasUploadedFiles } from './r2Enrichment';
+import {
+	enrichFiles,
+	enrichHasUploadedFiles,
+	batchEnrichHasUploadedFiles,
+	batchEnrichFiles
+} from './r2Enrichment';
 import type { R2Bucket } from '@cloudflare/workers-types';
 
 const makeBucket = (
@@ -153,7 +158,7 @@ describe('batchEnrichHasUploadedFiles', () => {
 		expect(result.size).toBe(0);
 	});
 
-	it('sets false for simfiles whose R2 check throws', async () => {
+	it('throws when R2 check fails for any simfile in the batch', async () => {
 		const listMock = vi.fn(async (opts: { prefix: string }) => {
 			if (opts.prefix === '1/') {
 				throw new Error('R2 error');
@@ -165,8 +170,51 @@ describe('batchEnrichHasUploadedFiles', () => {
 		});
 		const bucket = { list: listMock } as unknown as R2Bucket;
 
-		const result = await batchEnrichHasUploadedFiles(bucket, [1, 2]);
-		expect(result.get(1)).toBe(false);
-		expect(result.get(2)).toBe(true);
+		await expect(batchEnrichHasUploadedFiles(bucket, [1, 2])).rejects.toThrow('R2 error');
+	});
+});
+
+describe('batchEnrichFiles', () => {
+	it('returns a Map with file entries for all simfile IDs', async () => {
+		const listMock = vi.fn(async (opts: { prefix: string }) => {
+			if (opts.prefix === '1/') {
+				return {
+					objects: [
+						{ key: '1/song.dtx', size: 100, uploaded: new Date('2026-05-19T00:00:00Z') }
+					],
+					truncated: false
+				};
+			}
+			return { objects: [], truncated: false };
+		});
+		const bucket = { list: listMock } as unknown as R2Bucket;
+
+		const result = await batchEnrichFiles(bucket, [1, 2]);
+		expect(result).toBeInstanceOf(Map);
+		expect(result.get(1)).toEqual([
+			{ key: '1/song.dtx', size: 100, uploaded: '2026-05-19T00:00:00.000Z' }
+		]);
+		expect(result.get(2)).toEqual([]);
+	});
+
+	it('returns empty Map for empty input', async () => {
+		const bucket = {} as unknown as R2Bucket;
+		const result = await batchEnrichFiles(bucket, []);
+		expect(result.size).toBe(0);
+	});
+
+	it('throws when R2 check fails for any simfile in the batch', async () => {
+		const listMock = vi.fn(async (opts: { prefix: string }) => {
+			if (opts.prefix === '1/') {
+				throw new Error('R2 listing failed');
+			}
+			return {
+				objects: [{ key: '2/song.dtx', size: 100, uploaded: new Date() }],
+				truncated: false
+			};
+		});
+		const bucket = { list: listMock } as unknown as R2Bucket;
+
+		await expect(batchEnrichFiles(bucket, [1, 2])).rejects.toThrow('R2 listing failed');
 	});
 });

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { enrichFiles, enrichHasUploadedFiles } from './r2Enrichment';
+import { enrichFiles, enrichHasUploadedFiles, batchEnrichHasUploadedFiles } from './r2Enrichment';
 import type { R2Bucket } from '@cloudflare/workers-types';
 
 const makeBucket = (
@@ -123,5 +123,48 @@ describe('enrichHasUploadedFiles', () => {
 		}));
 		const bucket = { list: listMock } as unknown as R2Bucket;
 		await expect(enrichHasUploadedFiles(bucket, 42)).rejects.toThrow('R2 pagination stalled');
+	});
+});
+
+describe('batchEnrichHasUploadedFiles', () => {
+	it('returns a Map with results for all simfile IDs', async () => {
+		const listMock = vi.fn(async (opts: { prefix: string }) => {
+			if (opts.prefix === '1/') {
+				return {
+					objects: [{ key: '1/song.dtx', size: 100, uploaded: new Date() }],
+					truncated: false
+				};
+			}
+			return { objects: [], truncated: false };
+		});
+		const bucket = { list: listMock } as unknown as R2Bucket;
+
+		const result = await batchEnrichHasUploadedFiles(bucket, [1, 2]);
+		expect(result).toBeInstanceOf(Map);
+		expect(result.get(1)).toBe(true);
+		expect(result.get(2)).toBe(false);
+	});
+
+	it('returns empty Map for empty input', async () => {
+		const bucket = {} as unknown as R2Bucket;
+		const result = await batchEnrichHasUploadedFiles(bucket, []);
+		expect(result.size).toBe(0);
+	});
+
+	it('sets false for simfiles whose R2 check throws', async () => {
+		const listMock = vi.fn(async (opts: { prefix: string }) => {
+			if (opts.prefix === '1/') {
+				throw new Error('R2 error');
+			}
+			return {
+				objects: [{ key: '2/song.dtx', size: 100, uploaded: new Date() }],
+				truncated: false
+			};
+		});
+		const bucket = { list: listMock } as unknown as R2Bucket;
+
+		const result = await batchEnrichHasUploadedFiles(bucket, [1, 2]);
+		expect(result.get(1)).toBe(false);
+		expect(result.get(2)).toBe(true);
 	});
 });

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -7,6 +7,13 @@ export type R2FileEntry = {
 	uploaded: string;
 };
 
+/**
+ * Maximum number of concurrent R2 list calls when batch-enriching
+ * hasUploadedFiles for a list of simfiles. Matches the cap used in the
+ * dtx-web REST endpoint (MAX_CONCURRENT_R2_CHECKS = 4).
+ */
+const MAX_CONCURRENT_R2_LIST = 4;
+
 export const enrichFiles = async (bucket: R2Bucket, simfileId: number): Promise<R2FileEntry[]> => {
 	const prefix = `${simfileId}/`;
 	const objects = await listAllR2Objects(bucket, prefix);
@@ -53,4 +60,37 @@ export const enrichHasUploadedFiles = async (
 		}
 	} while (truncated);
 	return false;
+};
+
+/**
+ * Batch-enrich `hasUploadedFiles` for multiple simfiles with bounded
+ * concurrency. Returns a Map of simfileId → boolean.
+ *
+ * This should be used by GraphQL resolvers that resolve `hasUploadedFiles`
+ * for a list of simfiles, to avoid unbounded R2 list fan-out.
+ */
+export const batchEnrichHasUploadedFiles = async (
+	bucket: R2Bucket,
+	simfileIds: number[]
+): Promise<Map<number, boolean>> => {
+	const results = new Map<number, boolean>();
+	if (simfileIds.length === 0) return results;
+
+	let nextIndex = 0;
+	const worker = async () => {
+		while (nextIndex < simfileIds.length) {
+			const idx = nextIndex++;
+			const id = simfileIds[idx];
+			try {
+				results.set(id, await enrichHasUploadedFiles(bucket, id));
+			} catch {
+				results.set(id, false);
+			}
+		}
+	};
+
+	await Promise.all(
+		Array.from({ length: Math.min(MAX_CONCURRENT_R2_LIST, simfileIds.length) }, () => worker())
+	);
+	return results;
 };

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -42,7 +42,7 @@ export const batchEnrichFiles = async (
 	if (simfileIds.length === 0) return results;
 
 	let nextIndex = 0;
-	const worker = async () => {
+	const worker: () => Promise<void> = async () => {
 		while (nextIndex < simfileIds.length) {
 			const idx = nextIndex++;
 			const id = simfileIds[idx];
@@ -106,7 +106,7 @@ export const batchEnrichHasUploadedFiles = async (
 	if (simfileIds.length === 0) return results;
 
 	let nextIndex = 0;
-	const worker = async () => {
+	const worker: () => Promise<void> = async () => {
 		while (nextIndex < simfileIds.length) {
 			const idx = nextIndex++;
 			const id = simfileIds[idx];

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -27,6 +27,39 @@ export const enrichFiles = async (bucket: R2Bucket, simfileId: number): Promise<
 		}));
 };
 
+/**
+ * Batch-enrich `files` for multiple simfiles with bounded concurrency.
+ * Returns a Map of simfileId → R2FileEntry[].
+ *
+ * Mirrors batchEnrichHasUploadedFiles to avoid unbounded R2 fan-out
+ * when GraphQL resolves `files` for a list of simfiles.
+ */
+export const batchEnrichFiles = async (
+	bucket: R2Bucket,
+	simfileIds: number[]
+): Promise<Map<number, R2FileEntry[]>> => {
+	const results = new Map<number, R2FileEntry[]>();
+	if (simfileIds.length === 0) return results;
+
+	let nextIndex = 0;
+	const worker = async () => {
+		while (nextIndex < simfileIds.length) {
+			const idx = nextIndex++;
+			const id = simfileIds[idx];
+			try {
+				results.set(id, await enrichFiles(bucket, id));
+			} catch {
+				results.set(id, []);
+			}
+		}
+	};
+
+	await Promise.all(
+		Array.from({ length: Math.min(MAX_CONCURRENT_R2_LIST, simfileIds.length) }, () => worker())
+	);
+	return results;
+};
+
 export const enrichHasUploadedFiles = async (
 	bucket: R2Bucket,
 	simfileId: number

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -18,7 +18,7 @@ export const enrichFiles = async (bucket: R2Bucket, simfileId: number): Promise<
 	const prefix = `${simfileId}/`;
 	const objects = await listAllR2Objects(bucket, prefix);
 	return objects
-		.filter((obj: R2ObjectMeta) => obj.key.length > prefix.length && !isPreviewKey(obj.key))
+		.filter((obj: R2ObjectMeta) => obj.key.length > prefix.length)
 		.map((obj: R2ObjectMeta) => ({
 			key: obj.key,
 			size: obj.size,

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -46,11 +46,7 @@ export const batchEnrichFiles = async (
 		while (nextIndex < simfileIds.length) {
 			const idx = nextIndex++;
 			const id = simfileIds[idx];
-			try {
-				results.set(id, await enrichFiles(bucket, id));
-			} catch {
-				results.set(id, []);
-			}
+			results.set(id, await enrichFiles(bucket, id));
 		}
 	};
 
@@ -114,11 +110,7 @@ export const batchEnrichHasUploadedFiles = async (
 		while (nextIndex < simfileIds.length) {
 			const idx = nextIndex++;
 			const id = simfileIds[idx];
-			try {
-				results.set(id, await enrichHasUploadedFiles(bucket, id));
-			} catch {
-				results.set(id, false);
-			}
+			results.set(id, await enrichHasUploadedFiles(bucket, id));
 		}
 	};
 


### PR DESCRIPTION
## Summary
This PR bundles a series of production-hardening changes for the DTX API, focusing on:

- **ZIP downloads**: batch R2 lookups, split collect/validate phases, flatten single-simfile archives, add `collectZipSources` tests
- **Rate limiting**: unify download rate-limit keys, require client IP, guard consumption edge cases
- **R2 enrichment**: gate batch enrichment on GraphQL field selection, handle fragment spreads/`__typename`, URL-encode cache purge keys, propagate R2 errors
- **Security/TOCTOU**: harden `deleteSimfile`, `downloadBulk`, `sanitizeFilename`, deduplicate `verifyToken`, guard trailing parent-directory segments
- **Resilience**: wrap route handlers and enrichment with safe fallbacks, support form-urlencoded downloads, make `internalError` a factory

## Stats
- 20 files changed
- +1,021 / -129 lines

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for form-encoded payloads in bulk download requests.
  * Enhanced rate limiting with required client IP validation.

* **Bug Fixes**
  * Fixed cache purge failures caused by special characters in filenames.
  * Improved error handling and CORS header consistency on failed requests.
  * Strengthened path traversal attack prevention.

* **Improvements**
  * Search queries now trim whitespace for better results.
  * Strengthened access controls for private content.
  * Enhanced error messaging for rate limits and invalid download requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/DTXWeb/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->