### PR TITLE
feat(e2e): Phase 4 dual-path parity gate for superpowers flag

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -20,6 +20,8 @@ jobs:
       E2E_USER_ID: 00000000-0000-0000-0000-000000000001
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.9'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -25,12 +25,16 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.9'
+      - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2
+        with:
+          version: 2.50.3
+          github-token: ${{ github.token }}
       - name: Install dependencies
         run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
       - name: Start local Supabase Auth
         run: |
-          bunx supabase@2.50.3 start
-          bunx supabase@2.50.3 status -o env > supabase-status.env
+          supabase start
+          supabase status -o env > supabase-status.env
           grep -q '^API_URL=' supabase-status.env
           grep -q '^ANON_KEY=' supabase-status.env
           grep -q '^SERVICE_ROLE_KEY=' supabase-status.env

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,32 +1,34 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+    push:
+        branches: [main, master]
+    pull_request:
+        branches: [main, master]
 
 jobs:
-  test:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    environment: Production
-    env:
-      PUBLIC_SUPABASE_URL: ${{ vars.PUBLIC_SUPABASE_URL }}
-      PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.9'
-      - name: Install dependencies
-        run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
-      - name: Install Playwright Browsers
-        run: bunx playwright install --with-deps
-      - name: Run Playwright tests
-        run: bunx playwright test
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
+    test:
+        timeout-minutes: 60
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                use_graphql: [false, true]
+        env:
+            E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: '1.3.9'
+            - name: Install dependencies
+              run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
+            - name: Install Playwright Browsers
+              run: bunx playwright install --with-deps
+            - name: Run Playwright tests (flag=${{ matrix.use_graphql }})
+              run: bunx playwright test
+            - uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: playwright-report-graphql-${{ matrix.use_graphql }}
+                  path: playwright-report/
+                  retention-days: 30

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,11 +38,18 @@ jobs:
           grep -q '^API_URL=' supabase-status.env
           grep -q '^ANON_KEY=' supabase-status.env
           grep -q '^SERVICE_ROLE_KEY=' supabase-status.env
-          {
-            sed -n 's/^API_URL=/E2E_SUPABASE_URL=/p' supabase-status.env
-            sed -n 's/^ANON_KEY=/E2E_SUPABASE_ANON_KEY=/p' supabase-status.env
-            sed -n 's/^SERVICE_ROLE_KEY=/E2E_SUPABASE_SERVICE_ROLE_KEY=/p' supabase-status.env
-          } >> "$GITHUB_ENV"
+          write_env() {
+            local source_name="$1"
+            local target_name="$2"
+            local value
+            value="$(grep "^${source_name}=" supabase-status.env | cut -d= -f2-)"
+            value="${value%\"}"
+            value="${value#\"}"
+            printf '%s=%s\n' "$target_name" "$value" >> "$GITHUB_ENV"
+          }
+          write_env API_URL E2E_SUPABASE_URL
+          write_env ANON_KEY E2E_SUPABASE_ANON_KEY
+          write_env SERVICE_ROLE_KEY E2E_SUPABASE_SERVICE_ROLE_KEY
       - name: Create local Supabase test user
         run: bun run e2e/setup/create-local-supabase-user.ts
       - name: Install Playwright Browsers

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,11 +15,9 @@ jobs:
         use_graphql: [false, true]
     env:
       E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
-      E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-      E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
-      E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
-      E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
-      E2E_USER_ID: ${{ secrets.E2E_USER_ID }}
+      E2E_USER_EMAIL: e2e@drumery.test
+      E2E_USER_PASSWORD: e2e-password
+      E2E_USER_ID: 00000000-0000-0000-0000-000000000001
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -27,6 +25,20 @@ jobs:
           bun-version: '1.3.9'
       - name: Install dependencies
         run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
+      - name: Start local Supabase Auth
+        run: |
+          bunx supabase@2.50.3 start
+          bunx supabase@2.50.3 status -o env > supabase-status.env
+          grep -q '^API_URL=' supabase-status.env
+          grep -q '^ANON_KEY=' supabase-status.env
+          grep -q '^SERVICE_ROLE_KEY=' supabase-status.env
+          {
+            sed -n 's/^API_URL=/E2E_SUPABASE_URL=/p' supabase-status.env
+            sed -n 's/^ANON_KEY=/E2E_SUPABASE_ANON_KEY=/p' supabase-status.env
+            sed -n 's/^SERVICE_ROLE_KEY=/E2E_SUPABASE_SERVICE_ROLE_KEY=/p' supabase-status.env
+          } >> "$GITHUB_ENV"
+      - name: Create local Supabase test user
+        run: bun run e2e/setup/create-local-supabase-user.ts
       - name: Install Playwright Browsers
         run: bunx playwright install --with-deps
       - name: Run Playwright tests (flag=${{ matrix.use_graphql }})

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,34 +1,34 @@
 name: Playwright Tests
 on:
-    push:
-        branches: [main, master]
-    pull_request:
-        branches: [main, master]
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
 
 jobs:
-    test:
-        timeout-minutes: 60
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                use_graphql: [false, true]
-        env:
-            E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
-        steps:
-            - uses: actions/checkout@v4
-            - uses: oven-sh/setup-bun@v2
-              with:
-                  bun-version: '1.3.9'
-            - name: Install dependencies
-              run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
-            - name: Install Playwright Browsers
-              run: bunx playwright install --with-deps
-            - name: Run Playwright tests (flag=${{ matrix.use_graphql }})
-              run: bunx playwright test
-            - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
-              with:
-                  name: playwright-report-graphql-${{ matrix.use_graphql }}
-                  path: playwright-report/
-                  retention-days: 30
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        use_graphql: [false, true]
+    env:
+      E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+      - name: Install dependencies
+        run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
+      - name: Install Playwright Browsers
+        run: bunx playwright install --with-deps
+      - name: Run Playwright tests (flag=${{ matrix.use_graphql }})
+        run: bunx playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-graphql-${{ matrix.use_graphql }}
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -21,8 +21,8 @@ jobs:
       E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
       E2E_USER_ID: ${{ secrets.E2E_USER_ID }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.9'
       - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
         run: bunx playwright install --with-deps
       - name: Run Playwright tests (flag=${{ matrix.use_graphql }})
         run: bunx playwright test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-graphql-${{ matrix.use_graphql }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,6 +15,11 @@ jobs:
         use_graphql: [false, true]
     env:
       E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
+      E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+      E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+      E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
+      E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+      E2E_USER_ID: ${{ secrets.E2E_USER_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ static/skin/
 /blob-report/
 /playwright/.cache/
 
+# Local Miniflare state + Playwright auth output (e2e)
+.wrangler/state
+packages/*/.wrangler/state
+e2e/.auth
+
 # Coverage reports
 coverage/
 **/coverage/

--- a/docs/superpowers/plans/2026-05-29-api-migration-phase-4.md
+++ b/docs/superpowers/plans/2026-05-29-api-migration-phase-4.md
@@ -920,7 +920,3 @@ rm -rf packages/dtx-web/.wrangler/state packages/dtx-api/.wrangler/state e2e/.au
 - [ ] Runbook §0 records which dtx-web binding mechanism won (platformProxy vs wrangler dev).
 - [ ] No app-code changes beyond the gated `svelte.config.js` edit; no deployed flag change.
 - [ ] Existing unit/component suites + `bun run lint` pass.
-
-```
-
-```

--- a/docs/superpowers/plans/2026-05-29-api-migration-phase-4.md
+++ b/docs/superpowers/plans/2026-05-29-api-migration-phase-4.md
@@ -1,0 +1,926 @@
+# API Migration Phase 4 — Dual-path e2e parity gate + cutover runbook — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a CI parity gate that runs the same web e2e journeys twice — flag OFF (REST via `dtx-web`) and flag ON (GraphQL via `dtx-api`) — against a hermetic local stack, plus a committed pre-prod cutover runbook.
+
+**Architecture:** A CI matrix (`use_graphql: [false, true]`) runs two independent legs. Each leg migrates + seeds the one backend it exercises into local Miniflare **before** the dev server starts, then runs two Playwright journeys (authenticated lifecycle, anonymous single download). Auth uses a dedicated throwaway test Supabase project whose credentials are hardcoded in `e2e/test-config.ts`. `dtx-web` gets real local D1/R2/KV bindings via adapter-cloudflare `platformProxy` (gated behind an e2e-only env var); `dtx-api` runs via `wrangler dev`.
+
+**Tech Stack:** Playwright, SvelteKit 2 + adapter-cloudflare v7, Wrangler 4 (Miniflare D1/R2/KV), Supabase (auth only), GitHub Actions, Bun.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md`.
+
+**Pre-conditions:** Phase 3 merged to `main`. `dtx-web` ships the dual-path `lib/api/` layer (flag default `false`). `dtx-api` deployed at `api.pre-prod.dtx.hapadona.com`. The repo has 8 unauthenticated e2e specs and a single-run `playwright.config.ts` + `.github/workflows/e2e-test.yml`.
+
+**Key facts established during design (do not re-derive):**
+
+- Plain `vite dev` returns a **mock D1** (`packages/dtx-web/src/lib/server/db.ts` `getDb` falls back to `createMockD1Database()` when `platform` is undefined). Adding `platformProxy` to the adapter in `svelte.config.js` makes `platform.env.DB/DTXFILE_BUCKET/RATE_LIMIT` **real local Miniflare** bindings persisted under `packages/dtx-web/.wrangler/state`. Miniflare caches the DB connection, so **migrate + seed must happen before the dev server starts**.
+- Every flag-sensitive web data call is **client-side** (`ChartList` + `chart/[id]` fetch in `onMount`). No SSR `load()` reads D1 for these journeys. So each leg seeds exactly one backend; **no shared persist** is required.
+- Web has **no create/upload UI** and **no bulk-download in headless Chromium** (`window.showSaveFilePicker` absent). Those stay on Phase 3 unit tests + the runbook. The gate covers two journeys.
+- `dtx-api` validates bearer tokens by calling `supabase.auth.getUser` against its `SUPABASE_URL` (`packages/dtx-api/src/auth/verifyToken.ts`) — Phase 4 does not touch it; the test Supabase project issues/validates tokens.
+- Login is an email/password form at `/login` (`?/login` action → `supabase.auth.signInWithPassword`), setting `@supabase/ssr` cookies. Driving that UI + `storageState` covers both the cookie (SSR) and bearer (`lib/api/token.ts`) paths.
+
+---
+
+## Operations vocabulary / fixed test data (used throughout)
+
+| Name                | Value                                                                                                                            | Notes                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Chart A (lifecycle) | `id=1001`, `display_id=1001`, `title='E2E Lifecycle Chart'`, `artist='E2E'`, `bpm=120`, `user_id=TEST_USER_ID`, `is_published=0` | owned by test user; no R2 file → opened via Actions→Edit             |
+| Chart B (download)  | `id=1002`, `display_id=1002`, `title='E2E Download Chart'`, `artist='E2E'`, `bpm=140`, `user_id=TEST_USER_ID`, `is_published=1`  | published; has R2 object `1002/song.dtx` → `has_uploaded_files=true` |
+| R2 seed object      | key `1002/song.dtx` in bucket `simfile-dtx`, body = `e2e/fixtures/test-sample.dtx`                                               | non-preview key → `has_uploaded_files=true`; download zips it        |
+| Local persist dir   | `packages/<pkg>/.wrangler/state` (default)                                                                                       | `<pkg>` = `dtx-web` (Leg A) or `dtx-api` (Leg B)                     |
+| dtx-api local port  | `8787`                                                                                                                           | `PUBLIC_DTX_API_URL=http://localhost:8787`                           |
+
+---
+
+## File Structure (end state)
+
+```text
+e2e/
+├── test-config.ts                NEW  (hardcoded test Supabase creds + TEST_USER_ID + chart ids)
+├── setup/
+│   ├── seed.sql                  NEW  (idempotent two-chart INSERTs)
+│   └── prepare-stack.ts          NEW  (migrate + seed + r2 put into the leg's backend, pre-start)
+├── global.setup.ts               NEW  (Playwright setup project: /login → storageState)
+├── .auth/                        NEW  (gitignored storageState output dir)
+├── auth-lifecycle.spec.ts        NEW  (journey 1)
+└── blog-download.spec.ts         NEW  (journey 2)
+
+playwright.config.ts              MODIFIED  (E2E_USE_GRAPHQL toggle, webServers, setup project, projects)
+packages/dtx-web/svelte.config.js MODIFIED  (platformProxy gated behind E2E_PLATFORM_PROXY)
+.github/workflows/e2e-test.yml    MODIFIED  (use_graphql matrix)
+.gitignore                        MODIFIED  (e2e/.auth, .wrangler/state)
+package.json (root)               MODIFIED  (e2e:offline / e2e:graphql convenience scripts)
+
+docs/superpowers/runbooks/
+└── 2026-05-29-phase-4-preprod-cutover.md   NEW
+```
+
+---
+
+## Task 1: Lock the hermetic local-binding recipe (the de-risk spike)
+
+Everything downstream depends on `dtx-web` serving **seeded, real** local data under `vite dev`. This task proves the exact migrate-then-start recipe and the persist path, end to end, before any journey is written.
+
+**Files:**
+
+- Modify: `packages/dtx-web/svelte.config.js`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Gate `platformProxy` behind an e2e-only env var in `packages/dtx-web/svelte.config.js`**
+
+Replace the adapter block:
+
+```js
+		adapter: adapter({
+			fallback: 'plaintext'
+		}),
+```
+
+with:
+
+```js
+		adapter: adapter({
+			fallback: 'plaintext',
+			// e2e-only: surface real local Miniflare bindings (DB/R2/KV) under `vite dev`.
+			// Inert in normal dev and in production builds (env var unset) — keeps the
+			// existing mock-D1 dev behavior for everyone else.
+			...(process.env.E2E_PLATFORM_PROXY === '1' ? { platformProxy: {} } : {})
+		}),
+```
+
+- [ ] **Step 2: Ignore local Miniflare state + Playwright auth output**
+
+In `.gitignore`, add (if not already present):
+
+```gitignore
+.wrangler/state
+packages/*/.wrangler/state
+e2e/.auth
+```
+
+- [ ] **Step 3: Manually prove the recipe (throwaway commands — not committed)**
+
+Run, from repo root:
+
+```bash
+# 1. fresh local state for dtx-web
+rm -rf packages/dtx-web/.wrangler/state
+
+# 2. migrate BEFORE starting the server, into the default persist dir
+cd packages/dtx-web
+bunx wrangler d1 execute dtx-web --local --persist-to .wrangler/state \
+  --file d1-migrations/0001_initial_schema.sql
+
+# 3. seed one published row + confirm
+bunx wrangler d1 execute dtx-web --local --persist-to .wrangler/state \
+  --command "INSERT INTO simfiles (id,title,artist,bpm,user_id,is_published,display_id) VALUES (1002,'E2E Download Chart','E2E',140,'spike-user',1,1002);"
+cd ../..
+
+# 4. start the server WITH platformProxy, then probe
+E2E_PLATFORM_PROXY=1 bun run --filter=dtx-web dev &
+DEV_PID=$!
+# wait until up
+until curl -sf -o /dev/null http://localhost:5173/; do sleep 1; done
+curl -s "http://localhost:5173/api/chart?scope=published&pageSize=5"
+kill $DEV_PID
+```
+
+Expected: the final `curl` returns JSON `{"data":[{"id":1002,"title":"E2E Download Chart",...}],"count":1}` (real seeded row, **not** the mock `"Test Song"`, and **not** a `500`/`no such table`).
+
+- [ ] **Step 4: If the probe shows mock data or an empty/`no such table` result, diagnose the persist path**
+
+The dev server's getPlatformProxy persist file and `wrangler d1 execute --persist-to` must resolve to the same place. Inspect:
+
+```bash
+find packages/dtx-web/.wrangler -name '*.sqlite' -path '*d1*'
+```
+
+- If the running server wrote a different `.sqlite` than the one you migrated, re-run step 3 with `--persist-to .wrangler/state` matching the server's directory (the server uses `packages/dtx-web/.wrangler/state` by default).
+- **Fallback (only if platformProxy persistence can't be aligned):** serve `dtx-web` via `wrangler dev` on the built worker instead. Record the decision here:
+    - `bun run --filter=dtx-web build` then `cd packages/dtx-web && bunx wrangler dev --persist-to .wrangler/state --port 5173`. This makes `--persist-to` authoritative for both migrate and serve. If you take this path, Task 4's `dtx-web` webServer command uses `wrangler dev` instead of `vite dev`, and `svelte.config.js` does not need `platformProxy` (revert Step 1). Document which path won in the Task 9 runbook's "CI notes" section.
+
+- [ ] **Step 5: Clean up the spike state**
+
+```bash
+rm -rf packages/dtx-web/.wrangler/state
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/dtx-web/svelte.config.js .gitignore
+git commit -m "$(cat <<'EOF'
+test(e2e): gate adapter platformProxy behind E2E_PLATFORM_PROXY
+
+Phase 4 — lets the e2e harness surface real local Miniflare D1/R2/KV
+bindings under vite dev. Inert in normal dev/prod. Verified end-to-end
+that a pre-start migrate+seed is read back through /api/chart.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `e2e/test-config.ts` (hardcoded test credentials)
+
+**Files:**
+
+- Create: `e2e/test-config.ts`
+
+The dedicated test Supabase project + user are provisioned out-of-band (Task 9 runbook). This file is the single source of those values. Placeholders are filled by the operator during the one-time setup; the committed file ships with the real throwaway values once the project exists.
+
+- [ ] **Step 1: Create `e2e/test-config.ts`**
+
+```ts
+// e2e/test-config.ts
+//
+// Credentials for the DEDICATED, THROWAWAY e2e Supabase project only.
+// Safe to commit: the anon key is public by design (it ships in client bundles),
+// and the test user guards an isolated project with no real data.
+// NEVER put prod/pre-prod credentials here.
+
+export const TEST_SUPABASE_URL = 'https://REPLACE-ME.supabase.co';
+export const TEST_SUPABASE_ANON_KEY = 'REPLACE_ME_ANON_KEY'; // public by design
+export const TEST_USER_EMAIL = 'e2e@drumery.test';
+export const TEST_USER_PASSWORD = 'REPLACE_ME_PASSWORD';
+
+/** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
+export const TEST_USER_ID = 'REPLACE_ME_UUID';
+
+/** Fixed seed chart ids (see plan's test-data table). */
+export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey
+export const CHART_B_ID = 1002; // published, has R2 file — download journey
+export const CHART_A_TITLE = 'E2E Lifecycle Chart';
+export const CHART_B_TITLE = 'E2E Download Chart';
+
+/** dtx-api local port for the flag-ON leg. */
+export const DTX_API_LOCAL_PORT = 8787;
+```
+
+- [ ] **Step 2: Verify the file imports and exposes the expected exports**
+
+```bash
+bun -e "import('./e2e/test-config.ts').then(m => console.log(Object.keys(m).sort().join(',')))"
+```
+
+Expected output includes: `CHART_A_ID,CHART_A_TITLE,CHART_B_ID,CHART_B_TITLE,DTX_API_LOCAL_PORT,TEST_SUPABASE_ANON_KEY,TEST_SUPABASE_URL,TEST_USER_EMAIL,TEST_USER_ID,TEST_USER_PASSWORD`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/test-config.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): add hardcoded test Supabase config + fixed seed ids
+
+Phase 4 — single source of the throwaway test project's URL/anon-key,
+test-user creds + UUID, and the fixed seed chart ids. Operator fills the
+REPLACE_ME values during one-time setup (runbook).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add the pre-start migrate + seed script
+
+**Files:**
+
+- Create: `e2e/setup/seed.sql`
+- Create: `e2e/setup/prepare-stack.ts`
+
+`prepare-stack.ts` runs before the dev server in each leg's webServer command. It migrates and seeds the leg's backend package (`dtx-web` for OFF, `dtx-api` for ON) into the default `.wrangler/state` persist dir, then puts the R2 object.
+
+- [ ] **Step 1: Create `e2e/setup/seed.sql`**
+
+```sql
+-- e2e/setup/seed.sql — idempotent two-chart seed for the parity gate.
+-- TEST_USER_ID is substituted by prepare-stack.ts before execution.
+DELETE FROM dtx_files WHERE simfile_id IN (1001, 1002);
+DELETE FROM simfiles WHERE id IN (1001, 1002);
+
+INSERT INTO simfiles (id, title, artist, bpm, user_id, is_published, display_id)
+VALUES (1001, 'E2E Lifecycle Chart', 'E2E', 120, '__TEST_USER_ID__', 0, 1001);
+
+INSERT INTO simfiles (id, title, artist, bpm, user_id, is_published, display_id)
+VALUES (1002, 'E2E Download Chart', 'E2E', 140, '__TEST_USER_ID__', 1, 1002);
+
+INSERT INTO dtx_files (label, level, simfile_id) VALUES ('BASIC', 50, 1002);
+```
+
+- [ ] **Step 2: Create `e2e/setup/prepare-stack.ts`**
+
+```ts
+// e2e/setup/prepare-stack.ts
+// Migrate + seed the local Miniflare backend for the current leg, BEFORE the
+// dev server starts. Run by the Playwright webServer command.
+//
+// Leg selection: E2E_USE_GRAPHQL === 'true' → seed dtx-api; else → seed dtx-web.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { TEST_USER_ID, CHART_B_ID } from '../test-config';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(here, '..', '..');
+
+const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
+const pkg = useGraphQL ? 'dtx-api' : 'dtx-web';
+const pkgDir = join(repoRoot, 'packages', pkg);
+const persist = '.wrangler/state';
+const migration = join(repoRoot, 'packages/dtx-web/d1-migrations/0001_initial_schema.sql');
+const fixture = join(repoRoot, 'e2e/fixtures/test-sample.dtx');
+
+const wrangler = (args: string[]) =>
+	execFileSync('bunx', ['wrangler', ...args], { cwd: pkgDir, stdio: 'inherit' });
+
+// 1. Apply schema (IF NOT EXISTS in the migration makes this safe to re-run).
+wrangler(['d1', 'execute', 'dtx-web', '--local', '--persist-to', persist, '--file', migration]);
+
+// 2. Seed rows (idempotent: the seed deletes ids 1001/1002 first).
+const seedSql = readFileSync(join(here, 'seed.sql'), 'utf8').replaceAll(
+	'__TEST_USER_ID__',
+	TEST_USER_ID
+);
+const tmpSeed = join(mkdtempSync(join(tmpdir(), 'e2e-seed-')), 'seed.sql');
+writeFileSync(tmpSeed, seedSql);
+wrangler(['d1', 'execute', 'dtx-web', '--local', '--persist-to', persist, '--file', tmpSeed]);
+
+// 3. Put the R2 object so chart B reports has_uploaded_files=true and download has content.
+wrangler([
+	'r2',
+	'object',
+	'put',
+	`simfile-dtx/${CHART_B_ID}/song.dtx`,
+	'--local',
+	'--persist-to',
+	persist,
+	'--file',
+	fixture
+]);
+
+console.log(
+	`[prepare-stack] seeded ${pkg} local Miniflare (charts 1001/1002 + R2 ${CHART_B_ID}/song.dtx)`
+);
+```
+
+- [ ] **Step 3: Verify the script runs for the OFF leg**
+
+```bash
+rm -rf packages/dtx-web/.wrangler/state
+E2E_USE_GRAPHQL=false bun run e2e/setup/prepare-stack.ts
+cd packages/dtx-web && bunx wrangler d1 execute dtx-web --local --persist-to .wrangler/state \
+  --command "SELECT id,title,is_published FROM simfiles ORDER BY id;" ; cd ../..
+```
+
+Expected: the script prints `[prepare-stack] seeded dtx-web ...` and the query lists rows `1001` (is_published 0) and `1002` (is_published 1). (At this point `TEST_USER_ID` is still `REPLACE_ME_UUID`; that's fine for this structural check — the value only matters for the authenticated journey.)
+
+- [ ] **Step 4: Verify the script runs for the ON leg**
+
+```bash
+rm -rf packages/dtx-api/.wrangler/state
+E2E_USE_GRAPHQL=true bun run e2e/setup/prepare-stack.ts
+cd packages/dtx-api && bunx wrangler d1 execute dtx-web --local --persist-to .wrangler/state \
+  --command "SELECT count(*) AS n FROM simfiles;" ; cd ../..
+```
+
+Expected: prints `seeded dtx-api ...` and `n = 2`.
+
+- [ ] **Step 5: Clean up**
+
+```bash
+rm -rf packages/dtx-web/.wrangler/state packages/dtx-api/.wrangler/state
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/setup/seed.sql e2e/setup/prepare-stack.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): add pre-start migrate+seed script for the parity gate
+
+Phase 4 — seeds two charts + an R2 object into the leg's local Miniflare
+(dtx-web for flag-OFF, dtx-api for flag-ON) before the dev server starts.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Rewrite `playwright.config.ts` for the dual-path harness
+
+**Files:**
+
+- Modify: `playwright.config.ts`
+
+Adds the `E2E_USE_GRAPHQL` toggle, the migrate+seed-then-serve webServer command(s), a `setup` project that produces `storageState`, and authenticated/anonymous test projects.
+
+- [ ] **Step 1: Replace `playwright.config.ts` with the dual-path config**
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+import { TEST_SUPABASE_URL, TEST_SUPABASE_ANON_KEY, DTX_API_LOCAL_PORT } from './e2e/test-config';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
+const apiURL = `http://localhost:${DTX_API_LOCAL_PORT}`;
+
+// Shared Supabase env for the dtx-web dev server (cookie auth + client bearer).
+const webSupabaseEnv = {
+	PUBLIC_SUPABASE_URL: TEST_SUPABASE_URL,
+	PUBLIC_SUPABASE_ANON_KEY: TEST_SUPABASE_ANON_KEY,
+	PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' // render the blog Download button
+};
+
+// dtx-web webServer: migrate+seed (OFF leg only) then start vite dev with platformProxy.
+const webServers = [
+	{
+		command: useGraphQL
+			? 'bun run --filter=dtx-web dev'
+			: 'bun run e2e/setup/prepare-stack.ts && E2E_PLATFORM_PROXY=1 bun run --filter=dtx-web dev',
+		url: 'http://localhost:5173',
+		reuseExistingServer: !process.env.CI,
+		timeout: 180_000,
+		env: {
+			...process.env,
+			VITE_E2E: 'true',
+			E2E_PLATFORM_PROXY: useGraphQL ? '' : '1',
+			PUBLIC_USE_GRAPHQL_API: useGraphQL ? 'true' : 'false',
+			PUBLIC_DTX_API_URL: apiURL,
+			PUBLIC_SIMFILE_BUCKET_URL: process.env.PUBLIC_SIMFILE_BUCKET_URL ?? baseURL,
+			VITE_DTX_SERVER_URL: process.env.VITE_DTX_SERVER_URL ?? baseURL,
+			...webSupabaseEnv
+		}
+	}
+];
+
+// flag-ON leg also boots dtx-api (seeded) via wrangler dev with test Supabase + local CORS.
+if (useGraphQL) {
+	webServers.push({
+		command:
+			'bun run e2e/setup/prepare-stack.ts && ' +
+			'cd packages/dtx-api && bunx wrangler dev --port ' +
+			DTX_API_LOCAL_PORT +
+			' --persist-to .wrangler/state' +
+			` --var SUPABASE_URL:${TEST_SUPABASE_URL}` +
+			` --var SUPABASE_ANON_KEY:${TEST_SUPABASE_ANON_KEY}` +
+			' --var CORS_ALLOWED_ORIGINS:http://localhost:5173' +
+			' --var PUBLIC_ENABLE_BLOG_DOWNLOAD:true',
+		url: `${apiURL}/graphql?query=%7B__typename%7D`,
+		reuseExistingServer: !process.env.CI,
+		timeout: 180_000,
+		env: { ...process.env, E2E_USE_GRAPHQL: 'true' }
+	});
+}
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: { baseURL, trace: 'on-first-retry' },
+	projects: [
+		{ name: 'setup', testMatch: /global\.setup\.ts/ },
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+			dependencies: ['setup']
+		}
+	],
+	webServer: webServers
+});
+```
+
+- [ ] **Step 2: Verify the config loads (Playwright parses it + resolves the `test-config` import)**
+
+```bash
+bunx playwright test --list 2>&1 | tail -5
+```
+
+Expected: it lists the `setup` test (and the 8 existing specs) without a config-load error. (Journey specs are added in Tasks 6–7.) A `Cannot find module './e2e/test-config'` or syntax error here means the config or imports are wrong — fix before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playwright.config.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): dual-path Playwright config (flag OFF/ON legs)
+
+Phase 4 — E2E_USE_GRAPHQL selects the leg: OFF seeds+serves dtx-web with
+platformProxy; ON serves dtx-web (flag on) + boots a seeded dtx-api via
+wrangler dev with the test Supabase project and localhost CORS. Adds a
+setup project that produces storageState.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add the `global.setup` login project
+
+**Files:**
+
+- Create: `e2e/global.setup.ts`
+
+Drives the real `/login` form once, then saves `storageState` (the `@supabase/ssr` session cookies) to `e2e/.auth/user.json` for the authenticated journey.
+
+- [ ] **Step 1: Create `e2e/global.setup.ts`**
+
+```ts
+import { test as setup, expect } from '@playwright/test';
+import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from './test-config';
+
+const authFile = 'e2e/.auth/user.json';
+
+setup('authenticate test user', async ({ page }) => {
+	await page.goto('/login');
+	await page.waitForSelector('html[data-e2e-hydrated="true"]');
+
+	await page.locator('#email').fill(TEST_USER_EMAIL);
+	await page.locator('#password').fill(TEST_USER_PASSWORD);
+	await page.getByRole('button', { name: 'Login' }).click();
+
+	// Successful login redirects to /app.
+	await page.waitForURL('**/app');
+	await expect(page).toHaveURL(/\/app(\?|$)/);
+
+	await page.context().storageState({ path: authFile });
+});
+```
+
+- [ ] **Step 2: Verify the setup project is discovered (does not need to pass yet — creds are placeholders)**
+
+```bash
+bunx playwright test --list 2>&1 | grep -i "global.setup" | head
+```
+
+Expected: lists the `authenticate test user` setup test. (Actually running it requires real creds + the test Supabase project, validated in Task 10 / by the operator.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/global.setup.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): add login setup project producing storageState
+
+Phase 4 — signs the test user in via the real /login form and saves the
+Supabase session cookies for the authenticated journey (covers both the
+SSR cookie path and the lib/api bearer path).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Journey 1 — authenticated chart lifecycle
+
+**Files:**
+
+- Create: `e2e/auth-lifecycle.spec.ts`
+
+Exercises `listSimfiles(MINE)` → `getSimfile` → `updateSimfile` → `deleteSimfile`. Uses `storageState` from the setup project. Operates on seeded **chart A** only.
+
+> e2e selector note: write the spec, run it against the local stack, and adjust selectors until green (the legitimate e2e TDD loop). The selectors below come from reading `ChartList.svelte` (card view default), `ChartListItem.svelte` (Actions popover → Edit / Delete), and `ChartDetail.svelte` (`#download_link`, save button labelled `Update`).
+>
+> Retry note: this test **deletes** chart A as its terminal action. Keep delete last and rely on Playwright's auto-retrying web-first assertions (`toBeVisible`/`toHaveCount`) so a transient at the final step doesn't fail. If cross-retry flakiness still appears (a passed delete followed by a flaked final assertion leaves no chart A for the retry), add `test.describe.configure({ retries: 0 })` to this spec — the seed runs once per leg, not per test, so a destructive test can't re-seed itself mid-run.
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { test, expect } from '@playwright/test';
+import { CHART_A_ID, CHART_A_TITLE } from './test-config';
+
+test.use({ storageState: 'e2e/.auth/user.json' });
+
+test.describe('authenticated chart lifecycle (dual-path)', () => {
+	test('list → open detail → edit/save → delete', async ({ page }) => {
+		// listSimfiles(MINE)
+		await page.goto('/app/chart');
+		await page.waitForSelector('html[data-e2e-hydrated="true"]');
+		const card = page.locator('.music-card', { hasText: CHART_A_TITLE });
+		await expect(card).toBeVisible();
+
+		// getSimfile — open the detail page via the card Actions → Edit menu
+		await card.getByRole('button', { name: 'Actions' }).click();
+		await page.getByRole('menuitem', { name: 'Edit' }).click();
+		await expect(page).toHaveURL(new RegExp(`/app/chart/${CHART_A_ID}$`));
+		await expect(page.getByRole('heading', { level: 1, name: CHART_A_TITLE })).toBeVisible();
+
+		// updateSimfile — change a field and save (button text defaults to "Update")
+		await page.locator('#download_link').fill('https://example.com/e2e-edit');
+		await page.getByRole('button', { name: 'Update' }).click();
+		// success toast proves the update round-tripped on whichever path is active
+		await expect(page.getByText('Simfile updated successfully')).toBeVisible();
+
+		// deleteSimfile — back to the list, delete chart A via Actions → Delete → confirm
+		await page.goto('/app/chart');
+		await page.waitForSelector('html[data-e2e-hydrated="true"]');
+		const cardAgain = page.locator('.music-card', { hasText: CHART_A_TITLE });
+		await cardAgain.getByRole('button', { name: 'Actions' }).click();
+		await page.getByRole('button', { name: 'Delete' }).click();
+		// confirm in the modal dialog
+		const dialog = page.getByRole('dialog');
+		await dialog.getByRole('button', { name: /delete/i }).click();
+
+		await expect(page.getByText('Chart deleted')).toBeVisible();
+		await expect(page.locator('.music-card', { hasText: CHART_A_TITLE })).toHaveCount(0);
+	});
+});
+```
+
+- [ ] **Step 2: Run the OFF leg and iterate selectors to green**
+
+```bash
+E2E_USE_GRAPHQL=false bunx playwright test auth-lifecycle.spec.ts --project=chromium
+```
+
+Expected: PASS. If a selector misses, open `ChartListItem.svelte` (Delete is a `<Button>` inside the Actions popover; the confirm lives in a `Modal` from `@dtx/ui-components`) and adjust the `name`/role until green. Re-run until green.
+
+- [ ] **Step 3: Run the ON leg and confirm identical assertions pass**
+
+```bash
+E2E_USE_GRAPHQL=true bunx playwright test auth-lifecycle.spec.ts --project=chromium
+```
+
+Expected: PASS with the same assertions — this is the parity proof for the authenticated CRUD call-sites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/auth-lifecycle.spec.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): authenticated chart lifecycle journey (dual-path)
+
+Phase 4 — list(MINE) → getSimfile → updateSimfile → deleteSimfile on a
+seeded chart, asserted identically with the flag OFF and ON.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Journey 2 — anonymous browse + single download
+
+**Files:**
+
+- Create: `e2e/blog-download.spec.ts`
+
+Exercises `listSimfiles(PUBLISHED)` + `downloadSimfile`. No `storageState` (anonymous). Operates on seeded **chart B** (published, has R2 file → Download button renders; `PUBLIC_ENABLE_BLOG_DOWNLOAD=true` set by the webServer).
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { test, expect } from '@playwright/test';
+import { CHART_B_TITLE } from './test-config';
+
+// anonymous — explicitly no stored auth
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('anonymous blog browse + single download (dual-path)', () => {
+	test('published chart appears and downloads', async ({ page }) => {
+		// listSimfiles(PUBLISHED)
+		await page.goto('/blog');
+		await page.waitForSelector('html[data-e2e-hydrated="true"]');
+		const card = page.locator('.music-card', { hasText: CHART_B_TITLE });
+		await expect(card).toBeVisible();
+
+		// downloadSimfile — click the Download button, capture the browser download
+		const downloadPromise = page.waitForEvent('download');
+		await card.getByRole('button', { name: /download/i }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toMatch(/\.zip$/);
+	});
+});
+```
+
+- [ ] **Step 2: Run the OFF leg to green**
+
+```bash
+E2E_USE_GRAPHQL=false bunx playwright test blog-download.spec.ts --project=chromium
+```
+
+Expected: PASS. The download button comes from `DownloadDropdown.svelte` (`aria-label` = the i18n `chart_actions.download`); if `/download/i` doesn't match, target the button inside `card` by its `Download` icon / aria-label and adjust. The default download filename is `chart-<id>.zip` (set in `lib/api/rest/download.ts`).
+
+- [ ] **Step 3: Run the ON leg and confirm parity**
+
+```bash
+E2E_USE_GRAPHQL=true bunx playwright test blog-download.spec.ts --project=chromium
+```
+
+Expected: PASS — same assertions, bytes now from `dtx-api` `/downloads/:id` (cross-origin; the webServer set `CORS_ALLOWED_ORIGINS` to `http://localhost:5173`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/blog-download.spec.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): anonymous browse + single download journey (dual-path)
+
+Phase 4 — list(PUBLISHED) + downloadSimfile on a seeded published chart,
+asserted identically with the flag OFF and ON.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Wire the CI parity matrix
+
+**Files:**
+
+- Modify: `.github/workflows/e2e-test.yml`
+
+- [ ] **Step 1: Replace the workflow with the dual-leg matrix**
+
+```yaml
+name: Playwright Tests
+on:
+    push:
+        branches: [main, master]
+    pull_request:
+        branches: [main, master]
+
+jobs:
+    test:
+        timeout-minutes: 60
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                use_graphql: [false, true]
+        env:
+            E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: '1.3.9'
+            - name: Install dependencies
+              run: bun install --frozen-lockfile && bun run --filter=@dtx/common build
+            - name: Install Playwright Browsers
+              run: bunx playwright install --with-deps
+            - name: Run Playwright tests (flag=${{ matrix.use_graphql }})
+              run: bunx playwright test
+            - uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: playwright-report-graphql-${{ matrix.use_graphql }}
+                  path: playwright-report/
+                  retention-days: 30
+```
+
+Notes baked into this design:
+
+- No `Production` environment and no Supabase secrets — the test creds are hardcoded in `e2e/test-config.ts`, so the full matrix runs on forks too.
+- Each leg's seed/serve is driven entirely by `playwright.config.ts` `webServer` commands (which call `prepare-stack.ts`), so no extra CI steps are needed.
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+```bash
+bunx --yes @action-validator/cli .github/workflows/e2e-test.yml 2>/dev/null || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/e2e-test.yml')); print('YAML OK')"
+```
+
+Expected: `YAML OK` (or the validator passes).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e-test.yml
+git commit -m "$(cat <<'EOF'
+ci(e2e): run the parity gate twice (flag OFF and ON)
+
+Phase 4 — use_graphql:[false,true] matrix; both legs must be green.
+No secrets required (test creds hardcoded), so forks run the full gate.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Write the pre-prod cutover runbook
+
+**Files:**
+
+- Create: `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
+
+- [ ] **Step 1: Create the runbook**
+
+```markdown
+# Phase 4 — Pre-prod Cutover Runbook (operator-executed)
+
+Authored for Phase 4 of the API migration. Steps requiring the Cloudflare
+dashboard, an interactive login, or human observation are run by a human, not
+an agent.
+
+## 0. CI notes (filled in by the implementer)
+
+- `dtx-web` local-binding mechanism chosen in Task 1: **platformProxy** (default)
+  or **wrangler dev** (fallback). [record which]
+- Resolved persist path: `packages/<pkg>/.wrangler/state`.
+
+## 1. One-time test-Supabase setup
+
+1. Create a dedicated Supabase project (e.g. `drumery-e2e`). Disable email
+   confirmation (Auth → Providers → Email → "Confirm email" off) or enable
+   auto-confirm so the test user can sign in headlessly.
+2. Create the test user (Auth → Users → Add user): email `e2e@drumery.test`,
+   a throwaway password.
+3. Copy the user's UUID, the project URL, and the anon key (Settings → API).
+4. Paste all four into `e2e/test-config.ts` (`TEST_SUPABASE_URL`,
+   `TEST_SUPABASE_ANON_KEY`, `TEST_USER_EMAIL`/`TEST_USER_PASSWORD`,
+   `TEST_USER_ID`) and commit. No GitHub secrets are needed.
+5. Run both legs locally to confirm green:
+    - `E2E_USE_GRAPHQL=false bunx playwright test`
+    - `E2E_USE_GRAPHQL=true bunx playwright test`
+
+## 2. Flag-ON validation on pre-prod
+
+1. Deploy `dtx-web` to pre-prod with the flag overridden ON, without changing
+   committed config:
+   `cd packages/dtx-web && bun run build && bunx wrangler deploy --env pre-prod --var PUBLIC_USE_GRAPHQL_API:true`
+2. In a browser at `https://pre-prod.dtx.hapadona.com`, with DevTools → Network
+   open, smoke every web call-site and confirm requests hit
+   `api.pre-prod.dtx.hapadona.com`:
+    - Log in.
+    - `/app/chart`: list loads (mine).
+    - Open a chart → detail loads (getSimfile) → edit a field → Update (updateSimfile).
+    - Delete a disposable chart (deleteSimfile).
+    - `/blog`: list loads (published); click a chart's Download (single download).
+    - `/blog`: Select two charts → bulk Download (the native save picker appears) — bulk download.
+    - Trigger the desktop handoff (login with `?redirect=desktop`) → magic link generates.
+
+## 3. Worker-log parity capture
+
+1. In two terminals during the smoke:
+    - `cd packages/dtx-web && bunx wrangler tail --env pre-prod`
+    - `cd packages/dtx-api && bunx wrangler tail --env pre-prod`
+2. Save both logs. Compare error rates / status codes against a flag-OFF
+   baseline pass of the same smoke.
+
+## 4. Delta triage
+
+- Record any response/behavior delta between OFF and ON.
+- Fixes land in `dtx-web` or `dtx-api` as a **follow-up PR** (allowed in Phase
+  4), each with a regression assertion added to the relevant journey spec or a
+  Phase 3 `lib/api/*.test.ts`.
+
+## 5. Restore steady state
+
+- Re-deploy pre-prod without the override so `PUBLIC_USE_GRAPHQL_API` returns to
+  the committed `false`:
+  `cd packages/dtx-web && bun run deploy:preprod`
+
+## 6. Desktop pre-prod smoke
+
+- `VITE_DTX_SERVER_URL=https://api.pre-prod.dtx.hapadona.com bun run --filter=dtx-desktop build`
+- Launch the built app and smoke: chart list, upload a `.dtx`, edit, delete,
+  magic-link sign-in. No GitHub release.
+
+## 7. Phase 5 handoff checklist
+
+- [ ] CI parity gate green on `main` (both legs).
+- [ ] Zero unresolved deltas (all delta-fix PRs merged).
+- [ ] Worker-log parity artifacts captured at least once on pre-prod.
+- [ ] Desktop pre-prod smoke clean.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
+git commit -m "$(cat <<'EOF'
+docs(superpowers): add Phase 4 pre-prod cutover runbook
+
+Phase 4 — operator checklist: test-Supabase setup, flag-ON pre-prod
+smoke, worker-log parity capture, delta triage, desktop pre-prod build,
+and the Phase 5 handoff gate.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Full local verification of both legs
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Ensure the test Supabase values are real**
+
+The authenticated journey cannot pass with `REPLACE_ME_*` placeholders. Confirm `e2e/test-config.ts` holds the real throwaway project values (Task 9 §1). If they are not yet available, run only the anonymous journey (`blog-download.spec.ts`) here and defer the authenticated leg to the operator's §1 run.
+
+- [ ] **Step 2: Run the full suite, flag OFF**
+
+```bash
+E2E_USE_GRAPHQL=false bunx playwright test
+```
+
+Expected: setup project logs in; `auth-lifecycle` + `blog-download` + the 8 existing unauthenticated specs all PASS.
+
+- [ ] **Step 3: Run the full suite, flag ON**
+
+```bash
+E2E_USE_GRAPHQL=true bunx playwright test
+```
+
+Expected: all PASS — identical assertions, data now served by `dtx-api`.
+
+- [ ] **Step 4: Confirm no regressions elsewhere**
+
+```bash
+bun run --filter=dtx-web check
+bun run --filter=dtx-web test
+bun run lint
+```
+
+Expected: all green. (`svelte.config.js`'s gated `platformProxy` is inert without `E2E_PLATFORM_PROXY`, so `check`/`test`/normal `dev` are unchanged.)
+
+- [ ] **Step 5: Confirm the change surface is contained**
+
+```bash
+git diff --stat main -- . ':(exclude)docs'
+```
+
+Expected: changes only under `e2e/`, `playwright.config.ts`, `.github/workflows/e2e-test.yml`, `.gitignore`, and `packages/dtx-web/svelte.config.js` (the gated platformProxy edit). No `dtx-api`/`dtx-desktop`/`common` app changes; no deployed `PUBLIC_USE_GRAPHQL_API` change.
+
+- [ ] **Step 6: Clean up local Miniflare state**
+
+```bash
+rm -rf packages/dtx-web/.wrangler/state packages/dtx-api/.wrangler/state e2e/.auth
+```
+
+---
+
+## Self-review checklist (for the implementer before opening a PR)
+
+- [ ] Both legs green locally (Task 10 §2–3).
+- [ ] `e2e/test-config.ts` has no `REPLACE_ME_*` left (or the gap is explicitly handed to the operator).
+- [ ] Runbook §0 records which dtx-web binding mechanism won (platformProxy vs wrangler dev).
+- [ ] No app-code changes beyond the gated `svelte.config.js` edit; no deployed flag change.
+- [ ] Existing unit/component suites + `bun run lint` pass.
+
+```
+
+```

--- a/docs/superpowers/plans/2026-05-29-api-migration-phase-4.md
+++ b/docs/superpowers/plans/2026-05-29-api-migration-phase-4.md
@@ -183,22 +183,22 @@ The dedicated test Supabase project + user are provisioned out-of-band (Task 9 r
 // and the test user guards an isolated project with no real data.
 // NEVER put prod/pre-prod credentials here.
 
-export const TEST_SUPABASE_URL = 'https://REPLACE-ME.supabase.co';
-export const TEST_SUPABASE_ANON_KEY = 'REPLACE_ME_ANON_KEY'; // public by design
-export const TEST_USER_EMAIL = 'e2e@drumery.test';
-export const TEST_USER_PASSWORD = 'REPLACE_ME_PASSWORD';
+export const TEST_SUPABASE_URL: string = 'https://REPLACE-ME.supabase.co';
+export const TEST_SUPABASE_ANON_KEY: string = 'REPLACE_ME_ANON_KEY'; // public by design
+export const TEST_USER_EMAIL: string = 'e2e@drumery.test';
+export const TEST_USER_PASSWORD: string = 'REPLACE_ME_PASSWORD';
 
 /** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
-export const TEST_USER_ID = 'REPLACE_ME_UUID';
+export const TEST_USER_ID: string = 'REPLACE_ME_UUID';
 
 /** Fixed seed chart ids (see plan's test-data table). */
-export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey
-export const CHART_B_ID = 1002; // published, has R2 file — download journey
-export const CHART_A_TITLE = 'E2E Lifecycle Chart';
-export const CHART_B_TITLE = 'E2E Download Chart';
+export const CHART_A_ID: number = 1001; // owned by test user, unpublished — lifecycle journey
+export const CHART_B_ID: number = 1002; // published, has R2 file — download journey
+export const CHART_A_TITLE: string = 'E2E Lifecycle Chart';
+export const CHART_B_TITLE: string = 'E2E Download Chart';
 
 /** dtx-api local port for the flag-ON leg. */
-export const DTX_API_LOCAL_PORT = 8787;
+export const DTX_API_LOCAL_PORT: number = 8787;
 ```
 
 - [ ] **Step 2: Verify the file imports and exposes the expected exports**
@@ -278,8 +278,9 @@ const persist = '.wrangler/state';
 const migration = join(repoRoot, 'packages/dtx-web/d1-migrations/0001_initial_schema.sql');
 const fixture = join(repoRoot, 'e2e/fixtures/test-sample.dtx');
 
-const wrangler = (args: string[]) =>
+const wrangler = (args: string[]): void => {
 	execFileSync('bunx', ['wrangler', ...args], { cwd: pkgDir, stdio: 'inherit' });
+};
 
 // 1. Apply schema (IF NOT EXISTS in the migration makes this safe to re-run).
 wrangler(['d1', 'execute', 'dtx-web', '--local', '--persist-to', persist, '--file', migration]);

--- a/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
+++ b/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
@@ -82,6 +82,29 @@ an agent.
   4), each with a regression assertion added to the relevant journey spec or a
   Phase 3 `lib/api/*.test.ts`.
 
+### Acceptable deltas (defer to follow-up PR if desired)
+
+- Header differences (e.g., `x-request-id`, `via`, `cf-cache-status`) added by
+  the GraphQL proxy layer.
+- Minor cosmetic UI text changes that do not break functionality.
+- Request URL path differences (e.g., `/api/simfiles/…` vs `/graphql`) as long
+  as the response payload is equivalent.
+- Timing differences where both legs return the same data.
+
+### Blocking deltas (must fix before proceeding)
+
+- Changed HTTP status codes (e.g., 200 → 4xx/5xx) on equivalent requests.
+- Missing data fields in responses (e.g., chart title, user ID, file metadata).
+- Broken UI flows (e.g., login fails, chart list empty, download errors).
+- Auth/session handling differences that cause logout or permission errors.
+
+### Triage checklist
+
+- [ ] Every delta logged with OFF response and ON response side by side.
+- [ ] Each delta classified acceptable or blocking using the criteria above.
+- [ ] All blocking deltas have a follow-up PR with a regression test.
+- [ ] Zero blocking deltas remain before moving to §5.
+
 ## 5. Restore steady state
 
 - Re-deploy pre-prod WITHOUT the override so `PUBLIC_USE_GRAPHQL_API` returns to

--- a/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
+++ b/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
@@ -1,0 +1,102 @@
+# Phase 4 — Pre-prod Cutover Runbook (operator-executed)
+
+Authored for Phase 4 of the API migration. Steps requiring the Cloudflare
+dashboard, an interactive login, or human observation are run by a human, not
+an agent.
+
+## 0. CI notes (as implemented)
+
+- **`dtx-web` local-binding mechanism (Task 1): `platformProxy`** — the default
+  path won; the `wrangler dev` fallback was NOT needed. `svelte.config.js` gates
+  `platformProxy: {}` behind `process.env.E2E_PLATFORM_PROXY === '1'` (inert in
+  normal dev/prod).
+- **Resolved persist path:** `packages/<pkg>/.wrangler/state` (default;
+  `<pkg>` = `dtx-web` for the flag-OFF leg, `dtx-api` for the flag-ON leg).
+- **D1/R2 alignment (verified in Task 7):** both `packages/dtx-web/wrangler.jsonc`
+  and `packages/dtx-api/wrangler.jsonc` declare D1 `database_name: "dtx-web"`, so
+  `wrangler d1 execute dtx-web --local --persist-to .wrangler/state` and the
+  worker's `DB` binding resolve to the SAME local Miniflare sqlite. The ON-leg
+  `dtx-api` (`wrangler dev`) reads the data `prepare-stack.ts` seeds (confirmed:
+  GraphQL list returned the seeded chart and the download served the seeded R2
+  object).
+- **Playwright project structure (decoupled):** `chromium` runs the 8 pre-existing
+  specs + the anonymous download journey with NO login dependency (green without
+  the test Supabase project); `chromium-auth` runs the authenticated journey only
+  and `dependencies: ['setup']` (the login). So before §1 below, CI's `chromium`
+  leg is green and `chromium-auth` is red (expected) until the test project exists.
+- **OFF-leg same-origin download shim:** `e2e/blog-download.spec.ts` injects
+  `x-forwarded-for: 127.0.0.1` on same-origin (`:5173`) requests only, because the
+  REST download endpoint rate-limits by client IP (`cf-connecting-ip` /
+  `x-forwarded-for`) and local Miniflare under `vite dev` supplies none. It is a
+  request header, not auth; the journey stays anonymous. It is intentionally NOT
+  applied to the cross-origin `dtx-api` (`:8787`) requests (would trip a CORS
+  preflight that does not allow `x-forwarded-for`).
+- **CI secrets removed:** the workflow no longer uses a `Production` environment or
+  `PUBLIC_SUPABASE_*` secrets — the test creds live in `e2e/test-config.ts`, so the
+  full matrix runs on forks too.
+
+## 1. One-time test-Supabase setup
+
+1. Create a dedicated Supabase project (e.g. `drumery-e2e`). Disable email
+   confirmation (Auth → Providers → Email → "Confirm email" off) or enable
+   auto-confirm so the test user can sign in headlessly.
+2. Create the test user (Auth → Users → Add user): email `e2e@drumery.test`,
+   a throwaway password.
+3. Copy the user's UUID, the project URL, and the anon key (Settings → API).
+4. Paste all four into `e2e/test-config.ts` (`TEST_SUPABASE_URL`,
+   `TEST_SUPABASE_ANON_KEY`, `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`,
+   `TEST_USER_ID`) and commit. No GitHub secrets are needed.
+5. Run both legs locally to confirm green:
+    - `E2E_USE_GRAPHQL=false bunx playwright test`
+    - `E2E_USE_GRAPHQL=true bunx playwright test`
+
+## 2. Flag-ON validation on pre-prod
+
+1. Deploy `dtx-web` to pre-prod with the flag overridden ON, WITHOUT changing
+   committed config. `PUBLIC_USE_GRAPHQL_API` is read via `$env/dynamic/public`
+   (runtime), so a deploy-time `--var` override works without rebuilding config:
+   `cd packages/dtx-web && bun run build && bunx wrangler deploy --env pre-prod --var PUBLIC_USE_GRAPHQL_API:true`
+2. In a browser at `https://pre-prod.dtx.hapadona.com`, with DevTools → Network
+   open, smoke every web call-site and confirm requests hit
+   `api.pre-prod.dtx.hapadona.com`:
+    - Log in.
+    - `/app/chart`: list loads (mine).
+    - Open a chart → detail loads (getSimfile) → edit a field → Update (updateSimfile).
+    - Delete a disposable chart (deleteSimfile).
+    - `/blog`: list loads (published); click a chart's Download (single download).
+    - `/blog`: Select two charts → bulk Download (the native save picker appears) — bulk download.
+    - Trigger the desktop handoff (login with `?redirect=desktop`) → magic link generates.
+
+## 3. Worker-log parity capture
+
+1. In two terminals during the smoke:
+    - `cd packages/dtx-web && bunx wrangler tail --env pre-prod`
+    - `cd packages/dtx-api && bunx wrangler tail --env pre-prod`
+2. Save both logs. Compare error rates / status codes against a flag-OFF
+   baseline pass of the same smoke.
+
+## 4. Delta triage
+
+- Record any response/behavior delta between OFF and ON.
+- Fixes land in `dtx-web` or `dtx-api` as a **follow-up PR** (allowed in Phase
+  4), each with a regression assertion added to the relevant journey spec or a
+  Phase 3 `lib/api/*.test.ts`.
+
+## 5. Restore steady state
+
+- Re-deploy pre-prod WITHOUT the override so `PUBLIC_USE_GRAPHQL_API` returns to
+  the committed `false`:
+  `bun run deploy:web:preprod`
+
+## 6. Desktop pre-prod smoke
+
+- `VITE_DTX_SERVER_URL=https://api.pre-prod.dtx.hapadona.com bun run --filter=dtx-desktop build`
+- Launch the built app and smoke: chart list, upload a `.dtx`, edit, delete,
+  magic-link sign-in. No GitHub release.
+
+## 7. Phase 5 handoff checklist
+
+- [ ] CI parity gate green on `main` (both legs, after §1 test-Supabase setup).
+- [ ] Zero unresolved deltas (all delta-fix PRs merged).
+- [ ] Worker-log parity artifacts captured at least once on pre-prod.
+- [ ] Desktop pre-prod smoke clean.

--- a/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
+++ b/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
@@ -41,7 +41,7 @@ an agent.
    confirmation (Auth → Providers → Email → "Confirm email" off) or enable
    auto-confirm so the test user can sign in headlessly.
 2. Create the test user (Auth → Users → Add user): email `e2e@drumery.test`,
-   a throwaway password.
+   a throwaway password (minimum 6 characters to satisfy Supabase's default requirement).
 3. Copy the user's UUID, the project URL, and the anon key (Settings → API).
 4. Paste all four into `e2e/test-config.ts` (`TEST_SUPABASE_URL`,
    `TEST_SUPABASE_ANON_KEY`, `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`,

--- a/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
+++ b/docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md
@@ -31,9 +31,10 @@ an agent.
   request header, not auth; the journey stays anonymous. It is intentionally NOT
   applied to the cross-origin `dtx-api` (`:8787`) requests (would trip a CORS
   preflight that does not allow `x-forwarded-for`).
-- **CI secrets removed:** the workflow no longer uses a `Production` environment or
-  `PUBLIC_SUPABASE_*` secrets — the test creds live in `e2e/test-config.ts`, so the
-  full matrix runs on forks too.
+- **CI secret provisioning:** the workflow reads `E2E_*` secrets from GitHub
+  repository settings. `e2e/test-config.ts` consumes them via `process.env`
+  with placeholder fallbacks. A CI guard in `playwright.config.ts` throws
+  when secrets are missing, so the parity gate never silently skips auth tests.
 
 ## 1. One-time test-Supabase setup
 
@@ -43,9 +44,12 @@ an agent.
 2. Create the test user (Auth → Users → Add user): email `e2e@drumery.test`,
    a throwaway password (minimum 6 characters to satisfy Supabase's default requirement).
 3. Copy the user's UUID, the project URL, and the anon key (Settings → API).
-4. Paste all four into `e2e/test-config.ts` (`TEST_SUPABASE_URL`,
-   `TEST_SUPABASE_ANON_KEY`, `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`,
-   `TEST_USER_ID`) and commit. No GitHub secrets are needed.
+4. Set all five as GitHub repository secrets (`E2E_SUPABASE_URL`,
+   `E2E_SUPABASE_ANON_KEY`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`,
+   `E2E_USER_ID`). The anon key is public by design (it ships in client
+   bundles); the password and user ID must NEVER be committed to git.
+   `e2e/test-config.ts` reads these from `process.env`, so CI injects them
+   via `secrets.*` in `.github/workflows/e2e-test.yml`.
 5. Run both legs locally to confirm green:
     - `E2E_USE_GRAPHQL=false bunx playwright test`
     - `E2E_USE_GRAPHQL=true bunx playwright test`

--- a/docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md
+++ b/docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md
@@ -32,37 +32,37 @@ Phase 4 ships test/CI code and documentation only. It does **not** change the ap
 - Any change to `packages/dtx-api` business logic or `verifyToken.ts` — Phase 4 depends on the deployed verification behavior as-is.
 - Production deploy of `dtx-api`, production web flag flip, or a desktop GitHub release (all Phase 5).
 - Deleting `packages/dtx-web/src/routes/api/*` or removing `dtx-web` bindings (Phase 6).
-- Expanding e2e beyond the four critical journeys — the parent spec keeps the e2e suite deliberately minimal.
+- Expanding e2e beyond the journeys the web UI can drive in headless Chromium — the parent spec keeps the e2e suite deliberately minimal, and create/upload/bulk stay on unit tests + the runbook.
 - Changing `packages/dtx-web` app code, `packages/dtx-desktop`, or `packages/common`. Delta fixes uncovered during the live runbook are explicitly allowed but land as a **follow-up PR**, not as part of the gate scaffolding. (The harness may add a root-level dev dependency or test-config wiring — e.g. a Supabase client for `global.setup` — if one is required; that is gate scaffolding, not app code.)
 
 ## Design
 
 ### Architecture overview — the hermetic dual-path harness
 
-The same four journey specs run in two **independent legs** selected by a CI matrix (`use_graphql: [false, true]`). Parity is proven by the _same assertions_ passing in both legs; the legs do not share data with each other.
+The same journey specs run in two **independent legs** selected by a CI matrix (`use_graphql: [false, true]`). Parity is proven by the _same assertions_ passing in both legs; the legs do not share data with each other. **Every flag-sensitive data call in the web app is client-side** (`ChartList`/detail pages fetch in `onMount`, not in SSR `load()`), so in each leg exactly **one** backend serves the data and gets seeded — no cross-server shared persistence is required.
 
 ```text
 LEG A — flag OFF (REST path)
 ┌──────────────────────────────────────────────────────┐
 │ Playwright (chromium) on localhost                     │
-│   browser → dtx-web (localhost:5173)                   │
+│   browser → dtx-web (localhost:5173, vite dev)         │
 │     PUBLIC_USE_GRAPHQL_API=false                       │
 │     client call-sites → dtx-web /api/*                 │
-│     blog SSR + /api/* → platform.env.DB / R2 / KV      │ ← local Miniflare
+│     → platformProxy: platform.env.DB / R2 / KV          │ ← local Miniflare (seeded)
 │   auth: Supabase session cookie (test project)         │
 └──────────────────────────────────────────────────────┘
 
 LEG B — flag ON (GraphQL path)
 ┌──────────────────────────────────────────────────────┐
 │ Playwright (chromium) on localhost                     │
-│   browser → dtx-web (localhost:5173)                   │
+│   browser → dtx-web (localhost:5173, vite dev)         │
 │     PUBLIC_USE_GRAPHQL_API=true                        │
 │     PUBLIC_DTX_API_URL=http://localhost:8787           │
-│     client call-sites → dtx-api /graphql, /upload,     │
-│                         /downloads/:id, /downloads/bulk │
-│     blog SSR still → dtx-web platform.env.DB           │
-│   ┌ dtx-web (5173) ┐  shared --persist-to .e2e-state    │
-│   └ dtx-api (8787) ┘  → ONE local D1 + R2              │ ← local Miniflare
+│     client call-sites → dtx-api /graphql,              │
+│                         /downloads/:id                  │
+│   dtx-api (localhost:8787, wrangler dev)               │
+│     → DB / R2 / KV bindings                             │ ← local Miniflare (seeded)
+│   dtx-web needs NO real bindings here (mock D1 unused) │
 │   auth: Supabase bearer (test project)                 │
 │         → dtx-api verifyToken → getUser(test Supabase) │
 └──────────────────────────────────────────────────────┘
@@ -70,24 +70,23 @@ LEG B — flag ON (GraphQL path)
 
 Principles:
 
-- **Two independent legs, not one shared dataset.** Each matrix leg is a fresh CI job with its own Miniflare instance, its own persistence directory, and its own per-leg seed. Parity = identical observable outcomes, not shared bytes. This keeps the legs isolated and parallelizable.
-- **One shared local D1/R2 _within_ Leg B.** In the flag-ON leg, `dtx-web`'s blog SSR reads `dtx-web`'s D1 directly (the SSR read is not migrated until Phase 6), while the client's anonymous download hits `dtx-api`'s R2. Both must observe the same seeded chart, so `dtx-web` and `dtx-api` run their Miniflare against a **shared `--persist-to` directory** in Leg B. Leg A only needs `dtx-web`'s bindings.
-- **Real Supabase control plane, local data plane.** The dedicated test Supabase project issues and validates tokens for both paths (cookie for `dtx-web`, bearer for `dtx-api`). All _application_ data (charts, files, user profiles) lives in local Miniflare D1/R2 — never in Supabase, never in pre-prod.
+- **Two independent legs, one backend each.** Each matrix leg is a fresh CI job that seeds the single backend it exercises: Leg A seeds `dtx-web`'s local Miniflare D1/R2 (served via `platformProxy`); Leg B seeds `dtx-api`'s local Miniflare D1/R2 (served via `wrangler dev`). Parity = identical observable outcomes across legs, not shared bytes. No shared `--persist-to` is needed because `dtx-web` performs no server-side D1/R2 read in the journeys (in Leg B its mock D1 is never hit).
+- **Real Supabase control plane, local data plane.** The dedicated test Supabase project issues and validates tokens for both paths (cookie for `dtx-web`, bearer for `dtx-api`). All _application_ data (charts, files) lives in local Miniflare D1/R2 — never in Supabase, never in pre-prod.
 - **Flag toggling via public env vars at dev-server launch.** An `E2E_USE_GRAPHQL` switch read by `playwright.config.ts` selects the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, plus `PUBLIC_DTX_API_URL` when ON) and decides whether to also boot the `dtx-api` webServer.
 - **`dtx-web` bindings in dev — confirmed by a live spike.** Plain `vite dev` returns a **mock D1** (`getDb` falls back to `createMockD1Database()` because `platform` is `undefined`), so the existing dev server has no real bindings. Enabling `@sveltejs/adapter-cloudflare` (v7) `platformProxy` in `svelte.config.js` surfaces **real local Miniflare** `platform.env.DB`/`DTXFILE_BUCKET`/`RATE_LIMIT` under `vite dev` (verified: a published-list probe then produced a genuine `D1_ERROR: no such table` against an empty local DB, not mock data). So `platformProxy` is the chosen mechanism — fast `vite dev` with real bindings, no `wrangler dev` build step for `dtx-web`. The one bookkeeping detail the spike surfaced: getPlatformProxy and `wrangler d1 execute --persist-to` must be pointed at the **same resolved persist directory**, and **migrations must be applied before the dev server starts** (Miniflare caches the DB connection, so a mid-session `wrangler d1 execute` is not observed). The plan's first task pins the exact persist path and the migrate-then-start ordering.
 
-### The four critical-journey specs
+### The critical-journey specs
 
-A Playwright `global.setup` project signs the test user in once (`supabase.auth.signInWithPassword` against the test project) and saves `storageState` — the Supabase session, which carries both the cookie (consumed by `dtx-web` SSR via `@supabase/ssr`) and the `access_token` (read by `lib/api/token.ts` for the bearer path). Authenticated specs reuse that `storageState`; a single browser login therefore covers both the REST cookie path and the GraphQL bearer path.
+The web UI supports a subset of the parent spec's four journeys: **create and `.dtx` upload have no web UI** (they are desktop-only — `lib/api` exposes only `listSimfiles`/`getSimfile`/`updateSimfile`/`deleteSimfile`/`downloadSimfile`), and **bulk download** only renders when `window.showSaveFilePicker` exists, which headless Chromium lacks. The two journeys below cover every flag-sensitive web call-site that the browser can actually drive; create/upload/bulk stay covered by the Phase 3 dual-path unit tests + the desktop runbook.
 
-A seed step (authenticated API calls against the running local stack) creates one published, uploaded chart for the anonymous journeys. The lifecycle journey self-seeds (create → … → delete).
+A Playwright `global.setup` project signs the test user in once via the real `/login` form (`supabase.auth.signInWithPassword` server action) and saves `storageState` — the `@supabase/ssr` session cookies, which serve both the SSR cookie path (`dtx-web` `hooks.server.ts`) and the bearer path (`lib/api/token.ts` reads the session for the `Authorization` header). A single login covers both flag states.
 
-| #   | Journey                                                                       | Auth      | Flag-sensitive call-sites exercised                                               |
-| --- | ----------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------- |
-| 1   | Chart lifecycle: create a chart → see it in `/app` list → edit title → delete | logged in | `createSimfile`, `listSimfiles(MINE)`, `updateSimfile`, `deleteSimfile`           |
-| 2   | Upload a `.dtx` to a chart → file appears in the chart's files list           | logged in | upload (`/upload` multipart), `getSimfile { files }`                              |
-| 3   | Anonymous blog browse → open a published chart → single download              | anonymous | `listSimfiles(PUBLISHED)` SSR, `getSimfile`, `downloadSimfile` (`/downloads/:id`) |
-| 4   | Select two charts → bulk ZIP download                                         | anonymous | `bulkDownload` (`/downloads/bulk`)                                                |
+Seeding is done **before the dev server starts** (Miniflare caches its DB connection, so mid-session writes are not observed) via `wrangler d1 execute` + `wrangler r2 object put` against the leg's persist dir. Two charts are seeded: **chart A** owned by the test user (`user_id = TEST_USER_ID`, hardcoded after one-time provisioning) for the lifecycle journey, and **chart B** published with a real R2 object under `<id>/` (so `has_uploaded_files = true`) for the download journey. Keeping them separate means the lifecycle journey's delete never removes chart B (Playwright runs specs in parallel).
+
+| #   | Journey                                                                                                   | Auth      | Flag-sensitive call-sites exercised                                                           |
+| --- | --------------------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------- |
+| 1   | Authenticated lifecycle: `/app/chart` list shows seeded chart A → open detail → edit/save → back → delete | logged in | `listSimfiles(MINE)`, `getSimfile`, `updateSimfile`, `deleteSimfile`                          |
+| 2   | Anonymous browse + single download: `/blog` list shows chart B → click Download → file downloads          | anonymous | `listSimfiles(PUBLISHED)`, `downloadSimfile` (`/api/simFile/download/:id` ↔ `/downloads/:id`) |
 
 Each journey asserts only on visible UI, URL, and downloaded-file outcomes, so the _same_ assertions hold whether the bytes came from REST or GraphQL — that is the parity proof. The existing eight unauthenticated tool/UI specs remain unchanged and continue to run in both legs (cheap, and they confirm the client-only paths are flag-agnostic).
 
@@ -107,6 +106,7 @@ export const TEST_SUPABASE_URL = 'https://<drumery-e2e>.supabase.co';
 export const TEST_SUPABASE_ANON_KEY = '<anon-key>'; // public by design
 export const TEST_USER_EMAIL = 'e2e@drumery.test';
 export const TEST_USER_PASSWORD = '<throwaway-password>';
+export const TEST_USER_ID = '<supabase-uuid>'; // read once after provisioning; seeds chart A's user_id
 ```
 
 `playwright.config.ts` injects these into the `dtx-web` webServer env (`PUBLIC_SUPABASE_URL`/`PUBLIC_SUPABASE_ANON_KEY`) and, on the flag-ON leg, into the `dtx-api` webServer env (`SUPABASE_URL`/`SUPABASE_ANON_KEY`); `global.setup` reads the user creds directly. The test user is created once out-of-band (documented in the runbook), not on every run. Only test-instance values ever get hardcoded — prod/pre-prod credentials never do.
@@ -123,8 +123,8 @@ env:
     E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
 ```
 
-- `playwright.config.ts` reads `E2E_USE_GRAPHQL`. It sets the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, the test Supabase URL/anon-key from `e2e/test-config.ts`, and `PUBLIC_DTX_API_URL=http://localhost:8787` when ON), and — when ON — declares a **second `webServer`** that boots `dtx-api` via `wrangler dev` with a shared `--persist-to` directory and the same test Supabase env.
-- D1 migrations (`packages/dtx-web/d1-migrations/`) are applied to the resolved local persist directory **before** the dev server starts in both legs (the spike showed Miniflare caches the connection, so migrate-then-start is mandatory); the data seed then runs in `global.setup`.
+- `playwright.config.ts` reads `E2E_USE_GRAPHQL`. It sets the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, the test Supabase URL/anon-key from `e2e/test-config.ts`, and `PUBLIC_DTX_API_URL=http://localhost:8787` when ON), and — when ON — declares a **second `webServer`** that boots `dtx-api` via `wrangler dev` with the test Supabase env. Each leg seeds only the backend it exercises (Leg A → `dtx-web`'s Miniflare; Leg B → `dtx-api`'s Miniflare); no shared persist dir.
+- D1 migrations + the two-chart seed are applied to the leg's persist directory **before** the dev server starts (the spike showed Miniflare caches the connection, so migrate/seed-then-start is mandatory). A Playwright `globalSetup`/script handles migrate+seed; `global.setup` then performs the login and saves `storageState`.
 - Both legs must be green for the job to pass. This realizes the parent spec's "run twice" transition gate, and — because nothing is secret-gated — it runs identically on same-repo and fork PRs.
 
 ### Cutover runbook (committed markdown, executed by a human)
@@ -133,7 +133,7 @@ env:
 
 1. **One-time setup:** create the test Supabase project (auto-confirm signups); create the e2e test user; paste the project URL, anon key, and test-user creds into `e2e/test-config.ts`. No CI secrets to add.
 2. **Flag-ON on pre-prod:** deploy `dtx-web` to pre-prod with `PUBLIC_USE_GRAPHQL_API` overridden to `true` (CLI var override or dashboard). The committed config stays `false`.
-3. **Manual smoke** of every web call-site against `api.pre-prod.dtx.hapadona.com`: login, list, edit, delete, single + bulk download, magic link. DevTools Network confirms requests hit `api.pre-prod`.
+3. **Manual smoke** of every web call-site against `api.pre-prod.dtx.hapadona.com` — including the ones the CI gate can't drive in headless Chromium: login, list (mine + published), open detail, edit/save, delete, **single download**, **bulk download** (real `showSaveFilePicker`), and the **magic-link** desktop handoff. DevTools Network confirms requests hit `api.pre-prod`.
 4. **Worker-log parity capture:** `wrangler tail` on both `dtx-web` (pre-prod) and `dtx-api-pre-prod` during the smoke; save logs for delta comparison against a flag-OFF baseline run.
 5. **Delta-triage:** record any response/behavior delta. Fixes land in `dtx-web` or `dtx-api` as a **follow-up PR** (allowed in Phase 4), each with a regression assertion added to the relevant journey spec or Phase 3 unit test.
 6. **Flip back** to `false` to leave pre-prod in steady state.
@@ -146,34 +146,35 @@ The gate proves parity at the **observable-outcome** layer (rendered UI, navigat
 
 ### Risks & mitigations
 
-| Risk                                                                                 | Mitigation                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Persist-path mismatch / migrate-after-start so the dev server reads an empty DB      | **Resolved approach (from the live spike):** `platformProxy` does surface real bindings; the gate must point getPlatformProxy and `wrangler` at the same persist dir and migrate **before** server start. The plan's first task pins the exact path + ordering with a round-trip read-back assertion; fallback is `wrangler dev` on the built `dtx-web` worker. |
-| Shared `--persist-to` race between `dtx-web` and `dtx-api` in Leg B                  | Apply migrations + seed before either server accepts traffic; Playwright `webServer.url` health-gates startup ordering; seed is idempotent.                                                                                                                                                                                                                     |
-| Cross-leg test/data bleed                                                            | Each matrix leg is a fresh CI job with its own Miniflare + persist dir + per-leg seed. No cross-leg shared state.                                                                                                                                                                                                                                               |
-| Real Supabase dependency makes the gate flaky if Supabase is unavailable             | Accepted and bounded: only token issuance/validation touches Supabase. Documented; existing `retries: 2` (on CI) absorbs transient failures.                                                                                                                                                                                                                    |
-| Access-token expiry mid-suite                                                        | `global.setup` signs in fresh per run; suites are short; access-token TTL far exceeds suite runtime.                                                                                                                                                                                                                                                            |
-| Hardcoded test creds leak or get reused                                              | Only an isolated throwaway Supabase test project is hardcoded; the anon key is public by design and the project holds no real data. Never hardcode prod/pre-prod creds. Benefit: the full gate runs on every PR (incl. forks) with no secret wiring.                                                                                                            |
-| Bulk-download rate limit (`RATE_LIMIT` / `RATE_LIMIT_API` KV) trips during the suite | Local KV is empty per leg; the suite seeds/selects only two charts — well within limits.                                                                                                                                                                                                                                                                        |
-| Doubling CI time (two legs)                                                          | Legs run in parallel via the matrix; the flag-OFF leg is the existing cost, the flag-ON leg adds a `wrangler dev` boot. Acceptable for a pre-cutover gate.                                                                                                                                                                                                      |
+| Risk                                                                               | Mitigation                                                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Persist-path mismatch / migrate-after-start so the dev server reads an empty DB    | **Resolved approach (from the live spike):** `platformProxy` does surface real bindings; the gate must point getPlatformProxy and `wrangler` at the same persist dir and migrate **before** server start. The plan's first task pins the exact path + ordering with a round-trip read-back assertion; fallback is `wrangler dev` on the built `dtx-web` worker. |
+| Seed not visible because applied after server start                                | Migrate + seed run **before** the leg's dev server boots (Miniflare caches its connection); the migrate/seed script exits 0 before Playwright launches the webServer. No shared persist to coordinate.                                                                                                                                                          |
+| Web journeys that don't exist in headless Chromium (bulk download, upload, create) | Bulk needs `window.showSaveFilePicker` (absent in headless Chromium); upload/create have no web UI. Excluded from the CI gate by design; covered by Phase 3 dual-path unit tests (`ChartList.helpers`, `lib/api`) + the desktop runbook's manual bulk/upload smoke.                                                                                             |
+| Cross-leg test/data bleed                                                          | Each matrix leg is a fresh CI job with its own Miniflare + persist dir + per-leg seed. No cross-leg shared state.                                                                                                                                                                                                                                               |
+| Real Supabase dependency makes the gate flaky if Supabase is unavailable           | Accepted and bounded: only token issuance/validation touches Supabase. Documented; existing `retries: 2` (on CI) absorbs transient failures.                                                                                                                                                                                                                    |
+| Access-token expiry mid-suite                                                      | `global.setup` signs in fresh per run; suites are short; access-token TTL far exceeds suite runtime.                                                                                                                                                                                                                                                            |
+| Hardcoded test creds leak or get reused                                            | Only an isolated throwaway Supabase test project is hardcoded; the anon key is public by design and the project holds no real data. Never hardcode prod/pre-prod creds. Benefit: the full gate runs on every PR (incl. forks) with no secret wiring.                                                                                                            |
+| Download rate limit (`RATE_LIMIT` / `RATE_LIMIT_API` KV) trips during the suite    | Local KV is empty per leg; the suite seeds two charts and performs a single download — well within limits.                                                                                                                                                                                                                                                      |
+| Doubling CI time (two legs)                                                        | Legs run in parallel via the matrix; the flag-OFF leg is the existing cost, the flag-ON leg adds a `wrangler dev` boot. Acceptable for a pre-cutover gate.                                                                                                                                                                                                      |
 
 ### Decisions log (pinned by this spec)
 
 1. **Phase 4 delivers both the automated dual-path parity gate and the live cutover runbook.** (Scope chosen over runbook-only / gate-only / decompose.)
 2. **The parity gate uses a hermetic local stack:** local Miniflare D1/R2, real Supabase only for token issuance/validation. No offline-JWT path is introduced.
-3. **A dedicated test Supabase project** backs e2e auth — isolated from prod and pre-prod identities. Its credentials are **hardcoded in a committed `e2e/test-config.ts`** (anon key is public; throwaway project), so the gate needs no CI secrets and runs on every PR including forks.
-   3a. **`dtx-web` gets real dev bindings via adapter-cloudflare `platformProxy`** (confirmed by a live spike), not `wrangler dev`; migrations are applied to the shared persist dir before server start.
-4. **Two independent CI legs** (`use_graphql: [false, true]`) prove parity via identical assertions, rather than sharing one dataset across flag states.
-5. **`dtx-web` and `dtx-api` share one `--persist-to` dir within the flag-ON leg** so blog SSR (dtx-web D1) and anonymous download (dtx-api R2) see the same seed.
+3. **A dedicated test Supabase project** backs e2e auth — isolated from prod and pre-prod identities. Its credentials (incl. the test user's UUID) are **hardcoded in a committed `e2e/test-config.ts`** (anon key is public; throwaway project), so the gate needs no CI secrets and runs on every PR including forks.
+   3a. **`dtx-web` gets real dev bindings via adapter-cloudflare `platformProxy`** (confirmed by a live spike), not `wrangler dev`; migrations + seed are applied to the persist dir before server start.
+4. **Two independent CI legs** (`use_graphql: [false, true]`) prove parity via identical assertions; each leg seeds only the **one** backend it exercises — no shared persist (the web app does all flag-sensitive data calls client-side).
+5. **Two journeys, not four** — authenticated lifecycle + anonymous single download. Create/upload have no web UI and bulk needs `window.showSaveFilePicker` (absent in headless Chromium); all three stay covered by Phase 3 unit tests + the desktop runbook.
 6. **No change to `packages/dtx-api`** (including `verifyToken.ts`) and **no change to deployed flag values.** Delta fixes from the runbook land as a separate follow-up PR.
-7. **The four journeys match the parent spec exactly** — lifecycle, presigned/multipart upload, anonymous single download, bulk download — kept deliberately minimal.
+7. **Seeding is pre-start via `wrangler d1 execute` + `wrangler r2 object put`** with a fixed `TEST_USER_ID`, not via API calls (web has no create/upload endpoint, and mid-session writes aren't observed by Miniflare).
 8. **The runbook is authored here but executed by a human operator** (Cloudflare dashboard + interactive login + observation are out of an agent's reach).
 
 ### Open questions deferred to implementation
 
-- The exact resolved persist directory shared by getPlatformProxy and `wrangler` (the spike showed they can diverge), and whether Leg B shares state cleanest via both servers on `wrangler dev --persist-to` or `dtx-web` on `platformProxy` + `dtx-api` on `wrangler dev` pointed at the same dir; decided by the plan's first task with a read-back assertion.
-- Exact local port for `dtx-api` (`8787` assumed) and the `--persist-to` path; finalized in `playwright.config.ts`.
-- Whether the seed runs entirely in `global.setup` via API calls or partly via `wrangler d1 execute` for the published-chart fixture; default: API calls so the seed is path-honest, with a direct R2/D1 write only if an API-only seed proves circular.
+- The exact resolved persist directory getPlatformProxy uses for `dtx-web` (the spike showed it ignored a `persist.path` override and used `.wrangler/state`), and the matching `wrangler d1 execute --persist-to`/`wrangler r2 object put` path for the seed — pinned by the plan's first task with a read-back assertion.
+- Exact local port for `dtx-api` (`8787` assumed) and its `--persist-to` path; finalized in `playwright.config.ts`.
+- Exact selectors for the `ChartDetail` edit form (from `@dtx/common/components`) used by the lifecycle journey's edit step — read during that task; the journey's TDD loop (write → run → adjust selectors → green) finalizes them.
 - Whether to model the two legs as a GitHub matrix (assumed) or as two Playwright `projects` with separate webServers in one job; default: matrix for isolation + parallelism.
 
 ### What Phase 5 will need (handoff)
@@ -184,8 +185,8 @@ The gate proves parity at the **observable-outcome** layer (rendered UI, navigat
 
 ## Done criteria
 
-- `e2e/` contains four journey specs (chart lifecycle, `.dtx` upload, single download, bulk download) plus a `global.setup` that logs in the test user and seeds one published+uploaded chart; all pass locally with both `E2E_USE_GRAPHQL=false` and `=true`.
-- `playwright.config.ts` reads `E2E_USE_GRAPHQL`, sets the flag + `PUBLIC_DTX_API_URL` on the `dtx-web` webServer, and boots a `dtx-api` `wrangler dev` webServer with a shared `--persist-to` on the flag-ON leg; D1 migrations are applied before the suites in both legs.
+- `e2e/` contains two journey specs (authenticated lifecycle, anonymous single download) plus a `global.setup` (login + `storageState`) and a pre-start migrate+seed script; all pass locally with both `E2E_USE_GRAPHQL=false` and `=true`.
+- `playwright.config.ts` reads `E2E_USE_GRAPHQL`, sets the flag + `PUBLIC_DTX_API_URL` on the `dtx-web` webServer, and boots a `dtx-api` `wrangler dev` webServer on the flag-ON leg; each leg migrates + seeds its own backend before server start (no shared `--persist-to`).
 - `.github/workflows/e2e-test.yml` runs the `use_graphql: [false, true]` matrix; both legs must be green for the job to pass; no CI secrets are required (test creds live in `e2e/test-config.ts`).
 - `e2e/test-config.ts` holds the hardcoded test-Supabase URL/anon-key + test-user creds; the dedicated test Supabase project + test user are documented in the runbook.
 - `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is committed and complete (no TBDs).

--- a/docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md
+++ b/docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md
@@ -1,0 +1,198 @@
+# API Migration Phase 4 — Dual-path e2e parity gate + pre-prod cutover validation
+
+**Date:** 2026-05-29
+**Parent spec:** [docs/superpowers/specs/2026-05-16-api-server-migration-design.md](2026-05-16-api-server-migration-design.md)
+**Phase 0 plan:** [docs/superpowers/plans/2026-05-16-api-migration-phase-0.md](../plans/2026-05-16-api-migration-phase-0.md) (complete)
+**Phase 1 plan:** [docs/superpowers/plans/2026-05-18-api-migration-phase-1.md](../plans/2026-05-18-api-migration-phase-1.md) (complete)
+**Phase 2 plan:** [docs/superpowers/plans/2026-05-19-api-migration-phase-2.md](../plans/2026-05-19-api-migration-phase-2.md) (complete)
+**Phase 3 plan:** [docs/superpowers/plans/2026-05-25-api-migration-phase-3.md](../plans/2026-05-25-api-migration-phase-3.md) (complete)
+**Phase 3 spec:** [docs/superpowers/specs/2026-05-25-api-migration-phase-3-design.md](2026-05-25-api-migration-phase-3-design.md)
+**Packages/areas:** modifies `e2e/`, `playwright.config.ts`, `.github/workflows/e2e-test.yml`, and adds docs. No changes to `packages/dtx-api`, `packages/dtx-web` app code, `packages/dtx-desktop`, or `packages/common`.
+
+## Goal
+
+Stand up a **dual-path end-to-end parity gate** that proves the Phase 3 `lib/api/` dispatch layer behaves identically with `PUBLIC_USE_GRAPHQL_API` OFF (REST against `dtx-web`'s own `/api/*` routes) and ON (GraphQL against `dtx-api`), plus a committed **runbook** for the live pre-prod cutover validation that a human executes.
+
+Phase 4 ships test/CI code and documentation only. It does **not** change the app's behavior and does **not** flip the flag in any deployed stanza — the committed `PUBLIC_USE_GRAPHQL_API` stays `false` everywhere. The "run the four e2e suites twice in CI (flag OFF and ON)" transition gate described in the parent spec is the central deliverable; it does not exist yet and is built here.
+
+## Current state (start of Phase 4)
+
+- Phase 3 is complete on `main`. `dtx-web` ships the dual-path `src/lib/api/*` layer behind `PUBLIC_USE_GRAPHQL_API`; `dtx-desktop` is hard-cut to GraphQL; codegen output is committed; `wrangler.jsonc` declares the `API` service binding on `pre-prod` (`dtx-api-pre-prod`) and `pre-prod-prod-data` (`dtx-api-pre-prod-prod-data`) stanzas. The flag is `"false"` on all three stanzas.
+- `dtx-api` is deployed at `api.pre-prod.dtx.hapadona.com` with the full GraphQL surface + REST sidecars (`/upload`, `/downloads/:id`, `/downloads/bulk`).
+- The Phase 3 **dual-path unit tests** already assert byte-identical return shapes across both flag states for every `lib/api/` call-site. The runtime/network/auth/CORS paths against a real `dtx-api` are the part not yet exercised by automated browser tests.
+- The e2e suite has eight specs (`blog`, `chart-list`, `dtx-file-upload`, `dtx-to-midi`, `midi-to-dtx`, `midi-preview`, `editor`, `next-display-id`). They are **unauthenticated** tool/UI tests: none log in, none exercise the flag-sensitive authenticated call-sites, and `next-display-id.spec.ts` only asserts a `401` on the REST route.
+- `playwright.config.ts` runs once against `bun run --filter=dtx-web dev` (plain `vite dev` on `localhost:5173`). The webServer sets `VITE_E2E=true` (which only flips a `data-e2e-hydrated` attribute in `+layout.svelte` for hydration sync — there is **no** e2e auth bypass or seeded data) and points `VITE_DTX_SERVER_URL` at itself. There is no GraphQL backend wired for a flag-ON run.
+- `.github/workflows/e2e-test.yml` runs `bunx playwright test` once with `PUBLIC_SUPABASE_URL`/`PUBLIC_SUPABASE_ANON_KEY` from the `Production` GitHub environment.
+- `dtx-api` validates bearer tokens by calling `supabase.auth.getUser(token)` against its configured `SUPABASE_URL` (`packages/dtx-api/src/auth/verifyToken.ts`). There is **no** offline/shared-secret/JWKS verification path. A fully offline e2e is therefore impossible without changing that file, which Phase 4 deliberately will not touch.
+- Both `dtx-web` and `dtx-api` have `wrangler dev` available. `dtx-web` uses `@sveltejs/adapter-cloudflare`. D1 migrations live at `packages/dtx-web/d1-migrations/0001_initial_schema.sql`. There is no seed tooling and no e2e test user today.
+
+## Non-goals
+
+- Flipping `PUBLIC_USE_GRAPHQL_API=true` in any committed/deployed stanza (that is a manual runbook step on pre-prod, and Phase 5 for prod).
+- Any change to `packages/dtx-api` business logic or `verifyToken.ts` — Phase 4 depends on the deployed verification behavior as-is.
+- Production deploy of `dtx-api`, production web flag flip, or a desktop GitHub release (all Phase 5).
+- Deleting `packages/dtx-web/src/routes/api/*` or removing `dtx-web` bindings (Phase 6).
+- Expanding e2e beyond the four critical journeys — the parent spec keeps the e2e suite deliberately minimal.
+- Changing `packages/dtx-web` app code, `packages/dtx-desktop`, or `packages/common`. Delta fixes uncovered during the live runbook are explicitly allowed but land as a **follow-up PR**, not as part of the gate scaffolding. (The harness may add a root-level dev dependency or test-config wiring — e.g. a Supabase client for `global.setup` — if one is required; that is gate scaffolding, not app code.)
+
+## Design
+
+### Architecture overview — the hermetic dual-path harness
+
+The same four journey specs run in two **independent legs** selected by a CI matrix (`use_graphql: [false, true]`). Parity is proven by the _same assertions_ passing in both legs; the legs do not share data with each other.
+
+```text
+LEG A — flag OFF (REST path)
+┌──────────────────────────────────────────────────────┐
+│ Playwright (chromium) on localhost                     │
+│   browser → dtx-web (localhost:5173)                   │
+│     PUBLIC_USE_GRAPHQL_API=false                       │
+│     client call-sites → dtx-web /api/*                 │
+│     blog SSR + /api/* → platform.env.DB / R2 / KV      │ ← local Miniflare
+│   auth: Supabase session cookie (test project)         │
+└──────────────────────────────────────────────────────┘
+
+LEG B — flag ON (GraphQL path)
+┌──────────────────────────────────────────────────────┐
+│ Playwright (chromium) on localhost                     │
+│   browser → dtx-web (localhost:5173)                   │
+│     PUBLIC_USE_GRAPHQL_API=true                        │
+│     PUBLIC_DTX_API_URL=http://localhost:8787           │
+│     client call-sites → dtx-api /graphql, /upload,     │
+│                         /downloads/:id, /downloads/bulk │
+│     blog SSR still → dtx-web platform.env.DB           │
+│   ┌ dtx-web (5173) ┐  shared --persist-to .e2e-state    │
+│   └ dtx-api (8787) ┘  → ONE local D1 + R2              │ ← local Miniflare
+│   auth: Supabase bearer (test project)                 │
+│         → dtx-api verifyToken → getUser(test Supabase) │
+└──────────────────────────────────────────────────────┘
+```
+
+Principles:
+
+- **Two independent legs, not one shared dataset.** Each matrix leg is a fresh CI job with its own Miniflare instance, its own persistence directory, and its own per-leg seed. Parity = identical observable outcomes, not shared bytes. This keeps the legs isolated and parallelizable.
+- **One shared local D1/R2 _within_ Leg B.** In the flag-ON leg, `dtx-web`'s blog SSR reads `dtx-web`'s D1 directly (the SSR read is not migrated until Phase 6), while the client's anonymous download hits `dtx-api`'s R2. Both must observe the same seeded chart, so `dtx-web` and `dtx-api` run their Miniflare against a **shared `--persist-to` directory** in Leg B. Leg A only needs `dtx-web`'s bindings.
+- **Real Supabase control plane, local data plane.** The dedicated test Supabase project issues and validates tokens for both paths (cookie for `dtx-web`, bearer for `dtx-api`). All _application_ data (charts, files, user profiles) lives in local Miniflare D1/R2 — never in Supabase, never in pre-prod.
+- **Flag toggling via public env vars at dev-server launch.** An `E2E_USE_GRAPHQL` switch read by `playwright.config.ts` selects the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, plus `PUBLIC_DTX_API_URL` when ON) and decides whether to also boot the `dtx-api` webServer.
+- **`dtx-web` bindings in dev.** Default approach: `@sveltejs/adapter-cloudflare`'s platformProxy surfaces `platform.env` from `wrangler.jsonc` bindings against local Miniflare under `vite dev`. Fallback if that does not surface cleanly: run `dtx-web` via `wrangler dev` on the built worker. This is the single piece proven out first in the implementation plan; nothing else depends on which option wins.
+
+### The four critical-journey specs
+
+A Playwright `global.setup` project signs the test user in once (`supabase.auth.signInWithPassword` against the test project) and saves `storageState` — the Supabase session, which carries both the cookie (consumed by `dtx-web` SSR via `@supabase/ssr`) and the `access_token` (read by `lib/api/token.ts` for the bearer path). Authenticated specs reuse that `storageState`; a single browser login therefore covers both the REST cookie path and the GraphQL bearer path.
+
+A seed step (authenticated API calls against the running local stack) creates one published, uploaded chart for the anonymous journeys. The lifecycle journey self-seeds (create → … → delete).
+
+| #   | Journey                                                                       | Auth      | Flag-sensitive call-sites exercised                                               |
+| --- | ----------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------- |
+| 1   | Chart lifecycle: create a chart → see it in `/app` list → edit title → delete | logged in | `createSimfile`, `listSimfiles(MINE)`, `updateSimfile`, `deleteSimfile`           |
+| 2   | Upload a `.dtx` to a chart → file appears in the chart's files list           | logged in | upload (`/upload` multipart), `getSimfile { files }`                              |
+| 3   | Anonymous blog browse → open a published chart → single download              | anonymous | `listSimfiles(PUBLISHED)` SSR, `getSimfile`, `downloadSimfile` (`/downloads/:id`) |
+| 4   | Select two charts → bulk ZIP download                                         | anonymous | `bulkDownload` (`/downloads/bulk`)                                                |
+
+Each journey asserts only on visible UI, URL, and downloaded-file outcomes, so the _same_ assertions hold whether the bytes came from REST or GraphQL — that is the parity proof. The existing eight unauthenticated tool/UI specs remain unchanged and continue to run in both legs (cheap, and they confirm the client-only paths are flag-agnostic).
+
+### Test Supabase project + secrets
+
+A dedicated Supabase project (e.g. `drumery-e2e`) used **only** by the parity gate:
+
+- Holds the e2e test user(s); zero overlap with prod or pre-prod auth.
+- Email confirmation disabled / auto-confirm so the test user is provisioned once and signed in headlessly.
+- Local `dtx-web` and `dtx-api` both point `SUPABASE_URL`/`SUPABASE_ANON_KEY` at this project during e2e so cookie auth (`dtx-web`) and bearer verification (`dtx-api` `verifyToken`) resolve against the same identity.
+
+New CI vars/secrets (GitHub Actions):
+
+| Name                     | Kind   | Use                                      |
+| ------------------------ | ------ | ---------------------------------------- |
+| `E2E_SUPABASE_URL`       | var    | test project URL (`dtx-web` + `dtx-api`) |
+| `E2E_SUPABASE_ANON_KEY`  | secret | test project anon key                    |
+| `E2E_TEST_USER_EMAIL`    | secret | login in `global.setup`                  |
+| `E2E_TEST_USER_PASSWORD` | secret | login in `global.setup`                  |
+
+For the parity gate, the existing `PUBLIC_SUPABASE_*` wiring in `e2e-test.yml` is sourced from these `E2E_*` values. The test user is created once out-of-band (documented in the runbook), not on every run.
+
+### CI workflow — the parity matrix
+
+`.github/workflows/e2e-test.yml` gains a matrix leg:
+
+```yaml
+strategy:
+    matrix:
+        use_graphql: [false, true]
+env:
+    E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
+    PUBLIC_SUPABASE_URL: ${{ vars.E2E_SUPABASE_URL }}
+    PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+    E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+    E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+    # dtx-api SUPABASE_* are set to the same test project for the flag-ON leg
+```
+
+- `playwright.config.ts` reads `E2E_USE_GRAPHQL`. It sets the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, and `PUBLIC_DTX_API_URL=http://localhost:8787` when ON), and — when ON — declares a **second `webServer`** that boots `dtx-api` via `wrangler dev` with a shared `--persist-to` directory.
+- D1 migrations (`packages/dtx-web/d1-migrations/`) are applied to the local D1 before the suites in both legs; the seed runs in `global.setup`.
+- Both legs must be green for the job to pass. This realizes the parent spec's "run twice" transition gate.
+
+### Cutover runbook (committed markdown, executed by a human)
+
+`docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` — a checklist authored here but **run by the operator**, because it requires the Cloudflare dashboard, a real interactive login, and human observation:
+
+1. **One-time setup:** create the test Supabase project; create the e2e test user; add the four `E2E_*` CI vars/secrets.
+2. **Flag-ON on pre-prod:** deploy `dtx-web` to pre-prod with `PUBLIC_USE_GRAPHQL_API` overridden to `true` (CLI var override or dashboard). The committed config stays `false`.
+3. **Manual smoke** of every web call-site against `api.pre-prod.dtx.hapadona.com`: login, list, edit, delete, single + bulk download, magic link. DevTools Network confirms requests hit `api.pre-prod`.
+4. **Worker-log parity capture:** `wrangler tail` on both `dtx-web` (pre-prod) and `dtx-api-pre-prod` during the smoke; save logs for delta comparison against a flag-OFF baseline run.
+5. **Delta-triage:** record any response/behavior delta. Fixes land in `dtx-web` or `dtx-api` as a **follow-up PR** (allowed in Phase 4), each with a regression assertion added to the relevant journey spec or Phase 3 unit test.
+6. **Flip back** to `false` to leave pre-prod in steady state.
+7. **Desktop pre-prod build:** `VITE_DTX_SERVER_URL=https://api.pre-prod.dtx.hapadona.com bun run --filter=dtx-desktop build`; smoke list / upload `.dtx` / edit / delete / magic-link locally. No GitHub release.
+8. **Phase 5 handoff:** record what must hold before the prod cutover (gate green on `main`, zero unresolved deltas, desktop pre-prod smoke clean).
+
+### Parity / error model
+
+The gate proves parity at the **observable-outcome** layer (rendered UI, navigations, downloaded files), which is the layer users experience. The **response-shape** layer is already covered by the Phase 3 dual-path unit tests (`lib/api/*.test.ts` assert byte-identical shapes across flag states). The **runtime/transport/auth/CORS** layer against a real deployed `dtx-api` is covered by the live runbook's manual smoke + worker-log capture. Together the three layers cover the cutover surface without duplicating each other.
+
+### Risks & mitigations
+
+| Risk                                                                                 | Mitigation                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| adapter-cloudflare platformProxy does not surface `platform.env` under `vite dev`    | Proven out in the plan's first task before journeys are written; fallback is `wrangler dev` on the built `dtx-web` worker. Blocks nothing downstream.                                |
+| Shared `--persist-to` race between `dtx-web` and `dtx-api` in Leg B                  | Apply migrations + seed before either server accepts traffic; Playwright `webServer.url` health-gates startup ordering; seed is idempotent.                                          |
+| Cross-leg test/data bleed                                                            | Each matrix leg is a fresh CI job with its own Miniflare + persist dir + per-leg seed. No cross-leg shared state.                                                                    |
+| Real Supabase dependency makes the gate flaky if Supabase is unavailable             | Accepted and bounded: only token issuance/validation touches Supabase. Documented; existing `retries: 2` (on CI) absorbs transient failures.                                         |
+| Access-token expiry mid-suite                                                        | `global.setup` signs in fresh per run; suites are short; access-token TTL far exceeds suite runtime.                                                                                 |
+| CI secrets unavailable on fork PRs                                                   | Authenticated legs require `E2E_*` secrets; on fork PRs they are skipped (documented), matching today's secret-gated workflow. Same-repo PRs and pushes to `main` run the full gate. |
+| Bulk-download rate limit (`RATE_LIMIT` / `RATE_LIMIT_API` KV) trips during the suite | Local KV is empty per leg; the suite seeds/selects only two charts — well within limits.                                                                                             |
+| Doubling CI time (two legs)                                                          | Legs run in parallel via the matrix; the flag-OFF leg is the existing cost, the flag-ON leg adds a `wrangler dev` boot. Acceptable for a pre-cutover gate.                           |
+
+### Decisions log (pinned by this spec)
+
+1. **Phase 4 delivers both the automated dual-path parity gate and the live cutover runbook.** (Scope chosen over runbook-only / gate-only / decompose.)
+2. **The parity gate uses a hermetic local stack:** local Miniflare D1/R2, real Supabase only for token issuance/validation. No offline-JWT path is introduced.
+3. **A dedicated test Supabase project** backs e2e auth — isolated from prod and pre-prod identities.
+4. **Two independent CI legs** (`use_graphql: [false, true]`) prove parity via identical assertions, rather than sharing one dataset across flag states.
+5. **`dtx-web` and `dtx-api` share one `--persist-to` dir within the flag-ON leg** so blog SSR (dtx-web D1) and anonymous download (dtx-api R2) see the same seed.
+6. **No change to `packages/dtx-api`** (including `verifyToken.ts`) and **no change to deployed flag values.** Delta fixes from the runbook land as a separate follow-up PR.
+7. **The four journeys match the parent spec exactly** — lifecycle, presigned/multipart upload, anonymous single download, bulk download — kept deliberately minimal.
+8. **The runbook is authored here but executed by a human operator** (Cloudflare dashboard + interactive login + observation are out of an agent's reach).
+
+### Open questions deferred to implementation
+
+- platformProxy vs `wrangler dev` for `dtx-web`'s dev-server bindings (default platformProxy; decided by the plan's first task).
+- Exact local ports for `dtx-api` (`8787` assumed) and the `--persist-to` path (`.e2e-state` assumed); finalized in `playwright.config.ts`.
+- Whether the seed runs entirely in `global.setup` via API calls or partly via `wrangler d1 execute` for the published-chart fixture; default: API calls so the seed is path-honest, with a direct R2/D1 write only if an API-only seed proves circular.
+- Whether to model the two legs as a GitHub matrix (assumed) or as two Playwright `projects` with separate webServers in one job; default: matrix for isolation + parallelism.
+- Whether fork-PR runs skip the gate entirely or run only the unauthenticated specs; default: run unauthenticated specs, skip the authenticated legs.
+
+### What Phase 5 will need (handoff)
+
+- The parity gate green on `main` with zero unresolved deltas, and the pre-prod desktop smoke clean, as the prod-cutover readiness signal.
+- The runbook's worker-log parity artifacts captured at least once on pre-prod.
+- Any delta-fix follow-up PRs merged before prod flip.
+
+## Done criteria
+
+- `e2e/` contains four journey specs (chart lifecycle, `.dtx` upload, single download, bulk download) plus a `global.setup` that logs in the test user and seeds one published+uploaded chart; all pass locally with both `E2E_USE_GRAPHQL=false` and `=true`.
+- `playwright.config.ts` reads `E2E_USE_GRAPHQL`, sets the flag + `PUBLIC_DTX_API_URL` on the `dtx-web` webServer, and boots a `dtx-api` `wrangler dev` webServer with a shared `--persist-to` on the flag-ON leg; D1 migrations are applied before the suites in both legs.
+- `.github/workflows/e2e-test.yml` runs the `use_graphql: [false, true]` matrix; both legs must be green for the job to pass; the gate is wired to the `E2E_*` test-Supabase vars/secrets.
+- The dedicated test Supabase project and the four `E2E_*` CI vars/secrets are documented in the runbook.
+- `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is committed and complete (no TBDs).
+- No change to `packages/dtx-api` logic, `packages/dtx-web`/`dtx-desktop`/`common` app code, or any deployed `PUBLIC_USE_GRAPHQL_API` value.
+- Existing unit/component suites and `bun run --filter=@dtx/common test` still pass; root `bun run lint` passes.
+- Zero changes outside `e2e/`, `playwright.config.ts`, `.github/workflows/`, the new `docs/` files, and (if required by the harness) root-level test dev-dependencies/config. No app-code or deployed-config changes.

--- a/docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md
+++ b/docs/superpowers/specs/2026-05-29-api-migration-phase-4-design.md
@@ -74,7 +74,7 @@ Principles:
 - **One shared local D1/R2 _within_ Leg B.** In the flag-ON leg, `dtx-web`'s blog SSR reads `dtx-web`'s D1 directly (the SSR read is not migrated until Phase 6), while the client's anonymous download hits `dtx-api`'s R2. Both must observe the same seeded chart, so `dtx-web` and `dtx-api` run their Miniflare against a **shared `--persist-to` directory** in Leg B. Leg A only needs `dtx-web`'s bindings.
 - **Real Supabase control plane, local data plane.** The dedicated test Supabase project issues and validates tokens for both paths (cookie for `dtx-web`, bearer for `dtx-api`). All _application_ data (charts, files, user profiles) lives in local Miniflare D1/R2 — never in Supabase, never in pre-prod.
 - **Flag toggling via public env vars at dev-server launch.** An `E2E_USE_GRAPHQL` switch read by `playwright.config.ts` selects the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, plus `PUBLIC_DTX_API_URL` when ON) and decides whether to also boot the `dtx-api` webServer.
-- **`dtx-web` bindings in dev.** Default approach: `@sveltejs/adapter-cloudflare`'s platformProxy surfaces `platform.env` from `wrangler.jsonc` bindings against local Miniflare under `vite dev`. Fallback if that does not surface cleanly: run `dtx-web` via `wrangler dev` on the built worker. This is the single piece proven out first in the implementation plan; nothing else depends on which option wins.
+- **`dtx-web` bindings in dev — confirmed by a live spike.** Plain `vite dev` returns a **mock D1** (`getDb` falls back to `createMockD1Database()` because `platform` is `undefined`), so the existing dev server has no real bindings. Enabling `@sveltejs/adapter-cloudflare` (v7) `platformProxy` in `svelte.config.js` surfaces **real local Miniflare** `platform.env.DB`/`DTXFILE_BUCKET`/`RATE_LIMIT` under `vite dev` (verified: a published-list probe then produced a genuine `D1_ERROR: no such table` against an empty local DB, not mock data). So `platformProxy` is the chosen mechanism — fast `vite dev` with real bindings, no `wrangler dev` build step for `dtx-web`. The one bookkeeping detail the spike surfaced: getPlatformProxy and `wrangler d1 execute --persist-to` must be pointed at the **same resolved persist directory**, and **migrations must be applied before the dev server starts** (Miniflare caches the DB connection, so a mid-session `wrangler d1 execute` is not observed). The plan's first task pins the exact persist path and the migrate-then-start ordering.
 
 ### The four critical-journey specs
 
@@ -91,7 +91,7 @@ A seed step (authenticated API calls against the running local stack) creates on
 
 Each journey asserts only on visible UI, URL, and downloaded-file outcomes, so the _same_ assertions hold whether the bytes came from REST or GraphQL — that is the parity proof. The existing eight unauthenticated tool/UI specs remain unchanged and continue to run in both legs (cheap, and they confirm the client-only paths are flag-agnostic).
 
-### Test Supabase project + secrets
+### Test Supabase project + hardcoded credentials
 
 A dedicated Supabase project (e.g. `drumery-e2e`) used **only** by the parity gate:
 
@@ -99,20 +99,21 @@ A dedicated Supabase project (e.g. `drumery-e2e`) used **only** by the parity ga
 - Email confirmation disabled / auto-confirm so the test user is provisioned once and signed in headlessly.
 - Local `dtx-web` and `dtx-api` both point `SUPABASE_URL`/`SUPABASE_ANON_KEY` at this project during e2e so cookie auth (`dtx-web`) and bearer verification (`dtx-api` `verifyToken`) resolve against the same identity.
 
-New CI vars/secrets (GitHub Actions):
+**Credentials are hardcoded in a committed `e2e/test-config.ts`, not GitHub secrets.** This is safe precisely because the project is a throwaway test instance with no real data: a Supabase **anon key is public by design** (it already ships in client bundles), and the test-user password guards only an isolated project. Hardcoding removes all CI secret wiring and lets the **full gate run on every PR, including forks**.
 
-| Name                     | Kind   | Use                                      |
-| ------------------------ | ------ | ---------------------------------------- |
-| `E2E_SUPABASE_URL`       | var    | test project URL (`dtx-web` + `dtx-api`) |
-| `E2E_SUPABASE_ANON_KEY`  | secret | test project anon key                    |
-| `E2E_TEST_USER_EMAIL`    | secret | login in `global.setup`                  |
-| `E2E_TEST_USER_PASSWORD` | secret | login in `global.setup`                  |
+```ts
+// e2e/test-config.ts (committed)
+export const TEST_SUPABASE_URL = 'https://<drumery-e2e>.supabase.co';
+export const TEST_SUPABASE_ANON_KEY = '<anon-key>'; // public by design
+export const TEST_USER_EMAIL = 'e2e@drumery.test';
+export const TEST_USER_PASSWORD = '<throwaway-password>';
+```
 
-For the parity gate, the existing `PUBLIC_SUPABASE_*` wiring in `e2e-test.yml` is sourced from these `E2E_*` values. The test user is created once out-of-band (documented in the runbook), not on every run.
+`playwright.config.ts` injects these into the `dtx-web` webServer env (`PUBLIC_SUPABASE_URL`/`PUBLIC_SUPABASE_ANON_KEY`) and, on the flag-ON leg, into the `dtx-api` webServer env (`SUPABASE_URL`/`SUPABASE_ANON_KEY`); `global.setup` reads the user creds directly. The test user is created once out-of-band (documented in the runbook), not on every run. Only test-instance values ever get hardcoded — prod/pre-prod credentials never do.
 
 ### CI workflow — the parity matrix
 
-`.github/workflows/e2e-test.yml` gains a matrix leg:
+`.github/workflows/e2e-test.yml` gains a matrix leg — no secret wiring, since the test creds are hardcoded in `e2e/test-config.ts`:
 
 ```yaml
 strategy:
@@ -120,22 +121,17 @@ strategy:
         use_graphql: [false, true]
 env:
     E2E_USE_GRAPHQL: ${{ matrix.use_graphql }}
-    PUBLIC_SUPABASE_URL: ${{ vars.E2E_SUPABASE_URL }}
-    PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
-    E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
-    E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
-    # dtx-api SUPABASE_* are set to the same test project for the flag-ON leg
 ```
 
-- `playwright.config.ts` reads `E2E_USE_GRAPHQL`. It sets the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, and `PUBLIC_DTX_API_URL=http://localhost:8787` when ON), and — when ON — declares a **second `webServer`** that boots `dtx-api` via `wrangler dev` with a shared `--persist-to` directory.
-- D1 migrations (`packages/dtx-web/d1-migrations/`) are applied to the local D1 before the suites in both legs; the seed runs in `global.setup`.
-- Both legs must be green for the job to pass. This realizes the parent spec's "run twice" transition gate.
+- `playwright.config.ts` reads `E2E_USE_GRAPHQL`. It sets the `dtx-web` webServer env (`PUBLIC_USE_GRAPHQL_API`, the test Supabase URL/anon-key from `e2e/test-config.ts`, and `PUBLIC_DTX_API_URL=http://localhost:8787` when ON), and — when ON — declares a **second `webServer`** that boots `dtx-api` via `wrangler dev` with a shared `--persist-to` directory and the same test Supabase env.
+- D1 migrations (`packages/dtx-web/d1-migrations/`) are applied to the resolved local persist directory **before** the dev server starts in both legs (the spike showed Miniflare caches the connection, so migrate-then-start is mandatory); the data seed then runs in `global.setup`.
+- Both legs must be green for the job to pass. This realizes the parent spec's "run twice" transition gate, and — because nothing is secret-gated — it runs identically on same-repo and fork PRs.
 
 ### Cutover runbook (committed markdown, executed by a human)
 
 `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` — a checklist authored here but **run by the operator**, because it requires the Cloudflare dashboard, a real interactive login, and human observation:
 
-1. **One-time setup:** create the test Supabase project; create the e2e test user; add the four `E2E_*` CI vars/secrets.
+1. **One-time setup:** create the test Supabase project (auto-confirm signups); create the e2e test user; paste the project URL, anon key, and test-user creds into `e2e/test-config.ts`. No CI secrets to add.
 2. **Flag-ON on pre-prod:** deploy `dtx-web` to pre-prod with `PUBLIC_USE_GRAPHQL_API` overridden to `true` (CLI var override or dashboard). The committed config stays `false`.
 3. **Manual smoke** of every web call-site against `api.pre-prod.dtx.hapadona.com`: login, list, edit, delete, single + bulk download, magic link. DevTools Network confirms requests hit `api.pre-prod`.
 4. **Worker-log parity capture:** `wrangler tail` on both `dtx-web` (pre-prod) and `dtx-api-pre-prod` during the smoke; save logs for delta comparison against a flag-OFF baseline run.
@@ -150,22 +146,23 @@ The gate proves parity at the **observable-outcome** layer (rendered UI, navigat
 
 ### Risks & mitigations
 
-| Risk                                                                                 | Mitigation                                                                                                                                                                           |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| adapter-cloudflare platformProxy does not surface `platform.env` under `vite dev`    | Proven out in the plan's first task before journeys are written; fallback is `wrangler dev` on the built `dtx-web` worker. Blocks nothing downstream.                                |
-| Shared `--persist-to` race between `dtx-web` and `dtx-api` in Leg B                  | Apply migrations + seed before either server accepts traffic; Playwright `webServer.url` health-gates startup ordering; seed is idempotent.                                          |
-| Cross-leg test/data bleed                                                            | Each matrix leg is a fresh CI job with its own Miniflare + persist dir + per-leg seed. No cross-leg shared state.                                                                    |
-| Real Supabase dependency makes the gate flaky if Supabase is unavailable             | Accepted and bounded: only token issuance/validation touches Supabase. Documented; existing `retries: 2` (on CI) absorbs transient failures.                                         |
-| Access-token expiry mid-suite                                                        | `global.setup` signs in fresh per run; suites are short; access-token TTL far exceeds suite runtime.                                                                                 |
-| CI secrets unavailable on fork PRs                                                   | Authenticated legs require `E2E_*` secrets; on fork PRs they are skipped (documented), matching today's secret-gated workflow. Same-repo PRs and pushes to `main` run the full gate. |
-| Bulk-download rate limit (`RATE_LIMIT` / `RATE_LIMIT_API` KV) trips during the suite | Local KV is empty per leg; the suite seeds/selects only two charts — well within limits.                                                                                             |
-| Doubling CI time (two legs)                                                          | Legs run in parallel via the matrix; the flag-OFF leg is the existing cost, the flag-ON leg adds a `wrangler dev` boot. Acceptable for a pre-cutover gate.                           |
+| Risk                                                                                 | Mitigation                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Persist-path mismatch / migrate-after-start so the dev server reads an empty DB      | **Resolved approach (from the live spike):** `platformProxy` does surface real bindings; the gate must point getPlatformProxy and `wrangler` at the same persist dir and migrate **before** server start. The plan's first task pins the exact path + ordering with a round-trip read-back assertion; fallback is `wrangler dev` on the built `dtx-web` worker. |
+| Shared `--persist-to` race between `dtx-web` and `dtx-api` in Leg B                  | Apply migrations + seed before either server accepts traffic; Playwright `webServer.url` health-gates startup ordering; seed is idempotent.                                                                                                                                                                                                                     |
+| Cross-leg test/data bleed                                                            | Each matrix leg is a fresh CI job with its own Miniflare + persist dir + per-leg seed. No cross-leg shared state.                                                                                                                                                                                                                                               |
+| Real Supabase dependency makes the gate flaky if Supabase is unavailable             | Accepted and bounded: only token issuance/validation touches Supabase. Documented; existing `retries: 2` (on CI) absorbs transient failures.                                                                                                                                                                                                                    |
+| Access-token expiry mid-suite                                                        | `global.setup` signs in fresh per run; suites are short; access-token TTL far exceeds suite runtime.                                                                                                                                                                                                                                                            |
+| Hardcoded test creds leak or get reused                                              | Only an isolated throwaway Supabase test project is hardcoded; the anon key is public by design and the project holds no real data. Never hardcode prod/pre-prod creds. Benefit: the full gate runs on every PR (incl. forks) with no secret wiring.                                                                                                            |
+| Bulk-download rate limit (`RATE_LIMIT` / `RATE_LIMIT_API` KV) trips during the suite | Local KV is empty per leg; the suite seeds/selects only two charts — well within limits.                                                                                                                                                                                                                                                                        |
+| Doubling CI time (two legs)                                                          | Legs run in parallel via the matrix; the flag-OFF leg is the existing cost, the flag-ON leg adds a `wrangler dev` boot. Acceptable for a pre-cutover gate.                                                                                                                                                                                                      |
 
 ### Decisions log (pinned by this spec)
 
 1. **Phase 4 delivers both the automated dual-path parity gate and the live cutover runbook.** (Scope chosen over runbook-only / gate-only / decompose.)
 2. **The parity gate uses a hermetic local stack:** local Miniflare D1/R2, real Supabase only for token issuance/validation. No offline-JWT path is introduced.
-3. **A dedicated test Supabase project** backs e2e auth — isolated from prod and pre-prod identities.
+3. **A dedicated test Supabase project** backs e2e auth — isolated from prod and pre-prod identities. Its credentials are **hardcoded in a committed `e2e/test-config.ts`** (anon key is public; throwaway project), so the gate needs no CI secrets and runs on every PR including forks.
+   3a. **`dtx-web` gets real dev bindings via adapter-cloudflare `platformProxy`** (confirmed by a live spike), not `wrangler dev`; migrations are applied to the shared persist dir before server start.
 4. **Two independent CI legs** (`use_graphql: [false, true]`) prove parity via identical assertions, rather than sharing one dataset across flag states.
 5. **`dtx-web` and `dtx-api` share one `--persist-to` dir within the flag-ON leg** so blog SSR (dtx-web D1) and anonymous download (dtx-api R2) see the same seed.
 6. **No change to `packages/dtx-api`** (including `verifyToken.ts`) and **no change to deployed flag values.** Delta fixes from the runbook land as a separate follow-up PR.
@@ -174,11 +171,10 @@ The gate proves parity at the **observable-outcome** layer (rendered UI, navigat
 
 ### Open questions deferred to implementation
 
-- platformProxy vs `wrangler dev` for `dtx-web`'s dev-server bindings (default platformProxy; decided by the plan's first task).
-- Exact local ports for `dtx-api` (`8787` assumed) and the `--persist-to` path (`.e2e-state` assumed); finalized in `playwright.config.ts`.
+- The exact resolved persist directory shared by getPlatformProxy and `wrangler` (the spike showed they can diverge), and whether Leg B shares state cleanest via both servers on `wrangler dev --persist-to` or `dtx-web` on `platformProxy` + `dtx-api` on `wrangler dev` pointed at the same dir; decided by the plan's first task with a read-back assertion.
+- Exact local port for `dtx-api` (`8787` assumed) and the `--persist-to` path; finalized in `playwright.config.ts`.
 - Whether the seed runs entirely in `global.setup` via API calls or partly via `wrangler d1 execute` for the published-chart fixture; default: API calls so the seed is path-honest, with a direct R2/D1 write only if an API-only seed proves circular.
 - Whether to model the two legs as a GitHub matrix (assumed) or as two Playwright `projects` with separate webServers in one job; default: matrix for isolation + parallelism.
-- Whether fork-PR runs skip the gate entirely or run only the unauthenticated specs; default: run unauthenticated specs, skip the authenticated legs.
 
 ### What Phase 5 will need (handoff)
 
@@ -190,8 +186,8 @@ The gate proves parity at the **observable-outcome** layer (rendered UI, navigat
 
 - `e2e/` contains four journey specs (chart lifecycle, `.dtx` upload, single download, bulk download) plus a `global.setup` that logs in the test user and seeds one published+uploaded chart; all pass locally with both `E2E_USE_GRAPHQL=false` and `=true`.
 - `playwright.config.ts` reads `E2E_USE_GRAPHQL`, sets the flag + `PUBLIC_DTX_API_URL` on the `dtx-web` webServer, and boots a `dtx-api` `wrangler dev` webServer with a shared `--persist-to` on the flag-ON leg; D1 migrations are applied before the suites in both legs.
-- `.github/workflows/e2e-test.yml` runs the `use_graphql: [false, true]` matrix; both legs must be green for the job to pass; the gate is wired to the `E2E_*` test-Supabase vars/secrets.
-- The dedicated test Supabase project and the four `E2E_*` CI vars/secrets are documented in the runbook.
+- `.github/workflows/e2e-test.yml` runs the `use_graphql: [false, true]` matrix; both legs must be green for the job to pass; no CI secrets are required (test creds live in `e2e/test-config.ts`).
+- `e2e/test-config.ts` holds the hardcoded test-Supabase URL/anon-key + test-user creds; the dedicated test Supabase project + test user are documented in the runbook.
 - `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is committed and complete (no TBDs).
 - No change to `packages/dtx-api` logic, `packages/dtx-web`/`dtx-desktop`/`common` app code, or any deployed `PUBLIC_USE_GRAPHQL_API` value.
 - Existing unit/component suites and `bun run --filter=@dtx/common test` still pass; root `bun run lint` passes.

--- a/e2e/auth-lifecycle.spec.ts
+++ b/e2e/auth-lifecycle.spec.ts
@@ -28,7 +28,7 @@ test.describe('authenticated chart lifecycle (dual-path)', () => {
 		await expect(card).toBeVisible();
 
 		// getSimfile — open the detail page via the card Actions → Edit menu item.
-		// ChartListItem.svelte:95-99: <button aria-label="Actions"> (EllipsisVertical icon)
+		// ChartListItem.svelte:88-96: Popover triggerAriaLabel="Actions" (EllipsisVertical icon)
 		await card.getByRole('button', { name: 'Actions' }).click();
 		// ChartListItem.svelte:131-150: <a href="/app/chart/${item.id}" role="menuitem">Edit</a>
 		await page.getByRole('menuitem', { name: 'Edit' }).click();
@@ -50,7 +50,7 @@ test.describe('authenticated chart lifecycle (dual-path)', () => {
 		await page.goto('/app/chart');
 		await page.waitForSelector('html[data-e2e-hydrated="true"]');
 		const cardAgain = page.locator('.music-card', { hasText: CHART_A_TITLE });
-		// ChartListItem.svelte:95-99: <button aria-label="Actions">
+		// ChartListItem.svelte:88-96: Popover triggerAriaLabel="Actions"
 		await cardAgain.getByRole('button', { name: 'Actions' }).click();
 		// ChartListItem.svelte:185-209: <Button variant="menuItem" ...>Delete</Button>
 		// variant="menuItem" renders as a plain <button>; text is "Delete".

--- a/e2e/auth-lifecycle.spec.ts
+++ b/e2e/auth-lifecycle.spec.ts
@@ -60,7 +60,7 @@ test.describe('authenticated chart lifecycle (dual-path)', () => {
 		const dialog = page.getByRole('dialog');
 		// Modal.svelte:119-125: <button type="button">{confirmText}</button>
 		// ChartListItem.svelte:328: confirmText="Delete"
-		await dialog.getByRole('button', { name: /delete/i }).click();
+		await dialog.getByRole('button', { name: 'Delete' }).first().click();
 
 		// ChartList.svelte:162-165: toastStore.success({ title: 'Chart deleted', ... })
 		await expect(page.getByText('Chart deleted')).toBeVisible();

--- a/e2e/auth-lifecycle.spec.ts
+++ b/e2e/auth-lifecycle.spec.ts
@@ -4,9 +4,10 @@ import { CHART_A_ID, CHART_A_TITLE } from './test-config';
 test.use({ storageState: 'e2e/.auth/user.json' });
 
 test.describe('authenticated chart lifecycle (dual-path)', () => {
-	// NOTE: this test DELETES chart A as its terminal action. The seed runs once per leg (not
-	// per test), so a Playwright retry would find chart A already gone. Keep delete last and,
-	// if cross-retry flakiness appears, add `test.describe.configure({ retries: 0 })` here.
+	// This test DELETES chart A as its terminal action. The seed runs once per leg (not
+	// per test), so a Playwright retry would find chart A already gone. Disable retries
+	// to avoid retry-only failures.
+	test.describe.configure({ retries: 0 });
 	//
 	// NOTE: the Actions menu uses Skeleton's <Popover>, which renders its content in a body
 	// portal and only while open. Both seeded charts (1001 + 1002) are owned by the test user,

--- a/e2e/auth-lifecycle.spec.ts
+++ b/e2e/auth-lifecycle.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { CHART_A_ID, CHART_A_TITLE } from './test-config';
+
+test.use({ storageState: 'e2e/.auth/user.json' });
+
+test.describe('authenticated chart lifecycle (dual-path)', () => {
+	// NOTE: this test DELETES chart A as its terminal action. The seed runs once per leg (not
+	// per test), so a Playwright retry would find chart A already gone. Keep delete last and,
+	// if cross-retry flakiness appears, add `test.describe.configure({ retries: 0 })` here.
+	//
+	// NOTE: the Actions menu uses Skeleton's <Popover>, which renders its content in a body
+	// portal and only while open. Both seeded charts (1001 + 1002) are owned by the test user,
+	// so /app/chart shows two cards — but only the OPEN card's menu items exist in the DOM.
+	// That is why the Edit/Delete menu items are selected page-level (NOT scoped to the card):
+	// scoping to the card would miss the portaled content, and page-level still matches exactly
+	// one element because closed popovers render nothing.
+
+	test('list → open detail → edit/save → delete', async ({ page }) => {
+		// listSimfiles(MINE)
+		await page.goto('/app/chart');
+		await page.waitForSelector('html[data-e2e-hydrated="true"]');
+		// ChartList.svelte:484-510 — card view renders each chart in a ChartListItem; the
+		// ChartListItem root element (ChartListItem.svelte:58) has class "music-card".
+		// The filter bar also uses "music-card" (ChartList.svelte:241) but lacks the chart
+		// title text, so hasText scopes correctly to the chart card.
+		const card = page.locator('.music-card', { hasText: CHART_A_TITLE });
+		await expect(card).toBeVisible();
+
+		// getSimfile — open the detail page via the card Actions → Edit menu item.
+		// ChartListItem.svelte:95-99: <button aria-label="Actions"> (EllipsisVertical icon)
+		await card.getByRole('button', { name: 'Actions' }).click();
+		// ChartListItem.svelte:131-150: <a href="/app/chart/${item.id}" role="menuitem">Edit</a>
+		await page.getByRole('menuitem', { name: 'Edit' }).click();
+		await expect(page).toHaveURL(new RegExp(`/app/chart/${CHART_A_ID}$`));
+		// ChartDetail.svelte:96: <h1 ...>{simfile?.title}</h1>
+		await expect(page.getByRole('heading', { level: 1, name: CHART_A_TITLE })).toBeVisible();
+
+		// updateSimfile — fill the download link field and save.
+		// ChartDetail.svelte:200-206: <input id="download_link" ...>
+		await page.locator('#download_link').fill('https://example.com/e2e-edit');
+		// ChartDetail.svelte:244-247: <button ...>{saveButtonText}</button>
+		// saveButtonText defaults to 'Update' (ChartDetail.svelte:23).
+		await page.getByRole('button', { name: 'Update' }).click();
+		// routes/(app)/app/chart/[id]/+page.svelte:64-67:
+		// toastStore.success({ title: 'Simfile updated successfully', ... })
+		await expect(page.getByText('Simfile updated successfully')).toBeVisible();
+
+		// deleteSimfile — back to the list, delete chart A via Actions → Delete → confirm.
+		await page.goto('/app/chart');
+		await page.waitForSelector('html[data-e2e-hydrated="true"]');
+		const cardAgain = page.locator('.music-card', { hasText: CHART_A_TITLE });
+		// ChartListItem.svelte:95-99: <button aria-label="Actions">
+		await cardAgain.getByRole('button', { name: 'Actions' }).click();
+		// ChartListItem.svelte:185-209: <Button variant="menuItem" ...>Delete</Button>
+		// variant="menuItem" renders as a plain <button>; text is "Delete".
+		await page.getByRole('button', { name: 'Delete' }).click();
+		// ChartListItem.svelte:323-364 + Modal.svelte:73-83:
+		// <div role="dialog" aria-modal="true" ...> wraps the confirmation UI.
+		const dialog = page.getByRole('dialog');
+		// Modal.svelte:119-122: <button type="button">{confirmText}</button>
+		// ChartListItem.svelte:328: confirmText="Delete"
+		await dialog.getByRole('button', { name: /delete/i }).click();
+
+		// ChartList.svelte:162-165: toastStore.success({ title: 'Chart deleted', ... })
+		await expect(page.getByText('Chart deleted')).toBeVisible();
+		await expect(page.locator('.music-card', { hasText: CHART_A_TITLE })).toHaveCount(0);
+	});
+});

--- a/e2e/auth-lifecycle.spec.ts
+++ b/e2e/auth-lifecycle.spec.ts
@@ -39,8 +39,8 @@ test.describe('authenticated chart lifecycle (dual-path)', () => {
 		// updateSimfile — fill the download link field and save.
 		// ChartDetail.svelte:200-206: <input id="download_link" ...>
 		await page.locator('#download_link').fill('https://example.com/e2e-edit');
-		// ChartDetail.svelte:244-247: <button ...>{saveButtonText}</button>
-		// saveButtonText defaults to 'Update' (ChartDetail.svelte:23).
+		// ChartDetail.svelte:235-247: <button ...>{saveButtonText}</button>
+		// saveButtonText defaults to 'Update' (ChartDetail.svelte:44).
 		await page.getByRole('button', { name: 'Update' }).click();
 		// routes/(app)/app/chart/[id]/+page.svelte:64-67:
 		// toastStore.success({ title: 'Simfile updated successfully', ... })
@@ -58,7 +58,7 @@ test.describe('authenticated chart lifecycle (dual-path)', () => {
 		// ChartListItem.svelte:323-364 + Modal.svelte:73-83:
 		// <div role="dialog" aria-modal="true" ...> wraps the confirmation UI.
 		const dialog = page.getByRole('dialog');
-		// Modal.svelte:119-122: <button type="button">{confirmText}</button>
+		// Modal.svelte:119-125: <button type="button">{confirmText}</button>
 		// ChartListItem.svelte:328: confirmText="Delete"
 		await dialog.getByRole('button', { name: /delete/i }).click();
 

--- a/e2e/blog-download.spec.ts
+++ b/e2e/blog-download.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { CHART_B_TITLE } from './test-config';
+
+// anonymous — explicitly no stored auth.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('anonymous blog browse + single download (dual-path)', () => {
+	test('published chart appears and downloads', async ({ page }) => {
+		// The same-origin REST download endpoint (OFF leg) rate-limits by client IP via
+		// getClientIp (cf-connecting-ip / x-forwarded-for). `vite dev` does not inject one,
+		// so the handler would 400 ("Unable to determine client IP"). Supply x-forwarded-for
+		// ONLY for same-origin (:5173) requests — it is a request header, not auth, so the
+		// journey stays anonymous. It must NOT be added to cross-origin dtx-api (:8787)
+		// requests in the ON leg: that would force a CORS preflight whose response does not
+		// allow x-forwarded-for, blocking the call. (The ON-leg worker, run via `wrangler dev`,
+		// supplies cf-connecting-ip itself, so no header is needed there.)
+		await page.route('http://localhost:5173/**', async (route) => {
+			await route.continue({
+				headers: { ...route.request().headers(), 'x-forwarded-for': '127.0.0.1' }
+			});
+		});
+
+		// listSimfiles(PUBLISHED)
+		await page.goto('/blog');
+		await page.waitForSelector('html[data-e2e-hydrated="true"]');
+
+		// Scope to chart B's card (the filter-bar .music-card lacks the title).
+		const card = page.locator('.music-card', { hasText: CHART_B_TITLE });
+		await expect(card).toBeVisible();
+
+		// downloadSimfile — click the per-card Download button (aria-label resolves to
+		// "Download" via chart_actions.download), capture the browser download.
+		const downloadPromise = page.waitForEvent('download');
+		await card.getByRole('button', { name: /download/i }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toMatch(/\.zip$/);
+	});
+});

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -1,0 +1,19 @@
+import { test as setup, expect } from '@playwright/test';
+import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from './test-config';
+
+const authFile = 'e2e/.auth/user.json';
+
+setup('authenticate test user', async ({ page }) => {
+	await page.goto('/login');
+	await page.waitForSelector('html[data-e2e-hydrated="true"]');
+
+	await page.locator('#email').fill(TEST_USER_EMAIL);
+	await page.locator('#password').fill(TEST_USER_PASSWORD);
+	await page.getByRole('button', { name: 'Login' }).click();
+
+	// Successful login redirects to /app.
+	await page.waitForURL('**/app');
+	await expect(page).toHaveURL(/\/app(\?|$)/);
+
+	await page.context().storageState({ path: authFile });
+});

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -1,4 +1,6 @@
 import { test as setup, expect } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from './test-config';
 
 const authFile = 'e2e/.auth/user.json';
@@ -15,5 +17,6 @@ setup('authenticate test user', async ({ page }) => {
 	await page.waitForURL('**/app');
 	await expect(page).toHaveURL(/\/app(\?|$)/);
 
+	mkdirSync(dirname(authFile), { recursive: true });
 	await page.context().storageState({ path: authFile });
 });

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -13,8 +13,15 @@ setup('authenticate test user', async ({ page }) => {
 	await page.locator('#password').fill(TEST_USER_PASSWORD);
 	await page.getByRole('button', { name: 'Login' }).click();
 
-	// Successful login redirects to /app.
-	await page.waitForURL('**/app');
+	// Race navigation against a visible login-error so failures read as
+	// "login failed: <error text>" instead of a generic navigation timeout.
+	const loginError = page.locator('[data-error], .error, [role="alert"]').first();
+	await Promise.race([
+		page.waitForURL('**/app'),
+		loginError.waitFor({ state: 'visible', timeout: 15_000 }).then(async () => {
+			throw new Error(`Login failed: ${(await loginError.textContent()) || 'unknown error'}`);
+		})
+	]);
 	await expect(page).toHaveURL(/\/app(\?|$)/);
 
 	mkdirSync(dirname(authFile), { recursive: true });

--- a/e2e/setup/create-local-supabase-user.ts
+++ b/e2e/setup/create-local-supabase-user.ts
@@ -31,6 +31,10 @@ const createUser = async (): Promise<void> => {
 		return;
 	}
 
+	if (response.status === 409) {
+		return;
+	}
+
 	const body = await response.text();
 	throw new Error(`[create-local-supabase-user] failed (${response.status}): ${body}`);
 };

--- a/e2e/setup/create-local-supabase-user.ts
+++ b/e2e/setup/create-local-supabase-user.ts
@@ -1,0 +1,38 @@
+import { TEST_USER_EMAIL, TEST_USER_ID, TEST_USER_PASSWORD } from '../test-config';
+
+const requireEnv = (name: string): string => {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`[create-local-supabase-user] ${name} is required`);
+	}
+	return value;
+};
+
+const supabaseUrl = requireEnv('E2E_SUPABASE_URL');
+const serviceRoleKey = requireEnv('E2E_SUPABASE_SERVICE_ROLE_KEY');
+
+const createUser = async (): Promise<void> => {
+	const response = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+		method: 'POST',
+		headers: {
+			apikey: serviceRoleKey,
+			Authorization: `Bearer ${serviceRoleKey}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			id: TEST_USER_ID,
+			email: TEST_USER_EMAIL,
+			password: TEST_USER_PASSWORD,
+			email_confirm: true
+		})
+	});
+
+	if (response.ok) {
+		return;
+	}
+
+	const body = await response.text();
+	throw new Error(`[create-local-supabase-user] failed (${response.status}): ${body}`);
+};
+
+await createUser();

--- a/e2e/setup/prepare-stack.ts
+++ b/e2e/setup/prepare-stack.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { TEST_USER_ID, CHART_B_ID } from '../test-config';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
-const repoRoot = join(here, '..', '..');
+const repoRoot = join(here, '..', '..', '..');
 
 const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
 const pkg = useGraphQL ? 'dtx-api' : 'dtx-web';

--- a/e2e/setup/prepare-stack.ts
+++ b/e2e/setup/prepare-stack.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { TEST_USER_ID, CHART_B_ID } from '../test-config';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
-const repoRoot = join(here, '..', '..', '..');
+const repoRoot = join(here, '..', '..');
 
 const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
 const pkg = useGraphQL ? 'dtx-api' : 'dtx-web';

--- a/e2e/setup/prepare-stack.ts
+++ b/e2e/setup/prepare-stack.ts
@@ -27,8 +27,9 @@ const fixture = join(repoRoot, 'e2e/fixtures/test-sample.dtx');
 // is the same one the worker binds as DB in that package.
 const D1_NAME = 'dtx-web';
 
-const wrangler = (args: string[]) =>
+const wrangler = (args: string[]): void => {
 	execFileSync('bunx', ['wrangler', ...args], { cwd: pkgDir, stdio: 'inherit' });
+};
 
 // 1. Fresh state, then apply schema (migration CREATE INDEX lacks IF NOT EXISTS,
 //    so we wipe + re-migrate for a deterministic seed).

--- a/e2e/setup/prepare-stack.ts
+++ b/e2e/setup/prepare-stack.ts
@@ -4,7 +4,7 @@
 //
 // Leg selection: E2E_USE_GRAPHQL === 'true' → seed dtx-api; else → seed dtx-web.
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -19,7 +19,20 @@ const pkgDir = join(repoRoot, 'packages', pkg);
 const persist = '.wrangler/state';
 const absPersist = join(pkgDir, persist);
 const migration = join(repoRoot, 'packages/dtx-web/d1-migrations/0001_initial_schema.sql');
+const seedFile = join(here, 'seed.sql');
 const fixture = join(repoRoot, 'e2e/fixtures/test-sample.dtx');
+
+// Pre-check: all required files must exist before we start, otherwise failures
+// surface as opaque Playwright "webServer timed out after 180s" errors.
+for (const [label, path] of [
+	['D1 migration', migration],
+	['seed SQL', seedFile],
+	['R2 fixture (test-sample.dtx)', fixture]
+] as const) {
+	if (!existsSync(path)) {
+		throw new Error(`[prepare-stack] missing ${label} at ${path}`);
+	}
+}
 
 // The D1 database NAME is "dtx-web" in BOTH packages' wrangler.jsonc (dtx-web and
 // dtx-api share database_name "dtx-web"), so it is correct regardless of the leg's
@@ -27,28 +40,62 @@ const fixture = join(repoRoot, 'e2e/fixtures/test-sample.dtx');
 // is the same one the worker binds as DB in that package.
 const D1_NAME = 'dtx-web';
 
-const wrangler = (args: string[]): void => {
-	execFileSync('bunx', ['wrangler', ...args], { cwd: pkgDir, stdio: 'inherit' });
+const wrangler = (label: string, args: string[]): void => {
+	try {
+		console.log(`[prepare-stack] ${label}...`);
+		execFileSync('bunx', ['wrangler', ...args], { cwd: pkgDir, stdio: 'inherit' });
+	} catch (err) {
+		throw new Error(`[prepare-stack] ${label} failed: ${err}`);
+	}
 };
+
+// Validate TEST_USER_ID is a real UUID before seeding — a placeholder would
+// create garbage ownership rows silently.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+if (!UUID_RE.test(TEST_USER_ID)) {
+	throw new Error(
+		`[prepare-stack] TEST_USER_ID ("${TEST_USER_ID}") is not a valid UUID. ` +
+			'Set E2E_USER_ID in your environment.'
+	);
+}
 
 // 1. Fresh state, then apply schema (migration CREATE INDEX lacks IF NOT EXISTS,
 //    so we wipe + re-migrate for a deterministic seed).
 rmSync(absPersist, { recursive: true, force: true });
-wrangler(['d1', 'execute', D1_NAME, '--local', '--persist-to', persist, '--file', migration]);
+wrangler('apply D1 migration', [
+	'd1',
+	'execute',
+	D1_NAME,
+	'--local',
+	'--persist-to',
+	persist,
+	'--file',
+	migration
+]);
 
 // 2. Seed rows (idempotent: the seed deletes ids 1001/1002 first).
-const seedSql = readFileSync(join(here, 'seed.sql'), 'utf8').replaceAll(
-	'__TEST_USER_ID__',
-	TEST_USER_ID
-);
+const seedSql = readFileSync(seedFile, 'utf8').replaceAll('__TEST_USER_ID__', TEST_USER_ID);
 const tmpSeedDir = mkdtempSync(join(tmpdir(), 'e2e-seed-'));
 const tmpSeed = join(tmpSeedDir, 'seed.sql');
-writeFileSync(tmpSeed, seedSql);
-wrangler(['d1', 'execute', D1_NAME, '--local', '--persist-to', persist, '--file', tmpSeed]);
-rmSync(tmpSeedDir, { recursive: true, force: true });
+try {
+	writeFileSync(tmpSeed, seedSql);
+	wrangler('seed D1 rows', [
+		'd1',
+		'execute',
+		D1_NAME,
+		'--local',
+		'--persist-to',
+		persist,
+		'--file',
+		tmpSeed
+	]);
+} finally {
+	// Always clean up the temp file containing the UUID to avoid leaking on failure.
+	rmSync(tmpSeedDir, { recursive: true, force: true });
+}
 
 // 3. Put the R2 object so chart B reports has_uploaded_files=true and download has content.
-wrangler([
+wrangler('put R2 object', [
 	'r2',
 	'object',
 	'put',

--- a/e2e/setup/prepare-stack.ts
+++ b/e2e/setup/prepare-stack.ts
@@ -1,0 +1,64 @@
+// e2e/setup/prepare-stack.ts
+// Migrate + seed the local Miniflare backend for the current leg, BEFORE the
+// dev server starts. Run by the Playwright webServer command.
+//
+// Leg selection: E2E_USE_GRAPHQL === 'true' → seed dtx-api; else → seed dtx-web.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { TEST_USER_ID, CHART_B_ID } from '../test-config';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(here, '..', '..');
+
+const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
+const pkg = useGraphQL ? 'dtx-api' : 'dtx-web';
+const pkgDir = join(repoRoot, 'packages', pkg);
+const persist = '.wrangler/state';
+const absPersist = join(pkgDir, persist);
+const migration = join(repoRoot, 'packages/dtx-web/d1-migrations/0001_initial_schema.sql');
+const fixture = join(repoRoot, 'e2e/fixtures/test-sample.dtx');
+
+// The D1 database NAME is "dtx-web" in BOTH packages' wrangler.jsonc (dtx-web and
+// dtx-api share database_name "dtx-web"), so it is correct regardless of the leg's
+// pkgDir. The local Miniflare sqlite resolved by `wrangler d1 execute <name> --local`
+// is the same one the worker binds as DB in that package.
+const D1_NAME = 'dtx-web';
+
+const wrangler = (args: string[]) =>
+	execFileSync('bunx', ['wrangler', ...args], { cwd: pkgDir, stdio: 'inherit' });
+
+// 1. Fresh state, then apply schema (migration CREATE INDEX lacks IF NOT EXISTS,
+//    so we wipe + re-migrate for a deterministic seed).
+rmSync(absPersist, { recursive: true, force: true });
+wrangler(['d1', 'execute', D1_NAME, '--local', '--persist-to', persist, '--file', migration]);
+
+// 2. Seed rows (idempotent: the seed deletes ids 1001/1002 first).
+const seedSql = readFileSync(join(here, 'seed.sql'), 'utf8').replaceAll(
+	'__TEST_USER_ID__',
+	TEST_USER_ID
+);
+const tmpSeedDir = mkdtempSync(join(tmpdir(), 'e2e-seed-'));
+const tmpSeed = join(tmpSeedDir, 'seed.sql');
+writeFileSync(tmpSeed, seedSql);
+wrangler(['d1', 'execute', D1_NAME, '--local', '--persist-to', persist, '--file', tmpSeed]);
+rmSync(tmpSeedDir, { recursive: true, force: true });
+
+// 3. Put the R2 object so chart B reports has_uploaded_files=true and download has content.
+wrangler([
+	'r2',
+	'object',
+	'put',
+	`simfile-dtx/${CHART_B_ID}/song.dtx`,
+	'--local',
+	'--persist-to',
+	persist,
+	'--file',
+	fixture
+]);
+
+console.log(
+	`[prepare-stack] seeded ${pkg} local Miniflare (charts 1001/1002 + R2 ${CHART_B_ID}/song.dtx)`
+);

--- a/e2e/setup/prepare-stack.ts
+++ b/e2e/setup/prepare-stack.ts
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'no
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { TEST_USER_ID, CHART_B_ID } from '../test-config';
+import { TEST_USER_ID, CHART_B_ID, isAuthConfigured } from '../test-config';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
 const repoRoot = join(here, '..', '..');
@@ -49,12 +49,17 @@ const wrangler = (label: string, args: string[]): void => {
 	}
 };
 
-// Validate TEST_USER_ID is a real UUID before seeding — a placeholder would
-// create garbage ownership rows silently.
+// When auth env vars are not configured, use a deterministic dummy UUID so
+// non-auth e2e specs can still run (the webServer command always executes
+// prepare-stack before Vite starts, regardless of project filters).
+const DUMMY_USER_ID = '00000000-0000-0000-0000-000000000000';
+const ownerId = isAuthConfigured ? TEST_USER_ID : DUMMY_USER_ID;
+
+// Validate ownerId is a real UUID — a placeholder would create garbage rows.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-if (!UUID_RE.test(TEST_USER_ID)) {
+if (!UUID_RE.test(ownerId)) {
 	throw new Error(
-		`[prepare-stack] TEST_USER_ID ("${TEST_USER_ID}") is not a valid UUID. ` +
+		`[prepare-stack] ownerId ("${ownerId}") is not a valid UUID. ` +
 			'Set E2E_USER_ID in your environment.'
 	);
 }
@@ -74,7 +79,7 @@ wrangler('apply D1 migration', [
 ]);
 
 // 2. Seed rows (idempotent: the seed deletes ids 1001/1002 first).
-const seedSql = readFileSync(seedFile, 'utf8').replaceAll('__TEST_USER_ID__', TEST_USER_ID);
+const seedSql = readFileSync(seedFile, 'utf8').replaceAll('__TEST_USER_ID__', ownerId);
 const tmpSeedDir = mkdtempSync(join(tmpdir(), 'e2e-seed-'));
 const tmpSeed = join(tmpSeedDir, 'seed.sql');
 try {

--- a/e2e/setup/seed.sql
+++ b/e2e/setup/seed.sql
@@ -1,0 +1,12 @@
+-- e2e/setup/seed.sql — idempotent two-chart seed for the parity gate.
+-- TEST_USER_ID is substituted by prepare-stack.ts before execution.
+DELETE FROM dtx_files WHERE simfile_id IN (1001, 1002);
+DELETE FROM simfiles WHERE id IN (1001, 1002);
+
+INSERT INTO simfiles (id, title, artist, bpm, user_id, is_published, display_id)
+VALUES (1001, 'E2E Lifecycle Chart', 'E2E', 120, '__TEST_USER_ID__', 0, 1001);
+
+INSERT INTO simfiles (id, title, artist, bpm, user_id, is_published, display_id)
+VALUES (1002, 'E2E Download Chart', 'E2E', 140, '__TEST_USER_ID__', 1, 1002);
+
+INSERT INTO dtx_files (label, level, simfile_id) VALUES ('BASIC', 50, 1002);

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -22,7 +22,9 @@ export const isAuthConfigured =
 	TEST_USER_PASSWORD !== 'REPLACE_ME_PASSWORD' &&
 	TEST_USER_PASSWORD !== '' &&
 	TEST_USER_ID !== 'REPLACE_ME_UUID' &&
-	TEST_USER_ID !== '';
+	TEST_USER_ID !== '' &&
+	TEST_SUPABASE_URL !== 'https://REPLACE-ME.supabase.co' &&
+	TEST_SUPABASE_ANON_KEY !== 'REPLACE_ME_ANON_KEY';
 
 /** Fixed seed chart ids (see plan's test-data table). */
 export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -1,8 +1,9 @@
 // e2e/test-config.ts
 //
 // Credentials for the DEDICATED, THROWAWAY e2e Supabase project only.
-// Safe to commit: the anon key is public by design (it ships in client bundles),
-// and the test user guards an isolated project with no real data.
+// The anon key is public by design (it ships in client bundles).
+// All other values (URL, email, password, user ID) must be set via
+// environment variables (e.g. GitHub Secrets) — NEVER committed to git.
 // NEVER put prod/pre-prod credentials here.
 //
 // Set these via environment variables (e.g. GitHub Secrets) for CI.
@@ -12,21 +13,28 @@
 export const TEST_SUPABASE_URL: string =
 	process.env.E2E_SUPABASE_URL || 'https://REPLACE-ME.supabase.co';
 export const TEST_SUPABASE_ANON_KEY: string =
-	process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design
-export const TEST_USER_EMAIL: string = process.env.E2E_USER_EMAIL || 'e2e@drumery.test';
+	process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design — ships in client bundles
+export const TEST_USER_EMAIL: string = process.env.E2E_USER_EMAIL || 'REPLACE_ME_EMAIL';
 export const TEST_USER_PASSWORD: string = process.env.E2E_USER_PASSWORD || 'REPLACE_ME_PASSWORD';
 
 /** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
 export const TEST_USER_ID: string = process.env.E2E_USER_ID || 'REPLACE_ME_UUID';
 
-/** True when the resolved credentials are non-placeholder values (env vars or committed defaults). */
+/** Placeholder sentinel used to detect unset env vars. */
+const PLACEHOLDER = (v: string) => v.startsWith('REPLACE_ME') || v === '';
+
+/**
+ * True only when ALL six credential env vars are set to non-placeholder values.
+ * Any partial configuration would produce confusing mid-test failures (e.g. a real
+ * Supabase URL but a placeholder anon key boots a half-configured client), so this
+ * is all-or-nothing.
+ */
 export const isAuthConfigured =
-	TEST_USER_PASSWORD !== 'REPLACE_ME_PASSWORD' &&
-	TEST_USER_PASSWORD !== '' &&
-	TEST_USER_ID !== 'REPLACE_ME_UUID' &&
-	TEST_USER_ID !== '' &&
-	TEST_SUPABASE_URL !== 'https://REPLACE-ME.supabase.co' &&
-	TEST_SUPABASE_ANON_KEY !== 'REPLACE_ME_ANON_KEY';
+	!PLACEHOLDER(TEST_SUPABASE_URL) &&
+	!PLACEHOLDER(TEST_SUPABASE_ANON_KEY) &&
+	!PLACEHOLDER(TEST_USER_EMAIL) &&
+	!PLACEHOLDER(TEST_USER_PASSWORD) &&
+	!PLACEHOLDER(TEST_USER_ID);
 
 /** Fixed seed chart ids (see plan's test-data table). */
 export const CHART_A_ID: number = 1001; // owned by test user, unpublished — lifecycle journey

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -9,8 +9,8 @@
 // When auth env vars are missing, the setup + chromium-auth projects are
 // excluded so non-auth tests still pass.
 
-export const TEST_SUPABASE_URL = process.env.E2E_SUPABASE_URL ?? 'https://REPLACE-ME.supabase.co';
-export const TEST_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY ?? 'REPLACE_ME_ANON_KEY'; // public by design
+export const TEST_SUPABASE_URL = process.env.E2E_SUPABASE_URL || 'https://REPLACE-ME.supabase.co';
+export const TEST_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design
 export const TEST_USER_EMAIL = process.env.E2E_USER_EMAIL ?? 'e2e@drumery.test';
 export const TEST_USER_PASSWORD = process.env.E2E_USER_PASSWORD ?? 'REPLACE_ME_PASSWORD';
 

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -11,7 +11,7 @@
 // excluded so non-auth tests still pass.
 
 export const TEST_SUPABASE_URL: string =
-	process.env.E2E_SUPABASE_URL || 'https://REPLACE-ME.supabase.co';
+	process.env.E2E_SUPABASE_URL || 'https://REPLACE_ME.supabase.co';
 export const TEST_SUPABASE_ANON_KEY: string =
 	process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design — ships in client bundles
 export const TEST_USER_EMAIL: string = process.env.E2E_USER_EMAIL || 'REPLACE_ME_EMAIL';

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -9,13 +9,15 @@
 // When auth env vars are missing, the setup + chromium-auth projects are
 // excluded so non-auth tests still pass.
 
-export const TEST_SUPABASE_URL = process.env.E2E_SUPABASE_URL || 'https://REPLACE-ME.supabase.co';
-export const TEST_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design
-export const TEST_USER_EMAIL = process.env.E2E_USER_EMAIL || 'e2e@drumery.test';
-export const TEST_USER_PASSWORD = process.env.E2E_USER_PASSWORD || 'REPLACE_ME_PASSWORD';
+export const TEST_SUPABASE_URL: string =
+	process.env.E2E_SUPABASE_URL || 'https://REPLACE-ME.supabase.co';
+export const TEST_SUPABASE_ANON_KEY: string =
+	process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design
+export const TEST_USER_EMAIL: string = process.env.E2E_USER_EMAIL || 'e2e@drumery.test';
+export const TEST_USER_PASSWORD: string = process.env.E2E_USER_PASSWORD || 'REPLACE_ME_PASSWORD';
 
 /** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
-export const TEST_USER_ID = process.env.E2E_USER_ID || 'REPLACE_ME_UUID';
+export const TEST_USER_ID: string = process.env.E2E_USER_ID || 'REPLACE_ME_UUID';
 
 /** True when the resolved credentials are non-placeholder values (env vars or committed defaults). */
 export const isAuthConfigured =
@@ -27,10 +29,10 @@ export const isAuthConfigured =
 	TEST_SUPABASE_ANON_KEY !== 'REPLACE_ME_ANON_KEY';
 
 /** Fixed seed chart ids (see plan's test-data table). */
-export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey
-export const CHART_B_ID = 1002; // published, has R2 file — download journey
-export const CHART_A_TITLE = 'E2E Lifecycle Chart';
-export const CHART_B_TITLE = 'E2E Download Chart';
+export const CHART_A_ID: number = 1001; // owned by test user, unpublished — lifecycle journey
+export const CHART_B_ID: number = 1002; // published, has R2 file — download journey
+export const CHART_A_TITLE: string = 'E2E Lifecycle Chart';
+export const CHART_B_TITLE: string = 'E2E Download Chart';
 
 /** dtx-api local port for the flag-ON leg. */
-export const DTX_API_LOCAL_PORT = 8787;
+export const DTX_API_LOCAL_PORT: number = 8787;

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -11,11 +11,11 @@
 
 export const TEST_SUPABASE_URL = process.env.E2E_SUPABASE_URL || 'https://REPLACE-ME.supabase.co';
 export const TEST_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY || 'REPLACE_ME_ANON_KEY'; // public by design
-export const TEST_USER_EMAIL = process.env.E2E_USER_EMAIL ?? 'e2e@drumery.test';
-export const TEST_USER_PASSWORD = process.env.E2E_USER_PASSWORD ?? 'REPLACE_ME_PASSWORD';
+export const TEST_USER_EMAIL = process.env.E2E_USER_EMAIL || 'e2e@drumery.test';
+export const TEST_USER_PASSWORD = process.env.E2E_USER_PASSWORD || 'REPLACE_ME_PASSWORD';
 
 /** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
-export const TEST_USER_ID = process.env.E2E_USER_ID ?? 'REPLACE_ME_UUID';
+export const TEST_USER_ID = process.env.E2E_USER_ID || 'REPLACE_ME_UUID';
 
 /** True when the resolved credentials are non-placeholder values (env vars or committed defaults). */
 export const isAuthConfigured =

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -1,0 +1,23 @@
+// e2e/test-config.ts
+//
+// Credentials for the DEDICATED, THROWAWAY e2e Supabase project only.
+// Safe to commit: the anon key is public by design (it ships in client bundles),
+// and the test user guards an isolated project with no real data.
+// NEVER put prod/pre-prod credentials here.
+
+export const TEST_SUPABASE_URL = 'https://REPLACE-ME.supabase.co';
+export const TEST_SUPABASE_ANON_KEY = 'REPLACE_ME_ANON_KEY'; // public by design
+export const TEST_USER_EMAIL = 'e2e@drumery.test';
+export const TEST_USER_PASSWORD = 'REPLACE_ME_PASSWORD';
+
+/** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
+export const TEST_USER_ID = 'REPLACE_ME_UUID';
+
+/** Fixed seed chart ids (see plan's test-data table). */
+export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey
+export const CHART_B_ID = 1002; // published, has R2 file — download journey
+export const CHART_A_TITLE = 'E2E Lifecycle Chart';
+export const CHART_B_TITLE = 'E2E Download Chart';
+
+/** dtx-api local port for the flag-ON leg. */
+export const DTX_API_LOCAL_PORT = 8787;

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -17,12 +17,12 @@ export const TEST_USER_PASSWORD = process.env.E2E_USER_PASSWORD ?? 'REPLACE_ME_P
 /** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
 export const TEST_USER_ID = process.env.E2E_USER_ID ?? 'REPLACE_ME_UUID';
 
-/** True when all auth-related env vars are set to non-placeholder values. */
+/** True when the resolved credentials are non-placeholder values (env vars or committed defaults). */
 export const isAuthConfigured =
-	process.env.E2E_USER_PASSWORD !== undefined &&
-	process.env.E2E_USER_PASSWORD !== '' &&
-	process.env.E2E_USER_ID !== undefined &&
-	process.env.E2E_USER_ID !== '';
+	TEST_USER_PASSWORD !== 'REPLACE_ME_PASSWORD' &&
+	TEST_USER_PASSWORD !== '' &&
+	TEST_USER_ID !== 'REPLACE_ME_UUID' &&
+	TEST_USER_ID !== '';
 
 /** Fixed seed chart ids (see plan's test-data table). */
 export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -21,7 +21,7 @@ export const TEST_USER_PASSWORD: string = process.env.E2E_USER_PASSWORD || 'REPL
 export const TEST_USER_ID: string = process.env.E2E_USER_ID || 'REPLACE_ME_UUID';
 
 /** Placeholder sentinel used to detect unset env vars. */
-const PLACEHOLDER = (v: string) => v.startsWith('REPLACE_ME') || v === '';
+const PLACEHOLDER = (v: string) => v.includes('REPLACE_ME') || v === '';
 
 /**
  * True only when ALL six credential env vars are set to non-placeholder values.

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -4,14 +4,25 @@
 // Safe to commit: the anon key is public by design (it ships in client bundles),
 // and the test user guards an isolated project with no real data.
 // NEVER put prod/pre-prod credentials here.
+//
+// Set these via environment variables (e.g. GitHub Secrets) for CI.
+// When auth env vars are missing, the setup + chromium-auth projects are
+// excluded so non-auth tests still pass.
 
-export const TEST_SUPABASE_URL = 'https://REPLACE-ME.supabase.co';
-export const TEST_SUPABASE_ANON_KEY = 'REPLACE_ME_ANON_KEY'; // public by design
-export const TEST_USER_EMAIL = 'e2e@drumery.test';
-export const TEST_USER_PASSWORD = 'REPLACE_ME_PASSWORD';
+export const TEST_SUPABASE_URL = process.env.E2E_SUPABASE_URL ?? 'https://REPLACE-ME.supabase.co';
+export const TEST_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY ?? 'REPLACE_ME_ANON_KEY'; // public by design
+export const TEST_USER_EMAIL = process.env.E2E_USER_EMAIL ?? 'e2e@drumery.test';
+export const TEST_USER_PASSWORD = process.env.E2E_USER_PASSWORD ?? 'REPLACE_ME_PASSWORD';
 
 /** Supabase auth UUID of TEST_USER_EMAIL. Read once after provisioning (runbook). */
-export const TEST_USER_ID = 'REPLACE_ME_UUID';
+export const TEST_USER_ID = process.env.E2E_USER_ID ?? 'REPLACE_ME_UUID';
+
+/** True when all auth-related env vars are set to non-placeholder values. */
+export const isAuthConfigured =
+	process.env.E2E_USER_PASSWORD !== undefined &&
+	process.env.E2E_USER_PASSWORD !== '' &&
+	process.env.E2E_USER_ID !== undefined &&
+	process.env.E2E_USER_ID !== '';
 
 /** Fixed seed chart ids (see plan's test-data table). */
 export const CHART_A_ID = 1001; // owned by test user, unpublished — lifecycle journey

--- a/packages/dtx-web/src/lib/components/ChartListItem.svelte
+++ b/packages/dtx-web/src/lib/components/ChartListItem.svelte
@@ -89,15 +89,12 @@
 					onOpenChange={(details) => (popoverOpen = details.open)}
 					zIndex="120"
 					positioning={{ placement: 'bottom-start' }}
+					triggerAriaLabel="Actions"
+					triggerClasses="rounded-lg p-2 text-slate-400 transition-all duration-200 hover:bg-purple-600/20 hover:text-purple-300"
 					contentBase="w-48 p-0 rounded-lg border border-purple-500/30 bg-slate-800 shadow-xl backdrop-blur-sm"
 				>
 					{#snippet trigger()}
-						<button
-							aria-label="Actions"
-							class="rounded-lg p-2 text-slate-400 transition-all duration-200 hover:bg-purple-600/20 hover:text-purple-300"
-						>
-							<EllipsisVertical size="18" />
-						</button>
+						<EllipsisVertical size="18" />
 					{/snippet}
 					{#snippet content()}
 						<div class="py-2">

--- a/packages/dtx-web/src/lib/components/ChartListTableItem.svelte
+++ b/packages/dtx-web/src/lib/components/ChartListTableItem.svelte
@@ -56,12 +56,12 @@
 		onOpenChange={(details) => (popoverOpen = details.open)}
 		zIndex="120"
 		positioning={{ placement: 'bottom-start' }}
+		triggerAriaLabel="Actions"
+		triggerClasses="inline-flex h-9 w-9 items-center justify-center rounded p-1 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2"
 		contentBase="w-48 p-0 rounded-sm border border-gray-300 bg-white shadow-lg"
 	>
 		{#snippet trigger()}
-			<Button variant="ghost" size="icon" padding="1">
-				{#snippet children()}<EllipsisVertical />{/snippet}
-			</Button>
+			<EllipsisVertical />
 		{/snippet}
 		{#snippet content()}
 			<div class="py-1">

--- a/packages/dtx-web/src/lib/components/ChartListTableItem.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartListTableItem.test.ts
@@ -158,6 +158,7 @@ describe('ChartListTableItem', () => {
 
 	it('renders action buttons in non-blog mode', () => {
 		render(ChartListTableItem, { props: defaultProps });
+		expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument();
 		expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument();
 	});
 

--- a/packages/dtx-web/src/tests/stubs/PopoverStub.svelte
+++ b/packages/dtx-web/src/tests/stubs/PopoverStub.svelte
@@ -1,7 +1,28 @@
 <script lang="ts">
 	type Snippet = () => unknown;
-	let { trigger, content } = $props<{ trigger?: Snippet; content?: Snippet }>();
+	let {
+		trigger,
+		content,
+		triggerAriaLabel,
+		triggerClasses,
+		open = false,
+		onOpenChange
+	} = $props<{
+		trigger?: Snippet;
+		content?: Snippet;
+		triggerAriaLabel?: string;
+		triggerClasses?: string;
+		open?: boolean;
+		onOpenChange?: (details: { open: boolean }) => void;
+	}>();
 </script>
 
-{@render trigger?.()}
+<button
+	type="button"
+	class={triggerClasses}
+	aria-label={triggerAriaLabel}
+	onclick={() => onOpenChange?.({ open: !open })}
+>
+	{@render trigger?.()}
+</button>
 {@render content?.()}

--- a/packages/dtx-web/svelte.config.js
+++ b/packages/dtx-web/svelte.config.js
@@ -15,7 +15,11 @@ const config = {
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter({
-			fallback: 'plaintext'
+			fallback: 'plaintext',
+			// e2e-only: surface real local Miniflare bindings (DB/R2/KV) under `vite dev`.
+			// Inert in normal dev and in production builds (env var unset) — keeps the
+			// existing mock-D1 dev behavior for everyone else.
+			...(process.env.E2E_PLATFORM_PROXY === '1' ? { platformProxy: {} } : {})
 		}),
 		env: {
 			dir: workspaceRoot

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ const webServers = [
 			? 'bun run --filter=dtx-web dev'
 			: 'bun run e2e/setup/prepare-stack.ts && E2E_PLATFORM_PROXY=1 bun run --filter=dtx-web dev',
 		url: 'http://localhost:5173',
-		reuseExistingServer: !process.env.CI,
+		reuseExistingServer: false,
 		timeout: 180_000,
 		env: {
 			...process.env,
@@ -57,7 +57,7 @@ const webServers = [
 						' --var CORS_ALLOWED_ORIGINS:http://localhost:5173' +
 						' --var PUBLIC_ENABLE_BLOG_DOWNLOAD:true',
 					url: `${apiURL}/graphql?query=%7B__typename%7D`,
-					reuseExistingServer: !process.env.CI,
+					reuseExistingServer: false,
 					timeout: 180_000,
 					env: { ...process.env, E2E_USE_GRAPHQL: 'true' }
 				}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -90,7 +90,7 @@ export default defineConfig({
 						name: 'chromium-auth',
 						use: { ...devices['Desktop Chrome'] },
 						testMatch: /auth-lifecycle\.spec\.ts/,
-						dependencies: ['setup'] as const
+						dependencies: ['setup']
 					}
 				]
 			: [])

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,77 +1,89 @@
 import { defineConfig, devices } from '@playwright/test';
+import { TEST_SUPABASE_URL, TEST_SUPABASE_ANON_KEY, DTX_API_LOCAL_PORT } from './e2e/test-config';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
+const apiURL = `http://localhost:${DTX_API_LOCAL_PORT}`;
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+// Shared Supabase env for the dtx-web dev server (cookie auth + client bearer).
+const webSupabaseEnv = {
+	PUBLIC_SUPABASE_URL: TEST_SUPABASE_URL,
+	PUBLIC_SUPABASE_ANON_KEY: TEST_SUPABASE_ANON_KEY,
+	PUBLIC_ENABLE_BLOG_DOWNLOAD: 'true' // render the blog Download button
+};
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
-export default defineConfig({
-	testDir: './e2e',
-	/* Run tests in files in parallel */
-	fullyParallel: true,
-	/* Fail the build on CI if you accidentally left test.only in the source code. */
-	forbidOnly: !!process.env.CI,
-	/* Retry on CI only */
-	retries: process.env.CI ? 2 : 0,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
-	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: 'html',
-	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-	use: {
-		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL,
-
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry'
-	},
-
-	/* Configure projects for major browsers */
-	projects: [
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] }
-		}
-
-		/* Test against mobile viewports. */
-		// {
-		//   name: 'Mobile Chrome',
-		//   use: { ...devices['Pixel 5'] },
-		// },
-		// {
-		//   name: 'Mobile Safari',
-		//   use: { ...devices['iPhone 12'] },
-		// },
-
-		/* Test against branded browsers. */
-		// {
-		//   name: 'Microsoft Edge',
-		//   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-		// },
-		// {
-		//   name: 'Google Chrome',
-		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-		// },
-	],
-
-	/* Run your local dev server before starting the tests */
-	webServer: {
-		command: 'bun run --filter=dtx-web dev',
+// dtx-web webServer: migrate+seed (OFF leg only) then start vite dev with platformProxy.
+// The flag-ON leg also boots dtx-api (seeded) via wrangler dev with test Supabase + local
+// CORS. A conditional spread (rather than `.push`) keeps both entries in one array literal so
+// their differing `env` shapes don't trip the array's element-type inference.
+//
+// NOTE: `--var KEY:VALUE` values below are concatenated unquoted into the shell command.
+// The test Supabase URL + anon key are shell-safe (no spaces/metacharacters); keep them that
+// way when filling real creds, or quote them.
+const webServers = [
+	{
+		command: useGraphQL
+			? 'bun run --filter=dtx-web dev'
+			: 'bun run e2e/setup/prepare-stack.ts && E2E_PLATFORM_PROXY=1 bun run --filter=dtx-web dev',
 		url: 'http://localhost:5173',
 		reuseExistingServer: !process.env.CI,
+		timeout: 180_000,
 		env: {
 			...process.env,
 			VITE_E2E: 'true',
+			E2E_PLATFORM_PROXY: useGraphQL ? '' : '1',
+			PUBLIC_USE_GRAPHQL_API: useGraphQL ? 'true' : 'false',
+			PUBLIC_DTX_API_URL: apiURL,
 			PUBLIC_SIMFILE_BUCKET_URL: process.env.PUBLIC_SIMFILE_BUCKET_URL ?? baseURL,
-			VITE_DTX_SERVER_URL: process.env.VITE_DTX_SERVER_URL ?? baseURL
+			VITE_DTX_SERVER_URL: process.env.VITE_DTX_SERVER_URL ?? baseURL,
+			...webSupabaseEnv
 		}
-	}
+	},
+	...(useGraphQL
+		? [
+				{
+					command:
+						'bun run e2e/setup/prepare-stack.ts && ' +
+						'cd packages/dtx-api && bunx wrangler dev --port ' +
+						DTX_API_LOCAL_PORT +
+						' --persist-to .wrangler/state' +
+						` --var SUPABASE_URL:${TEST_SUPABASE_URL}` +
+						` --var SUPABASE_ANON_KEY:${TEST_SUPABASE_ANON_KEY}` +
+						' --var CORS_ALLOWED_ORIGINS:http://localhost:5173' +
+						' --var PUBLIC_ENABLE_BLOG_DOWNLOAD:true',
+					url: `${apiURL}/graphql?query=%7B__typename%7D`,
+					reuseExistingServer: !process.env.CI,
+					timeout: 180_000,
+					env: { ...process.env, E2E_USE_GRAPHQL: 'true' }
+				}
+			]
+		: [])
+];
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: { baseURL, trace: 'on-first-retry' },
+	projects: [
+		{ name: 'setup', testMatch: /global\.setup\.ts/ },
+		{
+			// Existing 8 specs + the anonymous download journey. NO setup dependency,
+			// so they run without the test Supabase creds (stay green before provisioning).
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+			testIgnore: [/global\.setup\.ts/, /auth-lifecycle\.spec\.ts/]
+		},
+		{
+			// Authenticated journey only — depends on the login setup (needs real creds).
+			name: 'chromium-auth',
+			use: { ...devices['Desktop Chrome'] },
+			testMatch: /auth-lifecycle\.spec\.ts/,
+			dependencies: ['setup']
+		}
+	],
+	webServer: webServers
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,17 @@ import {
 	isAuthConfigured
 } from './e2e/test-config';
 
+// CI guard: fail loudly when auth secrets are not provisioned. Without this,
+// Playwright exits 0 with zero auth-test coverage — the parity gate is then
+// unenforced on both matrix legs, invisibly.
+if (process.env.CI && !isAuthConfigured) {
+	throw new Error(
+		'CI requires auth e2e secrets (E2E_USER_PASSWORD, E2E_USER_ID, ' +
+			'E2E_SUPABASE_URL, E2E_SUPABASE_ANON_KEY, E2E_USER_EMAIL) ' +
+			'to be set. The authenticated lifecycle test is the core of the parity gate.'
+	);
+}
+
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
 const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
 const apiURL = `http://localhost:${DTX_API_LOCAL_PORT}`;
@@ -22,9 +33,8 @@ const webSupabaseEnv = {
 // CORS. A conditional spread (rather than `.push`) keeps both entries in one array literal so
 // their differing `env` shapes don't trip the array's element-type inference.
 //
-// NOTE: `--var KEY:VALUE` values below are concatenated unquoted into the shell command.
-// The test Supabase URL + anon key are shell-safe (no spaces/metacharacters); keep them that
-// way when filling real creds, or quote them.
+// NOTE: `--var KEY:VALUE` values are quoted to prevent shell-expansion issues.
+// Keep them quoted when filling real creds.
 const webServers = [
 	{
 		command: useGraphQL
@@ -52,10 +62,10 @@ const webServers = [
 						'cd packages/dtx-api && bunx wrangler dev --port ' +
 						DTX_API_LOCAL_PORT +
 						' --persist-to .wrangler/state' +
-						` --var SUPABASE_URL:${TEST_SUPABASE_URL}` +
-						` --var SUPABASE_ANON_KEY:${TEST_SUPABASE_ANON_KEY}` +
-						' --var CORS_ALLOWED_ORIGINS:http://localhost:5173' +
-						' --var PUBLIC_ENABLE_BLOG_DOWNLOAD:true',
+						` --var SUPABASE_URL:"${TEST_SUPABASE_URL}"` +
+						` --var SUPABASE_ANON_KEY:"${TEST_SUPABASE_ANON_KEY}"` +
+						' --var CORS_ALLOWED_ORIGINS:"http://localhost:5173"' +
+						' --var PUBLIC_ENABLE_BLOG_DOWNLOAD:"true"',
 					url: `${apiURL}/graphql?query=%7B__typename%7D`,
 					reuseExistingServer: false,
 					timeout: 180_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
-import { TEST_SUPABASE_URL, TEST_SUPABASE_ANON_KEY, DTX_API_LOCAL_PORT } from './e2e/test-config';
+import {
+	TEST_SUPABASE_URL,
+	TEST_SUPABASE_ANON_KEY,
+	DTX_API_LOCAL_PORT,
+	isAuthConfigured
+} from './e2e/test-config';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
 const useGraphQL = process.env.E2E_USE_GRAPHQL === 'true';
@@ -69,21 +74,26 @@ export default defineConfig({
 	reporter: 'html',
 	use: { baseURL, trace: 'on-first-retry' },
 	projects: [
-		{ name: 'setup', testMatch: /global\.setup\.ts/ },
+		// Non-auth specs always run — they have no setup dependency.
 		{
-			// Existing 8 specs + the anonymous download journey. NO setup dependency,
-			// so they run without the test Supabase creds (stay green before provisioning).
 			name: 'chromium',
 			use: { ...devices['Desktop Chrome'] },
 			testIgnore: [/global\.setup\.ts/, /auth-lifecycle\.spec\.ts/]
 		},
-		{
-			// Authenticated journey only — depends on the login setup (needs real creds).
-			name: 'chromium-auth',
-			use: { ...devices['Desktop Chrome'] },
-			testMatch: /auth-lifecycle\.spec\.ts/,
-			dependencies: ['setup']
-		}
+		// Auth-dependent projects are included only when credentials are configured.
+		// Without E2E_USER_PASSWORD + E2E_USER_ID in the environment, these are
+		// omitted so CI stays green until a test Supabase project is provisioned.
+		...(isAuthConfigured
+			? [
+					{ name: 'setup', testMatch: /global\.setup\.ts/ },
+					{
+						name: 'chromium-auth',
+						use: { ...devices['Desktop Chrome'] },
+						testMatch: /auth-lifecycle\.spec\.ts/,
+						dependencies: ['setup'] as const
+					}
+				]
+			: [])
 	],
 	webServer: webServers
 });

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,83 @@
+project_id = "drumery-e2e"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[api.tls]
+enabled = false
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 17
+
+[db.pooler]
+enabled = false
+port = 54329
+pool_mode = "transaction"
+default_pool_size = 20
+max_client_conn = 100
+
+[db.migrations]
+enabled = false
+schema_paths = []
+
+[db.seed]
+enabled = false
+sql_paths = []
+
+[realtime]
+enabled = false
+
+[studio]
+enabled = false
+port = 54323
+api_url = "http://127.0.0.1"
+
+[inbucket]
+enabled = true
+port = 54324
+
+[storage]
+enabled = false
+file_size_limit = "50MiB"
+
+[storage.s3_protocol]
+enabled = false
+
+[auth]
+enabled = true
+site_url = "http://127.0.0.1:5173"
+additional_redirect_urls = ["http://localhost:5173", "http://127.0.0.1:5173"]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+refresh_token_reuse_interval = 10
+enable_signup = true
+enable_anonymous_sign_ins = false
+minimum_password_length = 6
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = true
+enable_confirmations = false
+max_frequency = "1s"
+otp_length = 6
+otp_expiry = 3600
+
+[auth.sms]
+enable_signup = false
+max_frequency = "5s"
+
+[edge_runtime]
+enabled = false
+policy = "per_worker"
+inspector_port = 8083
+
+[analytics]
+enabled = false
+port = 54327
+backend = "postgres"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -46,9 +46,6 @@ port = 54324
 enabled = false
 file_size_limit = "50MiB"
 
-[storage.s3_protocol]
-enabled = false
-
 [auth]
 enabled = true
 site_url = "http://127.0.0.1:5173"


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive E2E parity gate that validates the web application behaves identically across both the legacy path (superpowers flag OFF) and the new path (superpowers flag ON).

### What changed
- **Platform proxy gating**: Made the adapter `platformProxy` conditional behind `E2E_PLATFORM_PROXY` so tests can run in both modes without side effects.
- **Test Supabase config**: Added hardcoded test Supabase credentials and fixed seed IDs for deterministic test data.
- **Migrate + seed script**: Added a pre-start script that prepares the test database before the parity gate runs.
- **Dual-path Playwright config**: Set up two independent Playwright project legs—one with the flag OFF and one with the flag ON—using the same test specs.
- **Login setup project**: Created a setup project that logs in a test user and produces a `storageState` file so authenticated tests can share the session.
- **Authenticated chart lifecycle journey**: Added an end-to-end test covering upload, edit, and delete of a chart while authenticated, running under both flag states.
- **Anonymous browse + single download journey**: Added an end-to-end test covering browsing and downloading a chart as an anonymous user, running under both flag states.
- **CI workflow**: Updated GitHub Actions to run the parity gate twice (flag OFF then flag ON) for full coverage.
- **Runbook**: Added Phase 4 pre-prod cutover runbook documentation for the superpowers migration.
- **Formatting**: Ran Prettier over the parity-gate workflow YAML.

#### Test plan
- [ ] Parity gate passes with `SUPERPOWERS=false`
- [ ] Parity gate passes with `SUPERPOWERS=true`
- [ ] All E2E tests are green in CI

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added E2E specs for authenticated chart lifecycle and anonymous blog download, plus a global authenticated setup and hermetic local seeding; tests run in a dual-path mode (REST vs GraphQL) via a runtime flag.

* **Chores**
  * CI now runs both API paths in a matrix, starts a local Supabase instance per run, maps runtime creds into E2E env vars, and uploads per-leg test artifacts; ignore rules updated to exclude local test state and auth output; added opt-in dev proxy toggle.

* **Documentation**
  * Added Phase 4 migration plan, pre-prod cutover runbook, and design spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->