### PR TITLE
feat(api): simfile GraphQL compatibility with R2 catalog enrichment

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         run: bun run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         run: bun run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/docs/plans/2026-06-05-simfile-graphql-compatibility-api.md
+++ b/docs/plans/2026-06-05-simfile-graphql-compatibility-api.md
@@ -1,0 +1,683 @@
+# Simfile GraphQL Compatibility API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the existing Drumery `simfile` / `simfiles` GraphQL API so Virgo can consume it directly and download chart/audio assets through current public R2 URLs.
+
+**Architecture:** Keep the existing `packages/dtx-api` Pothos/Yoga schema and current `Simfile` / `DtxFile` type names. Add computed fields on those existing types, backed by request-scoped R2 discovery helpers that reuse the current R2 listing/batching patterns. Do not add new D1 columns, signed URLs, cursor pagination, or `song` / `songs` queries.
+
+**Tech Stack:** TypeScript, Cloudflare Workers, Pothos GraphQL, GraphQL Yoga, Vitest, Cloudflare R2/D1 types, Bun workspaces.
+
+---
+
+### Task 1: Add Failing Schema Tests For Metadata Defaults
+
+**Files:**
+
+- Modify: `packages/dtx-api/src/schema/simfile.test.ts`
+- Modify later: `packages/dtx-api/src/schema/simfile.ts`
+
+**Step 1: Write the failing tests**
+
+Add tests near the existing `Query.simfile` and `Query.simfiles` describe blocks:
+
+```ts
+it('exposes compatibility metadata defaults on a published simfile', async () => {
+	mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+	mockedGetSimfile.mockResolvedValue(publishedSimfile);
+
+	const result = await runQuery(makeCtx(), {
+		query: '{ simfile(id: "42") { id genre tags durationSeconds } }'
+	});
+
+	expect(result.errors).toBeUndefined();
+	expect(result.data?.simfile).toEqual({
+		id: '42',
+		genre: null,
+		tags: [],
+		durationSeconds: null
+	});
+});
+```
+
+Add this to the existing `Query.simfiles` describe block:
+
+```ts
+it('exposes compatibility metadata defaults in published list results', async () => {
+	mockedList.mockResolvedValue({ data: [publishedSimfile], count: 1 });
+
+	const result = await runQuery(makeCtx(), {
+		query: '{ simfiles(scope: PUBLISHED) { count data { id genre tags durationSeconds } } }'
+	});
+
+	expect(result.errors).toBeUndefined();
+	expect(result.data?.simfiles).toEqual({
+		count: 1,
+		data: [
+			{
+				id: '42',
+				genre: null,
+				tags: [],
+				durationSeconds: null
+			}
+		]
+	});
+});
+```
+
+**Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/schema/simfile.test.ts
+```
+
+Expected: FAIL with GraphQL validation errors for unknown fields `genre`, `tags`, and `durationSeconds`.
+
+**Step 3: Implement minimal schema fields**
+
+In `packages/dtx-api/src/schema/simfile.ts`, add fields to `SimfileRef`:
+
+```ts
+genre: t.string({ nullable: true, resolve: () => null }),
+tags: t.stringList({ resolve: () => [] }),
+durationSeconds: t.int({ nullable: true, resolve: () => null }),
+```
+
+Keep the fields computed only; do not touch D1 schema or shared types.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/schema/simfile.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/dtx-api/src/schema/simfile.ts packages/dtx-api/src/schema/simfile.test.ts
+git commit -m "feat(api): expose simfile catalog metadata defaults"
+```
+
+### Task 2: Add R2 Catalog Discovery Helpers
+
+**Files:**
+
+- Modify: `packages/dtx-api/src/services/r2Enrichment.ts`
+- Modify: `packages/dtx-api/src/services/r2Enrichment.test.ts`
+- Modify later: `packages/dtx-api/src/context.ts`
+
+**Step 1: Write failing helper tests**
+
+Add tests to `packages/dtx-api/src/services/r2Enrichment.test.ts` for a new `discoverCatalogFiles` helper. Use the existing mock style in the file.
+
+Cover:
+
+- Encodes each R2 key path segment against `PUBLIC_SIMFILE_BUCKET_URL`.
+- Selects `preview.mp3` for `previewUrl`.
+- Selects non-preview `.ogg` before `.mp3`, `.wav`, and `.flac` for `downloadUrl`.
+- Matches `.dtx` rows by sorted fallback when no `set.def` is available.
+- Parses `set.def` and matches labels to filenames when available.
+- Returns an unmatched chart entry when a required `.dtx` object is missing.
+
+Core expected shape:
+
+```ts
+const discovery = await discoverCatalogFiles(bucket, {
+	simfileId: 42,
+	dtxFiles: [{ label: 'BSC', level: 20 }],
+	publicBaseUrl: 'https://bucket.example'
+});
+
+expect(discovery.previewUrl).toBe('https://bucket.example/42/preview.mp3');
+expect(discovery.downloadUrl).toBe('https://bucket.example/42/music.ogg');
+expect(discovery.charts[0]).toMatchObject({
+	label: 'BSC',
+	level: 20,
+	fileUrl: 'https://bucket.example/42/basic.dtx',
+	fileSizeBytes: 123,
+	fileEncoding: 'SHIFT_JIS'
+});
+```
+
+**Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/services/r2Enrichment.test.ts
+```
+
+Expected: FAIL because `discoverCatalogFiles` does not exist.
+
+**Step 3: Implement helper types and URL builder**
+
+In `packages/dtx-api/src/services/r2Enrichment.ts`, import `GraphQLError` if needed later only in schema, not in this service. Add these exported types:
+
+```ts
+export type CatalogDtxFileInput = {
+	label: string;
+	level: number;
+};
+
+export type CatalogChartFile = CatalogDtxFileInput & {
+	fileUrl: string | null;
+	fileSizeBytes: number | null;
+	fileEncoding: 'SHIFT_JIS';
+};
+
+export type CatalogFileDiscovery = {
+	previewUrl: string | null;
+	downloadUrl: string | null;
+	charts: CatalogChartFile[];
+};
+```
+
+Add a helper to encode keys:
+
+```ts
+const publicUrlForKey = (baseUrl: string, key: string): string => {
+	const base = baseUrl.replace(/\/$/, '');
+	const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+	return `${base}/${encodedKey}`;
+};
+```
+
+**Step 4: Implement object classification**
+
+Use existing `listAllR2Objects(bucket, prefix)` inside `discoverCatalogFiles`.
+
+Rules:
+
+- `previewUrl`: exact filename `preview.mp3`, case-insensitive.
+- `downloadUrl`: first matching full audio by extension priority `.ogg`, `.mp3`, `.wav`, `.flac`, excluding `preview.mp3`.
+- `.dtx` charts: filenames ending in `.dtx`, case-insensitive.
+- `set.def`: exact filename `set.def`, case-insensitive.
+
+**Step 5: Implement `set.def` parsing**
+
+Use `await bucket.get(setDefKey)` only when `set.def` exists. Read text with `await object.text()`.
+
+Support lines that map common DTX set labels to filenames:
+
+```text
+#L1LABEL BASIC
+#L1FILE basic.dtx
+#L2LABEL ADVANCED
+#L2FILE advanced.dtx
+```
+
+Parsing rule:
+
+- Track `#L<number>LABEL` and `#L<number>FILE`.
+- Match a `dtxFiles` row when its `label` equals a parsed label, case-insensitive.
+- Resolve the parsed file path under the simfile prefix.
+
+If parsing fails or no match is found, fall through to sorted fallback.
+
+**Step 6: Implement sorted fallback matching**
+
+Sort input chart rows by `level`, then `label`, while retaining original index. Sort `.dtx` objects by key. Pair by sorted index, then restore original chart row order in the returned `charts` array.
+
+**Step 7: Run helper tests**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/services/r2Enrichment.test.ts
+```
+
+Expected: PASS.
+
+**Step 8: Commit**
+
+```bash
+git add packages/dtx-api/src/services/r2Enrichment.ts packages/dtx-api/src/services/r2Enrichment.test.ts
+git commit -m "feat(api): discover public catalog files in R2"
+```
+
+### Task 3: Add Computed URL Fields To GraphQL Types
+
+**Files:**
+
+- Modify: `packages/dtx-api/src/context.ts`
+- Modify: `packages/dtx-api/src/schema/simfile.ts`
+- Modify: `packages/dtx-api/src/schema/simfile.test.ts`
+- Modify: `packages/dtx-api/src/services/r2Enrichment.ts`
+
+**Step 1: Write failing GraphQL tests**
+
+In `packages/dtx-api/src/schema/simfile.test.ts`, update the `../services/r2Enrichment` mock to include:
+
+```ts
+discoverCatalogFiles: vi.fn();
+```
+
+Import and mock it:
+
+```ts
+const {
+	enrichFiles,
+	enrichHasUploadedFiles,
+	batchEnrichHasUploadedFiles,
+	batchEnrichFiles,
+	discoverCatalogFiles
+} = await import('../services/r2Enrichment');
+const mockedCatalogFiles = vi.mocked(discoverCatalogFiles);
+```
+
+Add tests:
+
+```ts
+it('resolves dtx file public URL metadata from catalog discovery', async () => {
+	mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+	mockedGetSimfile.mockResolvedValue({
+		...publishedSimfile,
+		dtx_files: [{ level: 20, label: 'BSC' }]
+	});
+	mockedCatalogFiles.mockResolvedValue({
+		previewUrl: null,
+		downloadUrl: null,
+		charts: [
+			{
+				label: 'BSC',
+				level: 20,
+				fileUrl: 'https://bucket.example/42/basic.dtx',
+				fileSizeBytes: 123,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]
+	});
+
+	const result = await runQuery(
+		makeCtx({ env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' } }),
+		{
+			query: '{ simfile(id: "42") { dtxFiles { label level fileUrl fileSizeBytes fileEncoding } } }'
+		}
+	);
+
+	expect(result.errors).toBeUndefined();
+	expect(result.data?.simfile).toEqual({
+		dtxFiles: [
+			{
+				label: 'BSC',
+				level: 20,
+				fileUrl: 'https://bucket.example/42/basic.dtx',
+				fileSizeBytes: 123,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]
+	});
+});
+```
+
+Add tests for:
+
+- `previewUrl` falls back when DB `preview_url` is `null`.
+- `downloadUrl` falls back when DB `download_url` is `null`.
+- Existing DB `preview_url` and `download_url` win over discovered values.
+- Missing `fileUrl` produces a GraphQL field error with code `INTERNAL`.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/schema/simfile.test.ts
+```
+
+Expected: FAIL because `DtxFile.fileUrl`, `fileSizeBytes`, `fileEncoding`, and `discoverCatalogFiles` wiring do not exist.
+
+**Step 3: Extend context**
+
+In `packages/dtx-api/src/context.ts`, import the discovery type:
+
+```ts
+import type { CatalogFileDiscovery } from './services/r2Enrichment';
+```
+
+Add to `Ctx`:
+
+```ts
+catalogFilesCache: Map<number, Promise<CatalogFileDiscovery>>;
+```
+
+Initialize in `createContext` and in the test `makeCtx` helper:
+
+```ts
+catalogFilesCache: new Map();
+```
+
+**Step 4: Add schema enum**
+
+In `packages/dtx-api/src/schema/simfile.ts`, register:
+
+```ts
+export const FileEncodingEnum = builder.enumType('FileEncoding', {
+	values: ['SHIFT_JIS', 'UTF_8'] as const
+});
+```
+
+**Step 5: Add helper functions in schema**
+
+In `packages/dtx-api/src/schema/simfile.ts`, import `discoverCatalogFiles`.
+
+Add:
+
+```ts
+const getCatalogDiscovery = (
+	ctx: Ctx,
+	simfile: SimfileWithDtxFiles
+): Promise<CatalogFileDiscovery> => {
+	const cached = ctx.catalogFilesCache.get(simfile.id);
+	if (cached) return cached;
+
+	const promise = discoverCatalogFiles(ctx.r2, {
+		simfileId: simfile.id,
+		dtxFiles: simfile.dtx_files,
+		publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+	});
+	ctx.catalogFilesCache.set(simfile.id, promise);
+	return promise;
+};
+```
+
+Use local imports for `Ctx`, `CatalogFileDiscovery`, and `SimfileWithDtxFiles` as needed.
+
+**Step 6: Add fallback resolvers on `SimfileRef`**
+
+Change `previewUrl` and `downloadUrl` from direct exposure to resolver fields:
+
+```ts
+previewUrl: t.string({
+	nullable: true,
+	resolve: async (s, _args, ctx) =>
+		s.preview_url ?? (await getCatalogDiscovery(ctx, s)).previewUrl
+}),
+downloadUrl: t.string({
+	nullable: true,
+	resolve: async (s, _args, ctx) =>
+		s.download_url ?? (await getCatalogDiscovery(ctx, s)).downloadUrl
+}),
+```
+
+**Step 7: Add `DtxFile` parent context**
+
+Change `DtxFile` object parent type from `{ level: number; label: string }` to include the owning simfile id:
+
+```ts
+type DtxFileParent = {
+	level: number;
+	label: string;
+	simfileId: number;
+	simfile: SimfileWithDtxFiles;
+};
+```
+
+Change `SimfileRef.dtxFiles` resolver from direct exposure to:
+
+```ts
+dtxFiles: t.field({
+	type: [DtxFile],
+	resolve: (s) =>
+		s.dtx_files.map((file) => ({
+			...file,
+			simfileId: s.id,
+			simfile: s
+		}))
+}),
+```
+
+**Step 8: Add `DtxFile` computed fields**
+
+Add to `DtxFile`:
+
+```ts
+fileUrl: t.string({
+	resolve: async (file, _args, ctx) => {
+		const discovery = await getCatalogDiscovery(ctx, file.simfile);
+		const chart = findCatalogChart(discovery, file);
+		if (!chart?.fileUrl) {
+			throw new GraphQLError('DTX chart file not found in R2', {
+				extensions: { code: 'INTERNAL' }
+			});
+		}
+		return chart.fileUrl;
+	}
+}),
+fileSizeBytes: t.int({
+	resolve: async (file, _args, ctx) => {
+		const discovery = await getCatalogDiscovery(ctx, file.simfile);
+		const chart = findCatalogChart(discovery, file);
+		return chart?.fileSizeBytes ?? 0;
+	}
+}),
+fileEncoding: t.field({
+	type: FileEncodingEnum,
+	resolve: async (file, _args, ctx) => {
+		const discovery = await getCatalogDiscovery(ctx, file.simfile);
+		const chart = findCatalogChart(discovery, file);
+		return chart?.fileEncoding ?? 'SHIFT_JIS';
+	}
+})
+```
+
+Implement `findCatalogChart` by matching `label` and `level` against `discovery.charts`.
+
+**Step 9: Run GraphQL tests**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/schema/simfile.test.ts
+```
+
+Expected: PASS.
+
+**Step 10: Commit**
+
+```bash
+git add packages/dtx-api/src/context.ts packages/dtx-api/src/schema/simfile.ts packages/dtx-api/src/schema/simfile.test.ts
+git commit -m "feat(api): expose public file metadata on simfiles"
+```
+
+### Task 4: Batch-Prefill Catalog Discovery For List Queries
+
+**Files:**
+
+- Modify: `packages/dtx-api/src/services/r2Enrichment.ts`
+- Modify: `packages/dtx-api/src/services/r2Enrichment.test.ts`
+- Modify: `packages/dtx-api/src/schema/simfile.ts`
+- Modify: `packages/dtx-api/src/schema/simfile.test.ts`
+
+**Step 1: Write failing helper tests**
+
+Add tests for `batchDiscoverCatalogFiles` in `packages/dtx-api/src/services/r2Enrichment.test.ts`:
+
+```ts
+const result = await batchDiscoverCatalogFiles(bucket, [
+	{ simfileId: 1, dtxFiles: [], publicBaseUrl: 'https://bucket.example' },
+	{ simfileId: 2, dtxFiles: [], publicBaseUrl: 'https://bucket.example' }
+]);
+
+expect(result).toBeInstanceOf(Map);
+expect(result.get(1)).toBeDefined();
+expect(result.get(2)).toBeDefined();
+```
+
+**Step 2: Implement batch helper**
+
+In `packages/dtx-api/src/services/r2Enrichment.ts`, export:
+
+```ts
+export type CatalogDiscoveryOptions = {
+	simfileId: number;
+	dtxFiles: CatalogDtxFileInput[];
+	publicBaseUrl: string;
+};
+
+export const batchDiscoverCatalogFiles = async (
+	bucket: R2Bucket,
+	options: CatalogDiscoveryOptions[]
+): Promise<Map<number, CatalogFileDiscovery>> => {
+	const results = new Map<number, CatalogFileDiscovery>();
+	let nextIndex = 0;
+	const worker = async () => {
+		while (nextIndex < options.length) {
+			const option = options[nextIndex++];
+			results.set(option.simfileId, await discoverCatalogFiles(bucket, option));
+		}
+	};
+	await Promise.all(
+		Array.from({ length: Math.min(MAX_CONCURRENT_R2_LIST, options.length) }, () => worker())
+	);
+	return results;
+};
+```
+
+If `MAX_CONCURRENT_R2_LIST` is not exported, keep it internal and reuse it in the same file.
+
+**Step 3: Write failing GraphQL batching tests**
+
+In `packages/dtx-api/src/schema/simfile.test.ts`, mock and import `batchDiscoverCatalogFiles`.
+
+Add tests:
+
+- Selecting `dtxFiles { fileUrl }` in `simfiles` calls `batchDiscoverCatalogFiles` once and does not call per-row `discoverCatalogFiles`.
+- Selecting only `id title` does not call catalog discovery.
+- Selecting `previewUrl` or `downloadUrl` triggers batch discovery only when DB values are absent is hard to know before resolving; for simplicity, prefill when either selected.
+
+Example query:
+
+```ts
+await runQuery(
+	makeCtx({ env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' } }),
+	{
+		query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id dtxFiles { fileUrl } } } }'
+	}
+);
+
+expect(mockedBatchCatalogFiles).toHaveBeenCalledWith(expect.anything(), [
+	{
+		simfileId: 1,
+		dtxFiles: sim1.dtx_files,
+		publicBaseUrl: 'https://bucket.example'
+	},
+	{
+		simfileId: 2,
+		dtxFiles: sim2.dtx_files,
+		publicBaseUrl: 'https://bucket.example'
+	}
+]);
+expect(mockedCatalogFiles).not.toHaveBeenCalled();
+```
+
+**Step 4: Wire batch prefill in `SimfileConnectionRef.data`**
+
+In `packages/dtx-api/src/schema/simfile.ts`, import `batchDiscoverCatalogFiles`.
+
+Add a selected-field check for any catalog-backed field:
+
+```ts
+const shouldBatchCatalogFiles =
+	isFieldSelected(info, 'previewUrl') ||
+	isFieldSelected(info, 'downloadUrl') ||
+	isNestedFieldSelected(info, 'dtxFiles', ['fileUrl', 'fileSizeBytes', 'fileEncoding']);
+```
+
+If needed, extend the existing field-selection helper to support nested checks through fragments. Keep it local to `simfile.ts`.
+
+When selected, call `batchDiscoverCatalogFiles` with all list rows and seed `ctx.catalogFilesCache`:
+
+```ts
+const catalogBatchPromise = batchDiscoverCatalogFiles(
+	ctx.r2,
+	c.data.map((s) => ({
+		simfileId: s.id,
+		dtxFiles: s.dtx_files,
+		publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+	}))
+);
+for (const s of c.data) {
+	ctx.catalogFilesCache.set(
+		s.id,
+		catalogBatchPromise.then((map) => map.get(s.id) ?? emptyCatalogDiscovery(s.dtx_files))
+	);
+}
+```
+
+Implement `emptyCatalogDiscovery` locally or export it from `r2Enrichment.ts`.
+
+**Step 5: Run focused tests**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test -- src/services/r2Enrichment.test.ts src/schema/simfile.test.ts
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add packages/dtx-api/src/services/r2Enrichment.ts packages/dtx-api/src/services/r2Enrichment.test.ts packages/dtx-api/src/schema/simfile.ts packages/dtx-api/src/schema/simfile.test.ts
+git commit -m "feat(api): batch catalog file discovery"
+```
+
+### Task 5: Verify Type Safety And Full API Tests
+
+**Files:**
+
+- Modify only if checks reveal issues.
+
+**Step 1: Run API tests**
+
+Run:
+
+```bash
+bun run --filter=dtx-api test
+```
+
+Expected: PASS.
+
+**Step 2: Run API typecheck**
+
+Run:
+
+```bash
+bun run --filter=dtx-api check
+```
+
+Expected: PASS.
+
+**Step 3: Fix failures narrowly**
+
+If tests or typecheck fail, fix only the related files from earlier tasks. Do not run project-wide build commands.
+
+**Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only implementation files changed, plus any generated schema file if a schema generation command is explicitly run later.
+
+**Step 5: Final commit if needed**
+
+If verification fixes produced changes:
+
+```bash
+git add packages/dtx-api/src
+git commit -m "test(api): verify simfile compatibility api"
+```
+
+If no changes were needed after the previous commits, do not create an empty commit.

--- a/docs/plans/2026-06-05-simfile-graphql-compatibility-api.md
+++ b/docs/plans/2026-06-05-simfile-graphql-compatibility-api.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add Failing Schema Tests For Metadata Defaults
+## Task 1: Add Failing Schema Tests For Metadata Defaults
 
 **Files:**
 
@@ -550,7 +550,7 @@ Add tests:
 
 - Selecting `dtxFiles { fileUrl }` in `simfiles` calls `batchDiscoverCatalogFiles` once and does not call per-row `discoverCatalogFiles`.
 - Selecting only `id title` does not call catalog discovery.
-- Selecting `previewUrl` or `downloadUrl` triggers batch discovery only when DB values are absent is hard to know before resolving; for simplicity, prefill when either selected.
+- Selecting `previewUrl` or `downloadUrl` triggers catalog prefill/batch discovery only when the corresponding DB value is absent (`null`/empty). The decision logic must still check the existing DB `preview_url`/`download_url` before initiating an R2 listing load, so sims whose DB URL is already populated are skipped (cache pre-populated with their existing URL) and only sims with missing DB URLs are passed to `batchDiscoverCatalogFiles`.
 
 Example query:
 

--- a/docs/superpowers/specs/2026-06-05-simfile-graphql-compatibility-api-design.md
+++ b/docs/superpowers/specs/2026-06-05-simfile-graphql-compatibility-api-design.md
@@ -1,0 +1,224 @@
+# Simfile GraphQL Compatibility API Design
+
+## Context
+
+Virgo's client requirements document asks for a GraphQL API that lets a native
+client browse published DTX songs, download chart/audio assets, and refresh a
+local cache. Drumery already has a `packages/dtx-api` GraphQL Worker with
+`simfile` and `simfiles` queries used by the existing web and desktop apps.
+
+This design implements the client need as a compatibility layer over the
+existing Drumery API contract. It does not introduce Virgo-specific `song` /
+`songs` query names or a parallel catalog schema.
+
+## Goals
+
+- Let Virgo consume existing Drumery GraphQL queries directly.
+- Preserve compatibility for current DTX web and desktop clients.
+- Expose enough file metadata for a native client to download DTX charts and
+  optional audio files.
+- Use the existing public R2 base URL in v1.
+- Avoid D1 schema migrations and R2 signing infrastructure in the first
+  implementation.
+
+## Non-Goals
+
+- No new `Song`, `SongConnection`, cursor pagination, or Virgo-specific naming.
+- No short-lived signed R2 URLs in v1.
+- No new mutations, authentication flows, upload changes, or admin features.
+- No strict support yet for `updatedSince`, genre filtering, difficulty
+  filtering, or configurable sorting.
+
+## API Contract
+
+Virgo will use the existing endpoint and query names:
+
+```graphql
+simfile(id: ID!): Simfile
+simfiles(scope: PUBLISHED, search: String, page: Int, pageSize: Int): SimfileConnection!
+```
+
+The existing connection shape remains:
+
+```graphql
+type SimfileConnection {
+	data: [Simfile!]!
+	count: Int!
+}
+```
+
+`Simfile` remains the catalog item type. The client maps:
+
+- `id` to its stable song/cache key.
+- `title`, `artist`, and `bpm` directly.
+- `previewUrl` to preview audio when available.
+- `downloadUrl` to full audio or downloadable backing asset when available.
+- `updatedAt` to cache refresh state.
+- `dtxFiles` to the chart list.
+
+Add computed compatibility fields to existing types:
+
+```graphql
+type Simfile {
+	genre: String
+	tags: [String!]!
+	durationSeconds: Int
+}
+
+type DtxFile {
+	fileUrl: String!
+	fileSizeBytes: Int!
+	fileEncoding: FileEncoding!
+}
+
+enum FileEncoding {
+	SHIFT_JIS
+	UTF_8
+}
+```
+
+For v1, `genre` returns `null`, `tags` returns `[]`, and `durationSeconds`
+returns `null` because current D1 storage does not contain those values.
+
+## Pagination And Filtering
+
+The existing `simfiles` query already supports page pagination:
+
+- `page` defaults to `1`.
+- `pageSize` defaults to `20`.
+- `pageSize` is capped at `100`.
+- `count` is the total match count after filters.
+- SQL uses `LIMIT pageSize OFFSET (page - 1) * pageSize`.
+
+This v1 keeps existing pagination rather than adding cursor pagination.
+Search remains the existing SQLite `LIKE` match over title or artist. Sorting
+remains current `publishDate DESC`.
+
+## Public R2 URL Strategy
+
+Use `env.PUBLIC_SIMFILE_BUCKET_URL` as the base for file URLs, matching current
+DTX web and desktop behavior. URL construction must encode path segments:
+
+```text
+{PUBLIC_SIMFILE_BUCKET_URL}/{encoded-r2-key}
+```
+
+`previewUrl` behavior:
+
+- Return the existing DB `preview_url` if set.
+- Otherwise, return the public URL for `{simfileId}/preview.mp3` when that
+  object exists in R2.
+- Return `null` if no preview object exists.
+
+`downloadUrl` behavior:
+
+- Return the existing DB `download_url` if set.
+- Otherwise, discover a likely full-audio object under `{simfileId}/` and return
+  its public URL.
+- Prefer `.ogg`, then common audio fallbacks such as `.mp3`, `.wav`, and `.flac`.
+- Ignore preview objects when selecting full audio.
+- Return `null` if no suitable audio object exists.
+
+`DtxFile.fileUrl` behavior:
+
+- Discover `.dtx` objects under the simfile's R2 prefix.
+- Match each `dtx_files` row to the corresponding R2 object.
+- Return the public URL for the matched object.
+
+`DtxFile.fileSizeBytes` uses the matched R2 object's size.
+
+`DtxFile.fileEncoding` returns `SHIFT_JIS` in v1.
+
+## DTX File Matching
+
+Current `dtx_files` stores `label`, `level`, and `simfile_id`, but not the chart
+filename. Matching should be deterministic:
+
+1. If `{simfileId}/set.def` exists, parse it and match chart labels to file
+   names.
+2. Otherwise, sort `.dtx` object keys and pair them with sorted `dtx_files`
+   rows.
+3. If a required chart file cannot be matched, `DtxFile.fileUrl` raises a
+   GraphQL field-level error.
+
+Sorted fallback ordering should be stable across requests. Sort chart rows by
+`level`, then `label`, then original row order.
+
+## Resolver Structure
+
+Keep the implementation in `packages/dtx-api/src/schema/simfile.ts` unless it
+becomes too large; if it does, split file-discovery helpers into a focused
+service under `packages/dtx-api/src/services/`.
+
+Use existing D1 helpers from `@dtx/common/server`:
+
+- `getSimfile`
+- `listSimfiles`
+- existing `SimfileWithDtxFiles` mapping
+
+Add request-scoped R2 discovery caching to `Ctx`, keyed by simfile id, similar
+to the existing `filesCache` and `hasUploadedFilesCache`.
+
+For list queries, batch-prefill R2 discovery only when selected fields require
+it. Reuse the existing `isFieldSelected` pattern so normal web/desktop list
+queries do not pay the R2 listing cost unless they request file-backed fields.
+
+## Errors
+
+Keep existing GraphQL error codes where they already exist:
+
+- `BAD_USER_INPUT`
+- `FORBIDDEN`
+- `UNAUTHORIZED`
+- `INTERNAL`
+
+For optional file fields, return `null` when no object exists.
+
+For required `DtxFile.fileUrl`, raise a GraphQL field-level error when the chart
+object cannot be found. The error code should be `INTERNAL` because a published
+chart with a missing DTX file is a server-side data inconsistency.
+
+## Compatibility Tradeoffs
+
+This v1 intentionally differs from the Virgo requirement document in these
+ways:
+
+- It uses existing Drumery field names instead of `Song` / `Chart`.
+- It uses page pagination instead of cursor pagination.
+- It uses public R2 URLs instead of short-lived signed URLs.
+- It defaults missing catalog metadata instead of adding new D1 columns.
+- It does not implement `updatedSince`, genre filters, difficulty filters, or
+  custom sort enums.
+
+These are accepted tradeoffs for a compatibility-first implementation. They can
+be addressed later with additive schema fields or a strict catalog query if the
+client needs them.
+
+## Tests
+
+Add focused tests in `packages/dtx-api/src/schema/simfile.test.ts`:
+
+- Published `simfile` exposes `genre`, `tags`, and `durationSeconds` defaults.
+- Published `simfiles` can return the same defaults without changing the
+  existing connection shape.
+- `DtxFile.fileUrl`, `fileSizeBytes`, and `fileEncoding` resolve from mocked R2
+  listing.
+- `previewUrl` falls back to a public `preview.mp3` URL when DB value is absent.
+- `downloadUrl` falls back to a public full-audio URL when DB value is absent.
+- Missing required DTX object produces a GraphQL field-level error.
+- R2 discovery is request-cached or batch-prefilled for list queries requesting
+  file-backed fields.
+
+If shared helper functions are added under `@dtx/common/server`, add focused
+common package tests for those helpers.
+
+## Verification
+
+After implementation, run:
+
+```bash
+bun run --filter=dtx-api test
+bun run --filter=dtx-api check
+```
+
+Do not run project-wide build commands unless explicitly requested.

--- a/docs/superpowers/specs/2026-06-05-simfile-graphql-compatibility-api-design.md
+++ b/docs/superpowers/specs/2026-06-05-simfile-graphql-compatibility-api-design.md
@@ -174,9 +174,7 @@ Keep existing GraphQL error codes where they already exist:
 
 For optional file fields, return `null` when no object exists.
 
-For required `DtxFile.fileUrl`, raise a GraphQL field-level error when the chart
-object cannot be found. The error code should be `INTERNAL` because a published
-chart with a missing DTX file is a server-side data inconsistency.
+For required `DtxFile` fields (`fileUrl`, `fileSizeBytes`, and `fileEncoding`), raise a GraphQL field-level error when the chart object cannot be found. All three fields describe the same R2 object, so they must fail consistently — returning a fallback value (e.g., `0` / `SHIFT_JIS`) for a missing file would mislead clients. The error code should be `INTERNAL` because a published chart with a missing DTX file is a server-side data inconsistency.
 
 ## Compatibility Tradeoffs
 

--- a/packages/common/src/lib/chart/encoding-utils.test.ts
+++ b/packages/common/src/lib/chart/encoding-utils.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	decodeFileWithEncodingDetection,
 	decodeFileWithEncodingDetectionLegacy,
 	decodeFileWithSpecificEncoding,
+	decodeArrayBufferWithBomDetection,
 	type ContentValidationCallback
 } from './encoding-utils';
+
+// Preserve real TextDecoder before mock replacement so BOM detection tests
+// (which exercise real decoding behavior) can opt-in to the runtime impl.
+const RealTextDecoder = globalThis.TextDecoder;
 
 // Mock TextDecoder
 const mockTextDecoder = vi.fn();
@@ -462,6 +467,58 @@ describe('encoding-utils', () => {
 			expect(midiCallback('MThd\x00\x00\x00\x06')).toBe(true);
 			expect(midiCallback('MTrk\x00\x00\x00\x20')).toBe(true);
 			expect(midiCallback('Not a MIDI file')).toBe(false);
+		});
+	});
+
+	describe('decodeArrayBufferWithBomDetection', () => {
+		// These tests exercise the real runtime TextDecoder behavior, so restore
+		// the global mock to the platform implementation for this block.
+		const originalDecoder = global.TextDecoder;
+		beforeEach(() => {
+			global.TextDecoder = RealTextDecoder;
+		});
+		afterEach(() => {
+			global.TextDecoder = originalDecoder;
+		});
+
+		it('decodes UTF-8 without BOM as UTF-8', () => {
+			const text = '#L1LABEL BASIC\n#L1FILE basic.dtx\n';
+			const buffer = new TextEncoder().encode(text).buffer;
+			expect(decodeArrayBufferWithBomDetection(buffer)).toBe(text);
+		});
+
+		it('decodes UTF-8 BOM and strips the BOM character', () => {
+			const text = '#TITLE UTF8 BOM\n#L1LABEL BASIC\n';
+			const bytes = new TextEncoder().encode(text);
+			const buffer = new Uint8Array([0xef, 0xbb, 0xbf, ...bytes]).buffer;
+			// Without BOM stripping, the first directive would start with \uFEFF
+			// and fail to match `^#L` regex parsing.
+			const decoded = decodeArrayBufferWithBomDetection(buffer);
+			expect(decoded).toBe(text);
+			expect(decoded.charCodeAt(0)).not.toBe(0xfeff);
+		});
+
+		it('decodes UTF-16LE BOM and strips the BOM character', () => {
+			const text = '#TITLE UTF16LE BOM\n#L1LABEL BASIC\n#L1FILE bas.dtx\n';
+			const utf16Bytes = new Uint8Array(text.length * 2);
+			for (let i = 0; i < text.length; i++) {
+				const codeUnit = text.charCodeAt(i);
+				utf16Bytes[i * 2] = codeUnit & 0xff;
+				utf16Bytes[i * 2 + 1] = (codeUnit >> 8) & 0xff;
+			}
+			const buffer = new Uint8Array([0xff, 0xfe, ...utf16Bytes]).buffer;
+			const decoded = decodeArrayBufferWithBomDetection(buffer);
+			expect(decoded).toBe(text);
+			expect(decoded.charCodeAt(0)).not.toBe(0xfeff);
+		});
+
+		it('returns empty string for empty buffer', () => {
+			expect(decodeArrayBufferWithBomDetection(new ArrayBuffer(0))).toBe('');
+		});
+
+		it('handles single-byte buffer without throwing (no BOM match)', () => {
+			const buffer = new Uint8Array([0x41]).buffer; // "A"
+			expect(decodeArrayBufferWithBomDetection(buffer)).toBe('A');
 		});
 	});
 });

--- a/packages/common/src/lib/chart/encoding-utils.ts
+++ b/packages/common/src/lib/chart/encoding-utils.ts
@@ -82,3 +82,36 @@ export async function decodeFileWithSpecificEncoding(
 	const decoder = new TextDecoder(encoding);
 	return decoder.decode(arrayBuffer);
 }
+
+/**
+ * Detects BOM (UTF-16LE or UTF-8) in an ArrayBuffer and decodes accordingly,
+ * stripping the BOM character from the result.
+ *
+ * Used for raw byte sources (e.g. `R2Object.arrayBuffer()`) where the default
+ * `text()` path always decodes as UTF-8 and would either garble UTF-16LE
+ * content or leave a BOM character on the first directive. set.def files in
+ * this app are routinely written as UTF-16LE with BOM
+ * (see `packages/dtx-desktop/src/main/index.ts`).
+ *
+ * @param buffer - Raw bytes (typically from `R2Object.arrayBuffer()`)
+ * @returns Decoded string with BOM character stripped if present
+ */
+export function decodeArrayBufferWithBomDetection(buffer: ArrayBuffer): string {
+	const uint8 = new Uint8Array(buffer);
+	let text: string;
+	if (uint8[0] === 0xff && uint8[1] === 0xfe) {
+		// UTF-16LE BOM
+		text = new TextDecoder('utf-16le').decode(buffer);
+	} else if (uint8[0] === 0xef && uint8[1] === 0xbb && uint8[2] === 0xbf) {
+		// UTF-8 BOM
+		text = new TextDecoder('utf-8').decode(buffer);
+	} else {
+		// Default to UTF-8 (matches Workers' default text() behavior)
+		text = new TextDecoder('utf-8').decode(buffer);
+	}
+	// Strip BOM character if it survived decoding
+	if (text.charCodeAt(0) === 0xfeff) {
+		text = text.slice(1);
+	}
+	return text;
+}

--- a/packages/common/src/lib/server.ts
+++ b/packages/common/src/lib/server.ts
@@ -6,7 +6,8 @@ export { SimFile } from './chart/simFile';
 export { LaneMeasureNote } from './chart/note';
 export {
 	decodeFileWithEncodingDetection,
-	decodeFileWithSpecificEncoding
+	decodeFileWithSpecificEncoding,
+	decodeArrayBufferWithBomDetection
 } from './chart/encoding-utils';
 
 // Export constants (server-safe)

--- a/packages/dtx-api/dist/schema.graphql
+++ b/packages/dtx-api/dist/schema.graphql
@@ -19,6 +19,9 @@ type DeleteResult {
 }
 
 type DtxFile {
+  fileEncoding: FileEncoding!
+  fileSizeBytes: Int!
+  fileUrl: String!
   label: String!
   level: Float!
 }
@@ -26,6 +29,11 @@ type DtxFile {
 input DtxFileInput {
   label: String!
   level: Float!
+}
+
+enum FileEncoding {
+  SHIFT_JIS
+  UTF_8
 }
 
 type MagicLinkResult {
@@ -63,12 +71,15 @@ type Simfile {
   displayId: Int
   downloadUrl: String
   dtxFiles: [DtxFile!]!
+  durationSeconds: Int
   files: [R2File!]!
+  genre: String
   hasUploadedFiles: Boolean!
   id: ID!
   isPublished: Boolean!
   previewUrl: String
   publishDate: String!
+  tags: [String!]!
   title: String!
   updatedAt: String!
   userId: ID

--- a/packages/dtx-api/package.json
+++ b/packages/dtx-api/package.json
@@ -11,6 +11,7 @@
 		"deploy:preprod:prod-data": "wrangler deploy --env pre-prod-prod-data",
 		"test": "vitest --run",
 		"test:watch": "vitest",
+		"test:coverage": "vitest --run --coverage",
 		"check": "tsc --noEmit",
 		"cf-typegen": "wrangler types --env-interface CloudflareBindings",
 		"gen-schema": "bun run src/scripts/gen-schema.ts"

--- a/packages/dtx-api/src/context.ts
+++ b/packages/dtx-api/src/context.ts
@@ -3,6 +3,7 @@ import type { D1Database, KVNamespace, R2Bucket } from '@cloudflare/workers-type
 import { workerLogger, type WorkerLogger } from '@dtx/common/server';
 import { verifyToken } from './auth/verifyToken';
 import type { Env } from './env';
+import type { CatalogFileDiscovery, R2FileEntry } from './services/r2Enrichment';
 
 export type OwnerCacheEntry = {
 	userId: string | null;
@@ -20,7 +21,8 @@ export type Ctx = {
 	logger: WorkerLogger;
 	ownerByIdCache: Map<string, OwnerCacheEntry | null>;
 	hasUploadedFilesCache: Map<number, Promise<boolean>>;
-	filesCache: Map<number, Promise<import('./services/r2Enrichment').R2FileEntry[]>>;
+	filesCache: Map<number, Promise<R2FileEntry[]>>;
+	catalogFilesCache?: Map<number, Promise<CatalogFileDiscovery>>;
 };
 
 export const createContext = async (request: Request, env: Env): Promise<Ctx> => {
@@ -36,6 +38,7 @@ export const createContext = async (request: Request, env: Env): Promise<Ctx> =>
 		logger: workerLogger,
 		ownerByIdCache: new Map(),
 		hasUploadedFilesCache: new Map(),
-		filesCache: new Map()
+		filesCache: new Map(),
+		catalogFilesCache: new Map()
 	};
 };

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -493,7 +493,8 @@ vi.mock('../services/r2Enrichment', () => ({
 	enrichFiles: vi.fn(),
 	enrichHasUploadedFiles: vi.fn(),
 	batchEnrichHasUploadedFiles: vi.fn(async () => new Map()),
-	batchEnrichFiles: vi.fn(async () => new Map())
+	batchEnrichFiles: vi.fn(async () => new Map()),
+	batchDiscoverCatalogFiles: vi.fn(async () => new Map())
 }));
 
 const {
@@ -501,13 +502,15 @@ const {
 	enrichFiles,
 	enrichHasUploadedFiles,
 	batchEnrichHasUploadedFiles,
-	batchEnrichFiles
+	batchEnrichFiles,
+	batchDiscoverCatalogFiles
 } = await import('../services/r2Enrichment');
 const mockedDiscoverCatalogFiles = vi.mocked(discoverCatalogFiles);
 const mockedFiles = vi.mocked(enrichFiles);
 const mockedHasUploaded = vi.mocked(enrichHasUploadedFiles);
 const mockedBatchHasUploaded = vi.mocked(batchEnrichHasUploadedFiles);
 const mockedBatchFiles = vi.mocked(batchEnrichFiles);
+const mockedBatchCatalog = vi.mocked(batchDiscoverCatalogFiles);
 
 beforeEach(() => {
 	mockedDiscoverCatalogFiles.mockReset().mockResolvedValue({
@@ -515,6 +518,7 @@ beforeEach(() => {
 		downloadUrl: null,
 		charts: []
 	});
+	mockedBatchCatalog.mockReset().mockResolvedValue(new Map());
 });
 
 describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
@@ -523,6 +527,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedHasUploaded.mockReset();
 		mockedBatchHasUploaded.mockReset().mockResolvedValue(new Map());
 		mockedBatchFiles.mockReset().mockResolvedValue(new Map());
+		mockedBatchCatalog.mockReset().mockResolvedValue(new Map());
 	});
 
 	it('resolves catalog DTX file metadata from discovered R2 files', async () => {
@@ -789,6 +794,232 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedFiles).not.toHaveBeenCalled();
 		// hasUploadedFiles batch should NOT be called (field not selected)
 		expect(mockedBatchHasUploaded).not.toHaveBeenCalled();
+	});
+
+	it('uses batch catalog discovery for DTX file URLs in list queries', async () => {
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			dtx_files: [{ label: 'BSC', level: 3 }]
+		};
+		const sim2 = {
+			...publishedSimfile,
+			id: 2,
+			dtx_files: [{ label: 'EXT', level: 8 }]
+		};
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					1,
+					{
+						previewUrl: null,
+						downloadUrl: null,
+						charts: [
+							{
+								label: 'BSC',
+								level: 3,
+								fileUrl: 'https://bucket.example/1/basic.dtx',
+								fileSizeBytes: 100,
+								fileEncoding: 'SHIFT_JIS'
+							}
+						]
+					}
+				],
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: null,
+						charts: [
+							{
+								label: 'EXT',
+								level: 8,
+								fileUrl: 'https://bucket.example/2/extreme.dtx',
+								fileSizeBytes: 200,
+								fileEncoding: 'SHIFT_JIS'
+							}
+						]
+					}
+				]
+			])
+		);
+
+		const result = await runQuery(
+			makeCtx({
+				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
+			}),
+			{
+				query:
+					'{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id dtxFiles { label fileUrl } } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{
+					id: '1',
+					dtxFiles: [{ label: 'BSC', fileUrl: 'https://bucket.example/1/basic.dtx' }]
+				},
+				{
+					id: '2',
+					dtxFiles: [{ label: 'EXT', fileUrl: 'https://bucket.example/2/extreme.dtx' }]
+				}
+			]
+		});
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 1,
+				dtxFiles: [{ label: 'BSC', level: 3 }],
+				publicBaseUrl: 'https://bucket.example'
+			},
+			{
+				simfileId: 2,
+				dtxFiles: [{ label: 'EXT', level: 8 }],
+				publicBaseUrl: 'https://bucket.example'
+			}
+		]);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('does not call catalog discovery for simple list metadata selections', async () => {
+		const sim1 = { ...publishedSimfile, id: 1 };
+		mockedList.mockResolvedValue({ data: [sim1], count: 1 });
+
+		await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 1) { data { id title } } }'
+		});
+
+		expect(mockedBatchCatalog).not.toHaveBeenCalled();
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('uses batch catalog discovery for list previewUrl and downloadUrl selections', async () => {
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			preview_url: 'https://db.example/preview.mp3'
+		};
+		const sim2 = {
+			...publishedSimfile,
+			id: 2,
+			download_url: 'https://db.example/download.zip'
+		};
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					1,
+					{
+						previewUrl: 'https://bucket.example/1/preview.mp3',
+						downloadUrl: null,
+						charts: []
+					}
+				],
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: 'https://bucket.example/2/song.ogg',
+						charts: []
+					}
+				]
+			])
+		);
+
+		const result = await runQuery(
+			makeCtx({
+				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
+			}),
+			{
+				query:
+					'{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{
+					id: '1',
+					previewUrl: 'https://db.example/preview.mp3',
+					downloadUrl: 'https://ext.example/a'
+				},
+				{
+					id: '2',
+					previewUrl: null,
+					downloadUrl: 'https://db.example/download.zip'
+				}
+			]
+		});
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('uses batch catalog discovery for nested DTX metadata selected via fragments', async () => {
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			dtx_files: [{ label: 'BSC', level: 3 }]
+		};
+		mockedList.mockResolvedValue({ data: [sim1], count: 1 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					1,
+					{
+						previewUrl: null,
+						downloadUrl: null,
+						charts: [
+							{
+								label: 'BSC',
+								level: 3,
+								fileUrl: null,
+								fileSizeBytes: 1234,
+								fileEncoding: 'SHIFT_JIS'
+							}
+						]
+					}
+				]
+			])
+		);
+
+		const result = await runQuery(makeCtx(), {
+			query: `
+				fragment DtxMetadata on DtxFile { fileSizeBytes fileEncoding }
+				{
+					simfiles(scope: PUBLISHED, pageSize: 1) {
+						data {
+							id
+							dtxFiles {
+								label
+								...DtxMetadata
+							}
+						}
+					}
+				}
+			`
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{
+					id: '1',
+					dtxFiles: [
+						{
+							label: 'BSC',
+							fileSizeBytes: 1234,
+							fileEncoding: 'SHIFT_JIS'
+						}
+					]
+				}
+			]
+		});
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
 	it('does not call hasUploadedFiles batch when field is not selected', async () => {

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -1369,6 +1369,94 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedBatchHasUploaded).toHaveBeenCalledWith(expect.anything(), [1]);
 		expect(mockedBatchFiles).not.toHaveBeenCalled();
 	});
+
+	it('does not poison catalog cache for sims skipped by list when same simfile is queried via another path', async () => {
+		// Regression: previously the list resolver wrote a partial cache entry
+		// (DB URLs only, charts: []) for every sim that did not need discovery.
+		// If the same simfile was also resolved via `simfile(id)` in the same
+		// GraphQL document with a different field selection, its preview/download
+		// resolvers would hit the partial entry and return stale null/empty
+		// values instead of triggering R2 discovery.
+		//
+		// Setup:
+		// - sim1 has download_url set, preview_url null. In the list (which only
+		//   selects downloadUrl) it does NOT need discovery — it would be skipped
+		//   and previously got a partial cache entry with previewUrl: null.
+		// - sim2 has download_url null. In the list it DOES need discovery — this
+		//   is what triggers entry into the block that used to write partial cache
+		//   entries for the skipped sims.
+		// - The aliased `simfile(id: "1")` query selects previewUrl. Without the
+		//   fix, the resolver hits the poisoned entry and returns null. With the
+		//   fix, it falls through to single-sim discovery and returns the R2 URL.
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			download_url: 'https://db.example/1-download.zip',
+			preview_url: null
+		};
+		const sim2 = { ...publishedSimfile, id: 2, download_url: null };
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(sim1);
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: 'https://bucket.example/2/song.ogg',
+						charts: []
+					}
+				]
+			])
+		);
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: 'https://bucket.example/1/preview.mp3',
+			downloadUrl: null,
+			charts: []
+		});
+
+		const result = await runQuery(
+			makeCtx({
+				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
+			}),
+			{
+				query: `{
+					list: simfiles(scope: PUBLISHED, pageSize: 2) { data { id downloadUrl } }
+					detail: simfile(id: "1") { id previewUrl }
+				}`
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.list).toEqual({
+			data: [
+				{ id: '1', downloadUrl: 'https://db.example/1-download.zip' },
+				{ id: '2', downloadUrl: 'https://bucket.example/2/song.ogg' }
+			]
+		});
+		expect(result.data?.detail).toEqual({
+			id: '1',
+			previewUrl: 'https://bucket.example/1/preview.mp3'
+		});
+		// Batch discovery fires only for sim2 (sim1 was skipped in the list path).
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 2,
+				dtxFiles: sim2.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			}
+		]);
+		// Single-sim discovery must fire for sim1 from the detail path — it must
+		// NOT have been served by a stale partial cache entry from the list path.
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledWith(expect.anything(), {
+			simfileId: 1,
+			dtxFiles: sim1.dtx_files,
+			publicBaseUrl: 'https://bucket.example'
+		});
+	});
 });
 
 const { updateSimfile } = await import('@dtx/common/server');

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -958,6 +958,115 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
+	it('does not batch catalog discovery for list URL selections when database URLs exist', async () => {
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			preview_url: 'https://db.example/1-preview.mp3',
+			download_url: 'https://db.example/1-download.zip'
+		};
+		const sim2 = {
+			...publishedSimfile,
+			id: 2,
+			preview_url: 'https://db.example/2-preview.mp3',
+			download_url: 'https://db.example/2-download.zip'
+		};
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+
+		const result = await runQuery(makeCtx(), {
+			query:
+				'{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{
+					id: '1',
+					previewUrl: 'https://db.example/1-preview.mp3',
+					downloadUrl: 'https://db.example/1-download.zip'
+				},
+				{
+					id: '2',
+					previewUrl: 'https://db.example/2-preview.mp3',
+					downloadUrl: 'https://db.example/2-download.zip'
+				}
+			]
+		});
+		expect(mockedBatchCatalog).not.toHaveBeenCalled();
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('uses batch catalog discovery for list previewUrl selections when any database value is missing', async () => {
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			preview_url: 'https://db.example/1-preview.mp3'
+		};
+		const sim2 = { ...publishedSimfile, id: 2, preview_url: null };
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[1, { previewUrl: null, downloadUrl: null, charts: [] }],
+				[2, { previewUrl: 'https://bucket.example/2/preview.mp3', downloadUrl: null, charts: [] }]
+			])
+		);
+
+		const result = await runQuery(
+			makeCtx({
+				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
+			}),
+			{
+				query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{ id: '1', previewUrl: 'https://db.example/1-preview.mp3' },
+				{ id: '2', previewUrl: 'https://bucket.example/2/preview.mp3' }
+			]
+		});
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('uses batch catalog discovery for list downloadUrl selections when any database value is missing', async () => {
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			download_url: 'https://db.example/1-download.zip'
+		};
+		const sim2 = { ...publishedSimfile, id: 2, download_url: null };
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[1, { previewUrl: null, downloadUrl: null, charts: [] }],
+				[2, { previewUrl: null, downloadUrl: 'https://bucket.example/2/song.ogg', charts: [] }]
+			])
+		);
+
+		const result = await runQuery(
+			makeCtx({
+				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
+			}),
+			{
+				query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id downloadUrl } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{ id: '1', downloadUrl: 'https://db.example/1-download.zip' },
+				{ id: '2', downloadUrl: 'https://bucket.example/2/song.ogg' }
+			]
+		});
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
 	it('uses batch catalog discovery for nested DTX metadata selected via fragments', async () => {
 		const sim1 = {
 			...publishedSimfile,

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -634,6 +634,49 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 	});
 
+	it('falls back to discovered previewUrl when database preview_url is an empty string', async () => {
+		// ChartDetail form submits empty inputs as '' which the update resolver
+		// stores verbatim. Blank strings must be treated like NULL so the
+		// catalog fallback runs instead of returning '' to clients.
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, preview_url: '' });
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: 'https://cdn.example/42/preview.mp3',
+			downloadUrl: null,
+			charts: []
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { previewUrl } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			previewUrl: 'https://cdn.example/42/preview.mp3'
+		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to discovered downloadUrl when database download_url is whitespace-only', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: '   ' });
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: 'https://cdn.example/42/song.ogg',
+			charts: []
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { downloadUrl } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			downloadUrl: 'https://cdn.example/42/song.ogg'
+		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
+	});
+
 	it('prefers database previewUrl and downloadUrl over discovered values', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		mockedGetSimfile.mockResolvedValue({
@@ -1133,6 +1176,74 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
 		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 2,
+				dtxFiles: sim2.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			}
+		]);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('routes sims with blank DB URLs through batch catalog discovery in list queries', async () => {
+		// Empty / whitespace-only DB URLs must be treated like NULL in the
+		// prefetch filter so the sims are included in the discovery batch
+		// and the resolver falls back to the discovered value.
+		const sim1 = { ...publishedSimfile, id: 1, preview_url: '' };
+		const sim2 = { ...publishedSimfile, id: 2, download_url: '   ' };
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					1,
+					{
+						previewUrl: 'https://bucket.example/1/preview.mp3',
+						downloadUrl: null,
+						charts: []
+					}
+				],
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: 'https://bucket.example/2/song.ogg',
+						charts: []
+					}
+				]
+			])
+		);
+
+		const result = await runQuery(
+			makeCtx({
+				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
+			}),
+			{
+				query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{
+					id: '1',
+					previewUrl: 'https://bucket.example/1/preview.mp3',
+					downloadUrl: 'https://ext.example/a'
+				},
+				{
+					id: '2',
+					previewUrl: null,
+					downloadUrl: 'https://bucket.example/2/song.ogg'
+				}
+			]
+		});
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 1,
+				dtxFiles: sim1.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			},
 			{
 				simfileId: 2,
 				dtxFiles: sim2.dtx_files,

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -515,7 +515,8 @@ beforeEach(() => {
 	mockedDiscoverCatalogFiles.mockReset().mockResolvedValue({
 		previewUrl: null,
 		downloadUrl: null,
-		charts: []
+		charts: [],
+		chartsPopulated: true
 	});
 	mockedBatchCatalog.mockReset().mockResolvedValue(new Map());
 });
@@ -556,7 +557,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					fileSizeBytes: 1234,
 					fileEncoding: 'SHIFT_JIS'
 				}
-			]
+			],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(
@@ -606,7 +608,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://cdn.example/42/preview.mp3',
 			downloadUrl: null,
-			charts: []
+			charts: [],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -625,7 +628,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
 			downloadUrl: 'https://cdn.example/42/song.ogg',
-			charts: []
+			charts: [],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -647,7 +651,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://cdn.example/42/preview.mp3',
 			downloadUrl: null,
-			charts: []
+			charts: [],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -667,7 +672,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
 			downloadUrl: 'https://cdn.example/42/song.ogg',
-			charts: []
+			charts: [],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -715,7 +721,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					fileSizeBytes: null,
 					fileEncoding: 'SHIFT_JIS'
 				}
-			]
+			],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -740,7 +747,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					fileSizeBytes: null,
 					fileEncoding: 'SHIFT_JIS'
 				}
-			]
+			],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -765,7 +773,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					fileSizeBytes: null,
 					fileEncoding: 'SHIFT_JIS'
 				}
-			]
+			],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(makeCtx(), {
@@ -790,7 +799,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					fileSizeBytes: null,
 					fileEncoding: 'SHIFT_JIS'
 				}
-			]
+			],
+			chartsPopulated: true
 		});
 
 		const logger = {
@@ -952,7 +962,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 								fileSizeBytes: 100,
 								fileEncoding: 'SHIFT_JIS'
 							}
-						]
+						],
+						chartsPopulated: true
 					}
 				],
 				[
@@ -968,7 +979,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 								fileSizeBytes: 200,
 								fileEncoding: 'SHIFT_JIS'
 							}
-						]
+						],
+						chartsPopulated: true
 					}
 				]
 			])
@@ -1050,7 +1062,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					{
 						previewUrl: null,
 						downloadUrl: 'https://bucket.example/2/song.ogg',
-						charts: []
+						charts: [],
+						chartsPopulated: false
 					}
 				]
 			])
@@ -1086,7 +1099,9 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			[
 				{
 					simfileId: 2,
-					dtxFiles: sim2.dtx_files,
+					// dtxFiles is [] because the query didn't select any dtxFiles
+					// fields — avoids an unnecessary SET.DEF fetch per simfile.
+					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				}
 			],
@@ -1149,7 +1164,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					{
 						previewUrl: 'https://bucket.example/2/preview.mp3',
 						downloadUrl: null,
-						charts: []
+						charts: [],
+						chartsPopulated: false
 					}
 				]
 			])
@@ -1177,7 +1193,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			[
 				{
 					simfileId: 2,
-					dtxFiles: sim2.dtx_files,
+					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				}
 			],
@@ -1202,7 +1218,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					{
 						previewUrl: null,
 						downloadUrl: 'https://bucket.example/2/song.ogg',
-						charts: []
+						charts: [],
+						chartsPopulated: false
 					}
 				]
 			])
@@ -1230,7 +1247,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			[
 				{
 					simfileId: 2,
-					dtxFiles: sim2.dtx_files,
+					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				}
 			],
@@ -1253,7 +1270,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					{
 						previewUrl: 'https://bucket.example/1/preview.mp3',
 						downloadUrl: null,
-						charts: []
+						charts: [],
+						chartsPopulated: false
 					}
 				],
 				[
@@ -1261,7 +1279,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					{
 						previewUrl: null,
 						downloadUrl: 'https://bucket.example/2/song.ogg',
-						charts: []
+						charts: [],
+						chartsPopulated: false
 					}
 				]
 			])
@@ -1297,12 +1316,12 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			[
 				{
 					simfileId: 1,
-					dtxFiles: sim1.dtx_files,
+					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				},
 				{
 					simfileId: 2,
-					dtxFiles: sim2.dtx_files,
+					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				}
 			],
@@ -1333,7 +1352,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 								fileSizeBytes: 1234,
 								fileEncoding: 'SHIFT_JIS'
 							}
-						]
+						],
+						chartsPopulated: true
 					}
 				]
 			])
@@ -1463,7 +1483,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					{
 						previewUrl: null,
 						downloadUrl: 'https://bucket.example/2/song.ogg',
-						charts: []
+						charts: [],
+						chartsPopulated: false
 					}
 				]
 			])
@@ -1471,7 +1492,8 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://bucket.example/1/preview.mp3',
 			downloadUrl: null,
-			charts: []
+			charts: [],
+			chartsPopulated: true
 		});
 
 		const result = await runQuery(
@@ -1504,7 +1526,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			[
 				{
 					simfileId: 2,
-					dtxFiles: sim2.dtx_files,
+					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				}
 			],

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -514,6 +514,7 @@ const mockedBatchCatalog = vi.mocked(batchDiscoverCatalogFiles);
 beforeEach(() => {
 	mockedDiscoverCatalogFiles.mockReset().mockResolvedValue({
 		previewUrl: null,
+		downloadUrl: null,
 		charts: [],
 		chartsPopulated: true
 	});
@@ -540,6 +541,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
+			downloadUrl: null,
 			charts: [
 				{
 					label: 'EXT',
@@ -605,6 +607,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, preview_url: null });
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://cdn.example/42/preview.mp3',
+			downloadUrl: null,
 			charts: [],
 			chartsPopulated: true
 		});
@@ -619,39 +622,49 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 	});
 
-	it('returns null downloadUrl when database download_url is null without consulting R2', async () => {
-		// downloadUrl is DB-only — the R2 listing cannot reliably identify
-		// "the main audio" because DTX simfiles contain many `#WAV` chip
-		// samples (kick.ogg, snare.wav, ...) which would otherwise be
-		// picked as the download URL. Actual file download is served by
-		// the /downloads/:id REST endpoint (ZIP stream), not by this field.
+	it('falls back to discovered downloadUrl when database download_url is null', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: null });
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: 'https://cdn.example/42/music.ogg',
+			charts: [],
+			chartsPopulated: true
+		});
 
 		const result = await runQuery(makeCtx(), {
 			query: '{ simfile(id: "42") { downloadUrl } }'
 		});
 
 		expect(result.errors).toBeUndefined();
-		expect(result.data?.simfile).toEqual({ downloadUrl: null });
-		// discovery should never run for the downloadUrl-only query
-		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+		expect(result.data?.simfile).toEqual({
+			downloadUrl: 'https://cdn.example/42/music.ogg'
+		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
 	});
 
-	it('treats whitespace-only database download_url as null without consulting R2', async () => {
+	it('falls back to discovered downloadUrl when database download_url is whitespace-only', async () => {
 		// Mirrors the previewUrl behavior: empty / whitespace DB strings
 		// must be coerced to null so the GraphQL field renders as null
-		// rather than the raw '' to clients.
+		// rather than the raw '' to clients, then the catalog fallback runs.
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: '   ' });
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: 'https://cdn.example/42/music.ogg',
+			charts: [],
+			chartsPopulated: true
+		});
 
 		const result = await runQuery(makeCtx(), {
 			query: '{ simfile(id: "42") { downloadUrl } }'
 		});
 
 		expect(result.errors).toBeUndefined();
-		expect(result.data?.simfile).toEqual({ downloadUrl: null });
-		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+		expect(result.data?.simfile).toEqual({
+			downloadUrl: 'https://cdn.example/42/music.ogg'
+		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
 	});
 
 	it('falls back to discovered previewUrl when database preview_url is an empty string', async () => {
@@ -662,6 +675,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, preview_url: '' });
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://cdn.example/42/preview.mp3',
+			downloadUrl: null,
 			charts: [],
 			chartsPopulated: true
 		});
@@ -702,6 +716,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
+			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -727,6 +742,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
+			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -752,6 +768,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
+			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -777,6 +794,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
+			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -939,6 +957,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					1,
 					{
 						previewUrl: null,
+						downloadUrl: null,
 						charts: [
 							{
 								label: 'BSC',
@@ -955,6 +974,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					2,
 					{
 						previewUrl: null,
+						downloadUrl: null,
 						charts: [
 							{
 								label: 'EXT',
@@ -1039,13 +1059,14 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		// sim1 has both DB URLs set (preview_url from override, download_url from
 		// publishedSimfile default), so it is filtered out. Only sim2 needs
 		// discovery because its preview_url is null (publishedSimfile default).
-		// downloadUrl is DB-only so it never drives the discovery filter.
+		// sim2's download_url is also set, so downloadUrl does not drive discovery.
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
 				[
 					2,
 					{
 						previewUrl: null,
+						downloadUrl: null,
 						charts: [],
 						chartsPopulated: false
 					}
@@ -1178,6 +1199,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					2,
 					{
 						previewUrl: 'https://bucket.example/2/preview.mp3',
+						downloadUrl: null,
 						charts: [],
 						chartsPopulated: false
 					}
@@ -1216,15 +1238,36 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
-	it('returns null downloadUrl for list rows whose DB value is null or blank', async () => {
-		// downloadUrl is DB-only — when a row's download_url is null/blank
-		// the field renders as null in the GraphQL response without
-		// triggering R2 discovery. Only sim1 (whitespace) and sim2 (null)
-		// are covered; sim3 has a real DB value.
+	it('triggers batch catalog discovery for list rows whose download_url is null or blank', async () => {
+		// When downloadUrl is selected and the DB value is null/blank, the
+		// resolver falls back to R2 discovery. sim1 (whitespace) and sim2 (null)
+		// are passed to the batch; sim3 has a real DB value and is skipped.
 		const sim1 = { ...publishedSimfile, id: 1, download_url: '   ' };
 		const sim2 = { ...publishedSimfile, id: 2, download_url: null };
 		const sim3 = { ...publishedSimfile, id: 3, download_url: 'https://db.example/3.zip' };
 		mockedList.mockResolvedValue({ data: [sim1, sim2, sim3], count: 3 });
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					1,
+					{
+						previewUrl: null,
+						downloadUrl: 'https://bucket.example/1/music.ogg',
+						charts: [],
+						chartsPopulated: false
+					}
+				],
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: null,
+						charts: [],
+						chartsPopulated: false
+					}
+				]
+			])
+		);
 
 		const result = await runQuery(makeCtx(), {
 			query: '{ simfiles(scope: PUBLISHED, pageSize: 3) { data { id downloadUrl } } }'
@@ -1233,27 +1276,41 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.simfiles).toEqual({
 			data: [
-				{ id: '1', downloadUrl: null },
+				{ id: '1', downloadUrl: 'https://bucket.example/1/music.ogg' },
 				{ id: '2', downloadUrl: null },
 				{ id: '3', downloadUrl: 'https://db.example/3.zip' }
 			]
 		});
-		expect(mockedBatchCatalog).not.toHaveBeenCalled();
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 1,
+					dtxFiles: [],
+					publicBaseUrl: ''
+				},
+				{
+					simfileId: 2,
+					dtxFiles: [],
+					publicBaseUrl: ''
+				}
+			],
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
 	it('routes sims with blank DB preview_url through batch catalog discovery in list queries', async () => {
 		// Empty / whitespace-only DB preview_url must be treated like NULL in
 		// the prefetch filter so the sims are included in the discovery batch
-		// and the resolver falls back to the discovered value. downloadUrl is
-		// DB-only and does not influence discovery triggering — sim2 has
-		// preview_url set so it is fully resolved from the DB.
+		// and the resolver falls back to the discovered value.
 		const sim1 = { ...publishedSimfile, id: 1, preview_url: '' };
 		const sim2 = {
 			...publishedSimfile,
 			id: 2,
 			preview_url: 'https://db.example/2-preview.mp3',
-			download_url: '   '
+			download_url: 'https://db.example/2-download.zip'
 		};
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
 		mockedBatchCatalog.mockResolvedValue(
@@ -1262,6 +1319,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					1,
 					{
 						previewUrl: 'https://bucket.example/1/preview.mp3',
+						downloadUrl: null,
 						charts: [],
 						chartsPopulated: false
 					}
@@ -1290,14 +1348,12 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 				{
 					id: '2',
 					previewUrl: 'https://db.example/2-preview.mp3',
-					// sim2's whitespace download_url is not a discovery driver
-					// anymore — it just coerces to null in the resolver.
-					downloadUrl: null
+					downloadUrl: 'https://db.example/2-download.zip'
 				}
 			]
 		});
-		// Only sim1 needed discovery (blank preview_url). sim2's blank
-		// download_url does not drive the prefetch filter anymore.
+		// Only sim1 needed discovery (blank preview_url). sim2 has both DB
+		// URLs set, so it is skipped.
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
 		expect(mockedBatchCatalog).toHaveBeenCalledWith(
 			expect.anything(),
@@ -1326,6 +1382,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					1,
 					{
 						previewUrl: null,
+						downloadUrl: null,
 						charts: [
 							{
 								label: 'BSC',
@@ -1438,14 +1495,13 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		// resolvers would hit the partial entry and return stale null/empty
 		// values instead of triggering R2 discovery.
 		//
-		// Setup (downloadUrl is DB-only, so it no longer drives the prefetch filter):
-		// - List selects only downloadUrl. With the new contract neither sim
-		//   triggers discovery in the list path — sim1 has DB download_url set,
-		//   and downloadUrl is no longer a discovery driver. The list path does
-		//   not even enter the discovery block, so no cache entries are written.
+		// Setup:
+		// - List selects downloadUrl. sim1 has DB download_url set, so it is
+		//   skipped. sim2 has null download_url, so it triggers batch discovery.
+		//   No cache entry is written for sim1.
 		// - Detail selects previewUrl for sim1. sim1's preview_url is null on
 		//   the DB row, so the resolver must trigger single-sim discovery and
-		//   return the R2 URL — not the stale DB value.
+		//   return the R2 URL — not a stale partial cache entry.
 		const sim1 = {
 			...publishedSimfile,
 			id: 1,
@@ -1456,16 +1512,26 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		mockedGetSimfile.mockResolvedValue(sim1);
-		// Batch discovery is not called for a downloadUrl-only list — provide
-		// a default empty Map so the list resolver completes cleanly if it
-		// were ever called (it should not be).
-		mockedBatchCatalog.mockResolvedValue(new Map());
+		mockedBatchCatalog.mockResolvedValue(
+			new Map([
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: 'https://bucket.example/2/music.ogg',
+						charts: [],
+						chartsPopulated: false
+					}
+				]
+			])
+		);
 		// This discovery result is what the detail path's single-sim call
 		// should produce for sim1. If a poisoned partial cache entry from
 		// the list path leaks, the detail path skips discovery and returns
 		// the stale DB value instead of this R2 URL.
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://bucket.example/1/preview.mp3',
+			downloadUrl: null,
 			charts: [],
 			chartsPopulated: true
 		});
@@ -1486,15 +1552,26 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(result.data?.list).toEqual({
 			data: [
 				{ id: '1', downloadUrl: 'https://db.example/1-download.zip' },
-				{ id: '2', downloadUrl: null }
+				{ id: '2', downloadUrl: 'https://bucket.example/2/music.ogg' }
 			]
 		});
 		expect(result.data?.detail).toEqual({
 			id: '1',
 			previewUrl: 'https://bucket.example/1/preview.mp3'
 		});
-		// Batch discovery is not triggered: downloadUrl is DB-only.
-		expect(mockedBatchCatalog).not.toHaveBeenCalled();
+		// Batch discovery is triggered for sim2 (null download_url), not sim1.
+		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 2,
+					dtxFiles: [],
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		// Single-sim discovery must fire for sim1 from the detail path — it must
 		// NOT have been served by a stale partial cache entry from the list path.
 		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -278,8 +278,7 @@ describe('Query.simfiles', () => {
 		mockedList.mockResolvedValue({ data: [publishedSimfile], count: 1 });
 
 		const result = await runQuery(makeCtx(), {
-			query:
-				'{ simfiles(scope: PUBLISHED) { count data { id genre tags durationSeconds } } }'
+			query: '{ simfiles(scope: PUBLISHED) { count data { id genre tags durationSeconds } } }'
 		});
 
 		expect(result.errors).toBeUndefined();
@@ -563,8 +562,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		const result = await runQuery(
 			makeCtx({ env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://cdn.example' } }),
 			{
-				query:
-					'{ simfile(id: "42") { dtxFiles { label level fileUrl fileSizeBytes fileEncoding } } }'
+				query: '{ simfile(id: "42") { dtxFiles { label level fileUrl fileSizeBytes fileEncoding } } }'
 			}
 		);
 
@@ -675,6 +673,56 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 
 		const result = await runQuery(makeCtx(), {
 			query: '{ simfile(id: "42") { dtxFiles { label fileUrl } } }'
+		});
+
+		expect(result.errors?.[0]?.message).toBe('DTX chart file not found in R2');
+		expect(result.errors?.[0]?.extensions?.code).toBe('INTERNAL');
+	});
+
+	it('returns INTERNAL for fileSizeBytes when the DTX chart file is missing', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: null,
+			charts: [
+				{
+					label: 'BSC',
+					level: 7.5,
+					fileUrl: null,
+					fileSizeBytes: null,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			]
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { dtxFiles { label fileSizeBytes } } }'
+		});
+
+		expect(result.errors?.[0]?.message).toBe('DTX chart file not found in R2');
+		expect(result.errors?.[0]?.extensions?.code).toBe('INTERNAL');
+	});
+
+	it('returns INTERNAL for fileEncoding when the DTX chart file is missing', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: null,
+			charts: [
+				{
+					label: 'BSC',
+					level: 7.5,
+					fileUrl: null,
+					fileSizeBytes: null,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			]
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { dtxFiles { label fileEncoding } } }'
 		});
 
 		expect(result.errors?.[0]?.message).toBe('DTX chart file not found in R2');
@@ -850,8 +898,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
 			}),
 			{
-				query:
-					'{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id dtxFiles { label fileUrl } } } }'
+				query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id dtxFiles { label fileUrl } } } }'
 			}
 		);
 
@@ -934,8 +981,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
 			}),
 			{
-				query:
-					'{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
+				query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
 			}
 		);
 
@@ -974,8 +1020,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
 
 		const result = await runQuery(makeCtx(), {
-			query:
-				'{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id previewUrl downloadUrl } } }'
 		});
 
 		expect(result.errors).toBeUndefined();
@@ -1008,7 +1053,14 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
 				[1, { previewUrl: null, downloadUrl: null, charts: [] }],
-				[2, { previewUrl: 'https://bucket.example/2/preview.mp3', downloadUrl: null, charts: [] }]
+				[
+					2,
+					{
+						previewUrl: 'https://bucket.example/2/preview.mp3',
+						downloadUrl: null,
+						charts: []
+					}
+				]
 			])
 		);
 
@@ -1043,7 +1095,14 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
 				[1, { previewUrl: null, downloadUrl: null, charts: [] }],
-				[2, { previewUrl: null, downloadUrl: 'https://bucket.example/2/song.ogg', charts: [] }]
+				[
+					2,
+					{
+						previewUrl: null,
+						downloadUrl: 'https://bucket.example/2/song.ogg',
+						charts: []
+					}
+				]
 			])
 		);
 
@@ -1085,7 +1144,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 							{
 								label: 'BSC',
 								level: 3,
-								fileUrl: null,
+								fileUrl: 'https://cdn.example/1/bsc.dtx',
 								fileSizeBytes: 1234,
 								fileEncoding: 'SHIFT_JIS'
 							}

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -955,16 +955,11 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			download_url: 'https://db.example/download.zip'
 		};
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		// sim1 has both DB URLs set (preview_url from override, download_url from
+		// publishedSimfile default), so it is filtered out. Only sim2 needs
+		// discovery because its preview_url is null (publishedSimfile default).
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
-				[
-					1,
-					{
-						previewUrl: 'https://bucket.example/1/preview.mp3',
-						downloadUrl: null,
-						charts: []
-					}
-				],
 				[
 					2,
 					{
@@ -1001,6 +996,13 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 2,
+				dtxFiles: sim2.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			}
+		]);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1050,9 +1052,9 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		};
 		const sim2 = { ...publishedSimfile, id: 2, preview_url: null };
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		// Only sim2 needs discovery — sim1 has a DB preview_url so it is filtered out.
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
-				[1, { previewUrl: null, downloadUrl: null, charts: [] }],
 				[
 					2,
 					{
@@ -1081,6 +1083,13 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 2,
+				dtxFiles: sim2.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			}
+		]);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1092,9 +1101,9 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		};
 		const sim2 = { ...publishedSimfile, id: 2, download_url: null };
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+		// Only sim2 needs discovery — sim1 has a DB download_url so it is filtered out.
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
-				[1, { previewUrl: null, downloadUrl: null, charts: [] }],
 				[
 					2,
 					{
@@ -1123,6 +1132,13 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
+			{
+				simfileId: 2,
+				dtxFiles: sim2.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			}
+		]);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -542,19 +542,21 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
 			downloadUrl: null,
+			// charts are positional: charts[index] corresponds to
+			// dtx_files[index]. Order must match the dtx_files array.
 			charts: [
-				{
-					label: 'EXT',
-					level: 8.75,
-					fileUrl: 'https://cdn.example/42/ext.dtx',
-					fileSizeBytes: 2345,
-					fileEncoding: 'SHIFT_JIS'
-				},
 				{
 					label: 'ADV',
 					level: 5.25,
 					fileUrl: 'https://cdn.example/42/adv.dtx',
 					fileSizeBytes: 1234,
+					fileEncoding: 'SHIFT_JIS'
+				},
+				{
+					label: 'EXT',
+					level: 8.75,
+					fileUrl: 'https://cdn.example/42/ext.dtx',
+					fileSizeBytes: 2345,
 					fileEncoding: 'SHIFT_JIS'
 				}
 			],
@@ -600,6 +602,68 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			expect.anything()
 		);
 		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
+	});
+
+	it('resolves duplicate label+level rows by row index, not by label search', async () => {
+		// The DB schema has no UNIQUE constraint on (simfile_id, label, level),
+		// so two dtx_files rows can share the same label+level. The resolver
+		// must resolve each row positionally (charts[index]) rather than
+		// searching by label+level, which would return the first chart for
+		// both rows and expose the wrong R2 object for the second.
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({
+			...publishedSimfile,
+			dtx_files: [
+				{ label: 'BSC', level: 3 },
+				{ label: 'BSC', level: 3 }
+			]
+		});
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: null,
+			charts: [
+				{
+					label: 'BSC',
+					level: 3,
+					fileUrl: 'https://cdn.example/42/chart-a.dtx',
+					fileSizeBytes: 100,
+					fileEncoding: 'SHIFT_JIS'
+				},
+				{
+					label: 'BSC',
+					level: 3,
+					fileUrl: 'https://cdn.example/42/chart-b.dtx',
+					fileSizeBytes: 200,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			],
+			chartsPopulated: true
+		});
+
+		const result = await runQuery(
+			makeCtx({ env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://cdn.example' } }),
+			{
+				query: '{ simfile(id: "42") { dtxFiles { label level fileUrl fileSizeBytes } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			dtxFiles: [
+				{
+					label: 'BSC',
+					level: 3,
+					fileUrl: 'https://cdn.example/42/chart-a.dtx',
+					fileSizeBytes: 100
+				},
+				{
+					label: 'BSC',
+					level: 3,
+					fileUrl: 'https://cdn.example/42/chart-b.dtx',
+					fileSizeBytes: 200
+				}
+			]
+		});
 	});
 
 	it('falls back to discovered previewUrl when database preview_url is null', async () => {

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -57,6 +57,7 @@ const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 	ownerByIdCache: new Map(),
 	hasUploadedFilesCache: new Map(),
 	filesCache: new Map(),
+	catalogFilesCache: new Map(),
 	...overrides
 });
 
@@ -488,18 +489,33 @@ describe('Mutation.createSimfile', () => {
 });
 
 vi.mock('../services/r2Enrichment', () => ({
+	discoverCatalogFiles: vi.fn(),
 	enrichFiles: vi.fn(),
 	enrichHasUploadedFiles: vi.fn(),
 	batchEnrichHasUploadedFiles: vi.fn(async () => new Map()),
 	batchEnrichFiles: vi.fn(async () => new Map())
 }));
 
-const { enrichFiles, enrichHasUploadedFiles, batchEnrichHasUploadedFiles, batchEnrichFiles } =
-	await import('../services/r2Enrichment');
+const {
+	discoverCatalogFiles,
+	enrichFiles,
+	enrichHasUploadedFiles,
+	batchEnrichHasUploadedFiles,
+	batchEnrichFiles
+} = await import('../services/r2Enrichment');
+const mockedDiscoverCatalogFiles = vi.mocked(discoverCatalogFiles);
 const mockedFiles = vi.mocked(enrichFiles);
 const mockedHasUploaded = vi.mocked(enrichHasUploadedFiles);
 const mockedBatchHasUploaded = vi.mocked(batchEnrichHasUploadedFiles);
 const mockedBatchFiles = vi.mocked(batchEnrichFiles);
+
+beforeEach(() => {
+	mockedDiscoverCatalogFiles.mockReset().mockResolvedValue({
+		previewUrl: null,
+		downloadUrl: null,
+		charts: []
+	});
+});
 
 describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 	beforeEach(() => {
@@ -507,6 +523,157 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedHasUploaded.mockReset();
 		mockedBatchHasUploaded.mockReset().mockResolvedValue(new Map());
 		mockedBatchFiles.mockReset().mockResolvedValue(new Map());
+	});
+
+	it('resolves catalog DTX file metadata from discovered R2 files', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({
+			...publishedSimfile,
+			dtx_files: [
+				{ label: 'ADV', level: 5.25 },
+				{ label: 'EXT', level: 8.75 }
+			]
+		});
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: null,
+			charts: [
+				{
+					label: 'EXT',
+					level: 8.75,
+					fileUrl: 'https://cdn.example/42/ext.dtx',
+					fileSizeBytes: 2345,
+					fileEncoding: 'SHIFT_JIS'
+				},
+				{
+					label: 'ADV',
+					level: 5.25,
+					fileUrl: 'https://cdn.example/42/adv.dtx',
+					fileSizeBytes: 1234,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			]
+		});
+
+		const result = await runQuery(
+			makeCtx({ env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://cdn.example' } }),
+			{
+				query:
+					'{ simfile(id: "42") { dtxFiles { label level fileUrl fileSizeBytes fileEncoding } } }'
+			}
+		);
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			dtxFiles: [
+				{
+					label: 'ADV',
+					level: 5.25,
+					fileUrl: 'https://cdn.example/42/adv.dtx',
+					fileSizeBytes: 1234,
+					fileEncoding: 'SHIFT_JIS'
+				},
+				{
+					label: 'EXT',
+					level: 8.75,
+					fileUrl: 'https://cdn.example/42/ext.dtx',
+					fileSizeBytes: 2345,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			]
+		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledWith(expect.anything(), {
+			simfileId: 42,
+			dtxFiles: [
+				{ label: 'ADV', level: 5.25 },
+				{ label: 'EXT', level: 8.75 }
+			],
+			publicBaseUrl: 'https://cdn.example'
+		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to discovered previewUrl when database preview_url is null', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, preview_url: null });
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: 'https://cdn.example/42/preview.mp3',
+			downloadUrl: null,
+			charts: []
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { previewUrl } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			previewUrl: 'https://cdn.example/42/preview.mp3'
+		});
+	});
+
+	it('falls back to discovered downloadUrl when database download_url is null', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: null });
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: 'https://cdn.example/42/song.ogg',
+			charts: []
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { downloadUrl } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			downloadUrl: 'https://cdn.example/42/song.ogg'
+		});
+	});
+
+	it('prefers database previewUrl and downloadUrl over discovered values', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({
+			...publishedSimfile,
+			preview_url: 'https://db.example/preview.mp3',
+			download_url: 'https://db.example/download.zip'
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { previewUrl downloadUrl } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			previewUrl: 'https://db.example/preview.mp3',
+			downloadUrl: 'https://db.example/download.zip'
+		});
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('returns an INTERNAL field error when a selected DTX chart fileUrl is missing', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: null,
+			charts: [
+				{
+					label: 'BSC',
+					level: 7.5,
+					fileUrl: null,
+					fileSizeBytes: null,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			]
+		});
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { dtxFiles { label fileUrl } } }'
+		});
+
+		expect(result.errors?.[0]?.message).toBe('DTX chart file not found in R2');
+		expect(result.errors?.[0]?.extensions?.code).toBe('INTERNAL');
 	});
 
 	it('does not call enrichFiles when files is not selected', async () => {

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -127,6 +127,23 @@ describe('Query.simfile', () => {
 		});
 	});
 
+	it('exposes compatibility metadata defaults on a published simfile', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { id genre tags durationSeconds } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({
+			id: '42',
+			genre: null,
+			tags: [],
+			durationSeconds: null
+		});
+	});
+
 	it('FORBIDDEN for anonymous unpublished', async () => {
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 0 });
 		const result = await runQuery(makeCtx(), {
@@ -253,6 +270,28 @@ describe('Query.simfiles', () => {
 			search: undefined,
 			page: 1,
 			pageSize: 5
+		});
+	});
+
+	it('exposes compatibility metadata defaults in published list results', async () => {
+		mockedList.mockResolvedValue({ data: [publishedSimfile], count: 1 });
+
+		const result = await runQuery(makeCtx(), {
+			query:
+				'{ simfiles(scope: PUBLISHED) { count data { id genre tags durationSeconds } } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			count: 1,
+			data: [
+				{
+					id: '42',
+					genre: null,
+					tags: [],
+					durationSeconds: null
+				}
+			]
 		});
 	});
 

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -514,7 +514,6 @@ const mockedBatchCatalog = vi.mocked(batchDiscoverCatalogFiles);
 beforeEach(() => {
 	mockedDiscoverCatalogFiles.mockReset().mockResolvedValue({
 		previewUrl: null,
-		downloadUrl: null,
 		charts: [],
 		chartsPopulated: true
 	});
@@ -541,7 +540,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
-			downloadUrl: null,
 			charts: [
 				{
 					label: 'EXT',
@@ -607,7 +605,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, preview_url: null });
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://cdn.example/42/preview.mp3',
-			downloadUrl: null,
 			charts: [],
 			chartsPopulated: true
 		});
@@ -622,24 +619,39 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 	});
 
-	it('falls back to discovered downloadUrl when database download_url is null', async () => {
+	it('returns null downloadUrl when database download_url is null without consulting R2', async () => {
+		// downloadUrl is DB-only — the R2 listing cannot reliably identify
+		// "the main audio" because DTX simfiles contain many `#WAV` chip
+		// samples (kick.ogg, snare.wav, ...) which would otherwise be
+		// picked as the download URL. Actual file download is served by
+		// the /downloads/:id REST endpoint (ZIP stream), not by this field.
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: null });
-		mockedDiscoverCatalogFiles.mockResolvedValue({
-			previewUrl: null,
-			downloadUrl: 'https://cdn.example/42/song.ogg',
-			charts: [],
-			chartsPopulated: true
-		});
 
 		const result = await runQuery(makeCtx(), {
 			query: '{ simfile(id: "42") { downloadUrl } }'
 		});
 
 		expect(result.errors).toBeUndefined();
-		expect(result.data?.simfile).toEqual({
-			downloadUrl: 'https://cdn.example/42/song.ogg'
+		expect(result.data?.simfile).toEqual({ downloadUrl: null });
+		// discovery should never run for the downloadUrl-only query
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('treats whitespace-only database download_url as null without consulting R2', async () => {
+		// Mirrors the previewUrl behavior: empty / whitespace DB strings
+		// must be coerced to null so the GraphQL field renders as null
+		// rather than the raw '' to clients.
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: '   ' });
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfile(id: "42") { downloadUrl } }'
 		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfile).toEqual({ downloadUrl: null });
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
 	it('falls back to discovered previewUrl when database preview_url is an empty string', async () => {
@@ -650,7 +662,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, preview_url: '' });
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://cdn.example/42/preview.mp3',
-			downloadUrl: null,
 			charts: [],
 			chartsPopulated: true
 		});
@@ -662,27 +673,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.simfile).toEqual({
 			previewUrl: 'https://cdn.example/42/preview.mp3'
-		});
-		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
-	});
-
-	it('falls back to discovered downloadUrl when database download_url is whitespace-only', async () => {
-		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
-		mockedGetSimfile.mockResolvedValue({ ...publishedSimfile, download_url: '   ' });
-		mockedDiscoverCatalogFiles.mockResolvedValue({
-			previewUrl: null,
-			downloadUrl: 'https://cdn.example/42/song.ogg',
-			charts: [],
-			chartsPopulated: true
-		});
-
-		const result = await runQuery(makeCtx(), {
-			query: '{ simfile(id: "42") { downloadUrl } }'
-		});
-
-		expect(result.errors).toBeUndefined();
-		expect(result.data?.simfile).toEqual({
-			downloadUrl: 'https://cdn.example/42/song.ogg'
 		});
 		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
 	});
@@ -712,7 +702,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
-			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -738,7 +727,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
-			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -764,7 +752,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
-			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -790,7 +777,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedGetSimfile.mockResolvedValue(publishedSimfile);
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: null,
-			downloadUrl: null,
 			charts: [
 				{
 					label: 'BSC',
@@ -953,7 +939,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					1,
 					{
 						previewUrl: null,
-						downloadUrl: null,
 						charts: [
 							{
 								label: 'BSC',
@@ -970,7 +955,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					2,
 					{
 						previewUrl: null,
-						downloadUrl: null,
 						charts: [
 							{
 								label: 'EXT',
@@ -1040,7 +1024,7 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
-	it('uses batch catalog discovery for list previewUrl and downloadUrl selections', async () => {
+	it('uses batch catalog discovery for list previewUrl selections and returns DB downloadUrl', async () => {
 		const sim1 = {
 			...publishedSimfile,
 			id: 1,
@@ -1055,13 +1039,13 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		// sim1 has both DB URLs set (preview_url from override, download_url from
 		// publishedSimfile default), so it is filtered out. Only sim2 needs
 		// discovery because its preview_url is null (publishedSimfile default).
+		// downloadUrl is DB-only so it never drives the discovery filter.
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
 				[
 					2,
 					{
 						previewUrl: null,
-						downloadUrl: 'https://bucket.example/2/song.ogg',
 						charts: [],
 						chartsPopulated: false
 					}
@@ -1107,6 +1091,37 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			],
 			expect.anything()
 		);
+		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
+	});
+
+	it('does not trigger catalog discovery when only downloadUrl is selected and DB has values', async () => {
+		// downloadUrl is DB-only. Selecting it in a list query must not
+		// pull simfiles into the discovery batch — the resolver just
+		// returns each row's DB value.
+		const sim1 = {
+			...publishedSimfile,
+			id: 1,
+			download_url: 'https://db.example/1-download.zip'
+		};
+		const sim2 = {
+			...publishedSimfile,
+			id: 2,
+			download_url: 'https://db.example/2-download.zip'
+		};
+		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
+
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id downloadUrl } } }'
+		});
+
+		expect(result.errors).toBeUndefined();
+		expect(result.data?.simfiles).toEqual({
+			data: [
+				{ id: '1', downloadUrl: 'https://db.example/1-download.zip' },
+				{ id: '2', downloadUrl: 'https://db.example/2-download.zip' }
+			]
+		});
+		expect(mockedBatchCatalog).not.toHaveBeenCalled();
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1163,7 +1178,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					2,
 					{
 						previewUrl: 'https://bucket.example/2/preview.mp3',
-						downloadUrl: null,
 						charts: [],
 						chartsPopulated: false
 					}
@@ -1202,66 +1216,45 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
-	it('uses batch catalog discovery for list downloadUrl selections when any database value is missing', async () => {
-		const sim1 = {
-			...publishedSimfile,
-			id: 1,
-			download_url: 'https://db.example/1-download.zip'
-		};
+	it('returns null downloadUrl for list rows whose DB value is null or blank', async () => {
+		// downloadUrl is DB-only — when a row's download_url is null/blank
+		// the field renders as null in the GraphQL response without
+		// triggering R2 discovery. Only sim1 (whitespace) and sim2 (null)
+		// are covered; sim3 has a real DB value.
+		const sim1 = { ...publishedSimfile, id: 1, download_url: '   ' };
 		const sim2 = { ...publishedSimfile, id: 2, download_url: null };
-		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
-		// Only sim2 needs discovery — sim1 has a DB download_url so it is filtered out.
-		mockedBatchCatalog.mockResolvedValue(
-			new Map([
-				[
-					2,
-					{
-						previewUrl: null,
-						downloadUrl: 'https://bucket.example/2/song.ogg',
-						charts: [],
-						chartsPopulated: false
-					}
-				]
-			])
-		);
+		const sim3 = { ...publishedSimfile, id: 3, download_url: 'https://db.example/3.zip' };
+		mockedList.mockResolvedValue({ data: [sim1, sim2, sim3], count: 3 });
 
-		const result = await runQuery(
-			makeCtx({
-				env: { ...makeEnv(), PUBLIC_SIMFILE_BUCKET_URL: 'https://bucket.example' }
-			}),
-			{
-				query: '{ simfiles(scope: PUBLISHED, pageSize: 2) { data { id downloadUrl } } }'
-			}
-		);
+		const result = await runQuery(makeCtx(), {
+			query: '{ simfiles(scope: PUBLISHED, pageSize: 3) { data { id downloadUrl } } }'
+		});
 
 		expect(result.errors).toBeUndefined();
 		expect(result.data?.simfiles).toEqual({
 			data: [
-				{ id: '1', downloadUrl: 'https://db.example/1-download.zip' },
-				{ id: '2', downloadUrl: 'https://bucket.example/2/song.ogg' }
+				{ id: '1', downloadUrl: null },
+				{ id: '2', downloadUrl: null },
+				{ id: '3', downloadUrl: 'https://db.example/3.zip' }
 			]
 		});
-		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(
-			expect.anything(),
-			[
-				{
-					simfileId: 2,
-					dtxFiles: [],
-					publicBaseUrl: 'https://bucket.example'
-				}
-			],
-			expect.anything()
-		);
+		expect(mockedBatchCatalog).not.toHaveBeenCalled();
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
-	it('routes sims with blank DB URLs through batch catalog discovery in list queries', async () => {
-		// Empty / whitespace-only DB URLs must be treated like NULL in the
-		// prefetch filter so the sims are included in the discovery batch
-		// and the resolver falls back to the discovered value.
+	it('routes sims with blank DB preview_url through batch catalog discovery in list queries', async () => {
+		// Empty / whitespace-only DB preview_url must be treated like NULL in
+		// the prefetch filter so the sims are included in the discovery batch
+		// and the resolver falls back to the discovered value. downloadUrl is
+		// DB-only and does not influence discovery triggering — sim2 has
+		// preview_url set so it is fully resolved from the DB.
 		const sim1 = { ...publishedSimfile, id: 1, preview_url: '' };
-		const sim2 = { ...publishedSimfile, id: 2, download_url: '   ' };
+		const sim2 = {
+			...publishedSimfile,
+			id: 2,
+			preview_url: 'https://db.example/2-preview.mp3',
+			download_url: '   '
+		};
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
 		mockedBatchCatalog.mockResolvedValue(
 			new Map([
@@ -1269,16 +1262,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					1,
 					{
 						previewUrl: 'https://bucket.example/1/preview.mp3',
-						downloadUrl: null,
-						charts: [],
-						chartsPopulated: false
-					}
-				],
-				[
-					2,
-					{
-						previewUrl: null,
-						downloadUrl: 'https://bucket.example/2/song.ogg',
 						charts: [],
 						chartsPopulated: false
 					}
@@ -1301,26 +1284,26 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 				{
 					id: '1',
 					previewUrl: 'https://bucket.example/1/preview.mp3',
+					// publishedSimfile's default download_url
 					downloadUrl: 'https://ext.example/a'
 				},
 				{
 					id: '2',
-					previewUrl: null,
-					downloadUrl: 'https://bucket.example/2/song.ogg'
+					previewUrl: 'https://db.example/2-preview.mp3',
+					// sim2's whitespace download_url is not a discovery driver
+					// anymore — it just coerces to null in the resolver.
+					downloadUrl: null
 				}
 			]
 		});
+		// Only sim1 needed discovery (blank preview_url). sim2's blank
+		// download_url does not drive the prefetch filter anymore.
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
 		expect(mockedBatchCatalog).toHaveBeenCalledWith(
 			expect.anything(),
 			[
 				{
 					simfileId: 1,
-					dtxFiles: [],
-					publicBaseUrl: 'https://bucket.example'
-				},
-				{
-					simfileId: 2,
 					dtxFiles: [],
 					publicBaseUrl: 'https://bucket.example'
 				}
@@ -1343,7 +1326,6 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 					1,
 					{
 						previewUrl: null,
-						downloadUrl: null,
 						charts: [
 							{
 								label: 'BSC',
@@ -1456,16 +1438,14 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		// resolvers would hit the partial entry and return stale null/empty
 		// values instead of triggering R2 discovery.
 		//
-		// Setup:
-		// - sim1 has download_url set, preview_url null. In the list (which only
-		//   selects downloadUrl) it does NOT need discovery — it would be skipped
-		//   and previously got a partial cache entry with previewUrl: null.
-		// - sim2 has download_url null. In the list it DOES need discovery — this
-		//   is what triggers entry into the block that used to write partial cache
-		//   entries for the skipped sims.
-		// - The aliased `simfile(id: "1")` query selects previewUrl. Without the
-		//   fix, the resolver hits the poisoned entry and returns null. With the
-		//   fix, it falls through to single-sim discovery and returns the R2 URL.
+		// Setup (downloadUrl is DB-only, so it no longer drives the prefetch filter):
+		// - List selects only downloadUrl. With the new contract neither sim
+		//   triggers discovery in the list path — sim1 has DB download_url set,
+		//   and downloadUrl is no longer a discovery driver. The list path does
+		//   not even enter the discovery block, so no cache entries are written.
+		// - Detail selects previewUrl for sim1. sim1's preview_url is null on
+		//   the DB row, so the resolver must trigger single-sim discovery and
+		//   return the R2 URL — not the stale DB value.
 		const sim1 = {
 			...publishedSimfile,
 			id: 1,
@@ -1476,22 +1456,16 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		mockedList.mockResolvedValue({ data: [sim1, sim2], count: 2 });
 		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
 		mockedGetSimfile.mockResolvedValue(sim1);
-		mockedBatchCatalog.mockResolvedValue(
-			new Map([
-				[
-					2,
-					{
-						previewUrl: null,
-						downloadUrl: 'https://bucket.example/2/song.ogg',
-						charts: [],
-						chartsPopulated: false
-					}
-				]
-			])
-		);
+		// Batch discovery is not called for a downloadUrl-only list — provide
+		// a default empty Map so the list resolver completes cleanly if it
+		// were ever called (it should not be).
+		mockedBatchCatalog.mockResolvedValue(new Map());
+		// This discovery result is what the detail path's single-sim call
+		// should produce for sim1. If a poisoned partial cache entry from
+		// the list path leaks, the detail path skips discovery and returns
+		// the stale DB value instead of this R2 URL.
 		mockedDiscoverCatalogFiles.mockResolvedValue({
 			previewUrl: 'https://bucket.example/1/preview.mp3',
-			downloadUrl: null,
 			charts: [],
 			chartsPopulated: true
 		});
@@ -1512,26 +1486,15 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		expect(result.data?.list).toEqual({
 			data: [
 				{ id: '1', downloadUrl: 'https://db.example/1-download.zip' },
-				{ id: '2', downloadUrl: 'https://bucket.example/2/song.ogg' }
+				{ id: '2', downloadUrl: null }
 			]
 		});
 		expect(result.data?.detail).toEqual({
 			id: '1',
 			previewUrl: 'https://bucket.example/1/preview.mp3'
 		});
-		// Batch discovery fires only for sim2 (sim1 was skipped in the list path).
-		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(
-			expect.anything(),
-			[
-				{
-					simfileId: 2,
-					dtxFiles: [],
-					publicBaseUrl: 'https://bucket.example'
-				}
-			],
-			expect.anything()
-		);
+		// Batch discovery is not triggered: downloadUrl is DB-only.
+		expect(mockedBatchCatalog).not.toHaveBeenCalled();
 		// Single-sim discovery must fire for sim1 from the detail path — it must
 		// NOT have been served by a stale partial cache entry from the list path.
 		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);

--- a/packages/dtx-api/src/schema/simfile.test.ts
+++ b/packages/dtx-api/src/schema/simfile.test.ts
@@ -585,14 +585,18 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 				}
 			]
 		});
-		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledWith(expect.anything(), {
-			simfileId: 42,
-			dtxFiles: [
-				{ label: 'ADV', level: 5.25 },
-				{ label: 'EXT', level: 8.75 }
-			],
-			publicBaseUrl: 'https://cdn.example'
-		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledWith(
+			expect.anything(),
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'ADV', level: 5.25 },
+					{ label: 'EXT', level: 8.75 }
+				],
+				publicBaseUrl: 'https://cdn.example'
+			},
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
 	});
 
@@ -770,6 +774,40 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 
 		expect(result.errors?.[0]?.message).toBe('DTX chart file not found in R2');
 		expect(result.errors?.[0]?.extensions?.code).toBe('INTERNAL');
+	});
+
+	it('logs to ctx.logger.error before throwing when a DTX chart file is missing', async () => {
+		mockedGetOwner.mockResolvedValue({ user_id: 'u1', is_published: 1 });
+		mockedGetSimfile.mockResolvedValue(publishedSimfile);
+		mockedDiscoverCatalogFiles.mockResolvedValue({
+			previewUrl: null,
+			downloadUrl: null,
+			charts: [
+				{
+					label: 'BSC',
+					level: 7.5,
+					fileUrl: null,
+					fileSizeBytes: null,
+					fileEncoding: 'SHIFT_JIS'
+				}
+			]
+		});
+
+		const logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn()
+		};
+		await runQuery(makeCtx({ logger }), {
+			query: '{ simfile(id: "42") { dtxFiles { label fileUrl } } }'
+		});
+
+		expect(logger.error).toHaveBeenCalledWith('DTX chart file missing in R2', {
+			simfileId: 42,
+			label: 'BSC',
+			level: 7.5
+		});
 	});
 
 	it('does not call enrichFiles when files is not selected', async () => {
@@ -959,18 +997,22 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
-			{
-				simfileId: 1,
-				dtxFiles: [{ label: 'BSC', level: 3 }],
-				publicBaseUrl: 'https://bucket.example'
-			},
-			{
-				simfileId: 2,
-				dtxFiles: [{ label: 'EXT', level: 8 }],
-				publicBaseUrl: 'https://bucket.example'
-			}
-		]);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 1,
+					dtxFiles: [{ label: 'BSC', level: 3 }],
+					publicBaseUrl: 'https://bucket.example'
+				},
+				{
+					simfileId: 2,
+					dtxFiles: [{ label: 'EXT', level: 8 }],
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1039,13 +1081,17 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
-			{
-				simfileId: 2,
-				dtxFiles: sim2.dtx_files,
-				publicBaseUrl: 'https://bucket.example'
-			}
-		]);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 2,
+					dtxFiles: sim2.dtx_files,
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1126,13 +1172,17 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
-			{
-				simfileId: 2,
-				dtxFiles: sim2.dtx_files,
-				publicBaseUrl: 'https://bucket.example'
-			}
-		]);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 2,
+					dtxFiles: sim2.dtx_files,
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1175,13 +1225,17 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
-			{
-				simfileId: 2,
-				dtxFiles: sim2.dtx_files,
-				publicBaseUrl: 'https://bucket.example'
-			}
-		]);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 2,
+					dtxFiles: sim2.dtx_files,
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1238,18 +1292,22 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 			]
 		});
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
-			{
-				simfileId: 1,
-				dtxFiles: sim1.dtx_files,
-				publicBaseUrl: 'https://bucket.example'
-			},
-			{
-				simfileId: 2,
-				dtxFiles: sim2.dtx_files,
-				publicBaseUrl: 'https://bucket.example'
-			}
-		]);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 1,
+					dtxFiles: sim1.dtx_files,
+					publicBaseUrl: 'https://bucket.example'
+				},
+				{
+					simfileId: 2,
+					dtxFiles: sim2.dtx_files,
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		expect(mockedDiscoverCatalogFiles).not.toHaveBeenCalled();
 	});
 
@@ -1441,21 +1499,29 @@ describe('Simfile.files / Simfile.hasUploadedFiles (lazy)', () => {
 		});
 		// Batch discovery fires only for sim2 (sim1 was skipped in the list path).
 		expect(mockedBatchCatalog).toHaveBeenCalledTimes(1);
-		expect(mockedBatchCatalog).toHaveBeenCalledWith(expect.anything(), [
-			{
-				simfileId: 2,
-				dtxFiles: sim2.dtx_files,
-				publicBaseUrl: 'https://bucket.example'
-			}
-		]);
+		expect(mockedBatchCatalog).toHaveBeenCalledWith(
+			expect.anything(),
+			[
+				{
+					simfileId: 2,
+					dtxFiles: sim2.dtx_files,
+					publicBaseUrl: 'https://bucket.example'
+				}
+			],
+			expect.anything()
+		);
 		// Single-sim discovery must fire for sim1 from the detail path — it must
 		// NOT have been served by a stale partial cache entry from the list path.
 		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledTimes(1);
-		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledWith(expect.anything(), {
-			simfileId: 1,
-			dtxFiles: sim1.dtx_files,
-			publicBaseUrl: 'https://bucket.example'
-		});
+		expect(mockedDiscoverCatalogFiles).toHaveBeenCalledWith(
+			expect.anything(),
+			{
+				simfileId: 1,
+				dtxFiles: sim1.dtx_files,
+				publicBaseUrl: 'https://bucket.example'
+			},
+			expect.anything()
+		);
 	});
 });
 

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -95,6 +95,9 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		publishDate: t.string({ resolve: (s) => s.publish_date }),
 		createdAt: t.string({ resolve: (s) => s.created_at }),
 		updatedAt: t.string({ resolve: (s) => s.updated_at }),
+		genre: t.string({ nullable: true, resolve: () => null }),
+		tags: t.stringList({ resolve: () => [] }),
+		durationSeconds: t.int({ nullable: true, resolve: () => null }),
 		dtxFiles: t.field({ type: [DtxFile], resolve: (s) => s.dtx_files }),
 		files: t.field({
 			type: [R2File],

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -254,14 +254,10 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		displayId: t.int({ nullable: true, resolve: (s) => s.display_id }),
 		downloadUrl: t.string({
 			nullable: true,
-			// DB-only: the canonical download URL is whatever the author sets
-			// (external link or hosted full audio). The R2 listing cannot
-			// identify "the main audio" reliably because DTX simfiles contain
-			// many `#WAV` chip samples (kick.ogg, snare.wav, ...) which would
-			// otherwise be picked as the download URL. Actual file download is
-			// served by the /downloads/:id REST endpoint (ZIP stream), not by
-			// this field.
-			resolve: (s) => nonBlank(s.download_url) ?? null
+			// Return the DB download_url if set; otherwise discover a likely
+			// full-audio object under the simfile's R2 prefix.
+			resolve: async (s, _args, ctx) =>
+				nonBlank(s.download_url) ?? (await getCatalogDiscovery(ctx, s)).downloadUrl
 		}),
 		previewUrl: t.string({
 			nullable: true,
@@ -348,6 +344,7 @@ export const SimfileConnectionRef = builder
 						}
 
 						const previewSelected = isFieldSelected(info, 'previewUrl');
+						const downloadSelected = isFieldSelected(info, 'downloadUrl');
 						const dtxSelected = isNestedFieldSelected(info, 'dtxFiles', [
 							'fileUrl',
 							'fileSizeBytes',
@@ -356,14 +353,11 @@ export const SimfileConnectionRef = builder
 
 						// Per-sim filter: only sims that actually need R2 discovery are passed
 						// to the batch. Sims whose selected catalog-backed fields all have
-						// non-blank DB values, and whose dtx file fields were not selected,
-						// skip discovery entirely — their resolvers short-circuit at
-						// nonBlank(...) before ever consulting the cache.
-						// Note: downloadUrl is DB-only (no R2 fallback) and is therefore
-						// intentionally excluded from this filter — selecting downloadUrl
-						// alone never triggers discovery.
+						// non-blank DB values skip discovery entirely — their resolvers
+						// short-circuit at nonBlank(...) before ever consulting the cache.
 						const simsNeedingDiscovery = c.data.filter((s) => {
 							if (previewSelected && nonBlank(s.preview_url) == null) return true;
+							if (downloadSelected && nonBlank(s.download_url) == null) return true;
 							if (dtxSelected) return true;
 							return false;
 						});
@@ -392,7 +386,9 @@ export const SimfileConnectionRef = builder
 										(map) =>
 											map.get(s.id) ?? {
 												previewUrl: null,
-												charts: []
+												downloadUrl: null,
+												charts: [],
+												chartsPopulated: false
 											}
 									)
 								);

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -294,14 +294,19 @@ export const SimfileConnectionRef = builder
 							}
 						}
 
+						const needsPreviewDiscovery =
+							isFieldSelected(info, 'previewUrl') &&
+							c.data.some((s) => s.preview_url == null);
+						const needsDownloadDiscovery =
+							isFieldSelected(info, 'downloadUrl') &&
+							c.data.some((s) => s.download_url == null);
+						const needsDtxDiscovery = isNestedFieldSelected(info, 'dtxFiles', [
+							'fileUrl',
+							'fileSizeBytes',
+							'fileEncoding'
+						]);
 						const shouldBatchCatalogFiles =
-							isFieldSelected(info, 'previewUrl') ||
-							isFieldSelected(info, 'downloadUrl') ||
-							isNestedFieldSelected(info, 'dtxFiles', [
-								'fileUrl',
-								'fileSizeBytes',
-								'fileEncoding'
-							]);
+							needsPreviewDiscovery || needsDownloadDiscovery || needsDtxDiscovery;
 
 						if (shouldBatchCatalogFiles) {
 							const catalogBatchPromise = batchDiscoverCatalogFiles(

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -18,7 +18,11 @@ import {
 	batchDiscoverCatalogFiles,
 	discoverCatalogFiles
 } from '../services/r2Enrichment';
-import type { CatalogChartFile, CatalogFileDiscovery } from '../services/r2Enrichment';
+import type {
+	CatalogChartFile,
+	CatalogChartFilePresent,
+	CatalogFileDiscovery
+} from '../services/r2Enrichment';
 import { createSimfileWithDtx } from '../services/createSimfile';
 import type { Ctx } from '../context';
 
@@ -151,11 +155,15 @@ const getCatalogDiscovery = (
 	const cached = cache.get(simfile.id);
 	if (cached) return cached;
 
-	const promise = discoverCatalogFiles(ctx.r2, {
-		simfileId: simfile.id,
-		dtxFiles: simfile.dtx_files,
-		publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
-	});
+	const promise = discoverCatalogFiles(
+		ctx.r2,
+		{
+			simfileId: simfile.id,
+			dtxFiles: simfile.dtx_files,
+			publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+		},
+		ctx.logger
+	);
 	cache.set(simfile.id, promise);
 	return promise;
 };
@@ -172,24 +180,27 @@ const findCatalogChart = async (
 
 /**
  * Returns the catalog chart for the given DTX row, or throws an INTERNAL
- * GraphQLError if the backing R2 object is missing. All three DTX file
- * fields (fileUrl, fileSizeBytes, fileEncoding) describe the same R2
- * object, so they must fail consistently — returning a fallback value
- * (0 / SHIFT_JIS) for a missing file would mislead clients.
+ * GraphQLError if the backing R2 object is missing. The discriminated-
+ * union return type (CatalogChartFilePresent) guarantees fileUrl and
+ * fileSizeBytes are both present, so callers get non-null values without
+ * defensive fallbacks.
  */
 const requireCatalogChart = async (
 	ctx: Ctx,
 	parent: DtxFileParent
-): Promise<Omit<CatalogChartFile, 'fileUrl' | 'fileSizeBytes'> & { fileUrl: string; fileSizeBytes: number }> => {
+): Promise<CatalogChartFilePresent> => {
 	const chart = await findCatalogChart(ctx, parent);
-	if (!chart?.fileUrl) {
+	if (!chart || chart.fileUrl === null) {
+		ctx.logger.error('DTX chart file missing in R2', {
+			simfileId: parent.simfile.id,
+			label: parent.label,
+			level: parent.level
+		});
 		throw new GraphQLError('DTX chart file not found in R2', {
 			extensions: { code: 'INTERNAL' }
 		});
 	}
-	// fileUrl is non-null here, and fileSizeBytes is always set alongside
-	// fileUrl in discoverCatalogFiles (both derive from the same R2 object).
-	return { ...chart, fileUrl: chart.fileUrl, fileSizeBytes: chart.fileSizeBytes ?? 0 };
+	return chart;
 };
 
 const DtxFile = builder.objectRef<DtxFileParent>('DtxFile').implement({
@@ -331,50 +342,51 @@ export const SimfileConnectionRef = builder
 						// non-blank DB values, and whose dtx file fields were not selected,
 						// skip discovery entirely — their resolvers short-circuit at
 						// nonBlank(...) before ever consulting the cache.
-					const simsNeedingDiscovery = c.data.filter((s) => {
-						if (previewSelected && nonBlank(s.preview_url) == null) return true;
-						if (downloadSelected && nonBlank(s.download_url) == null) return true;
-						if (dtxSelected) return true;
-						return false;
-					});
+						const simsNeedingDiscovery = c.data.filter((s) => {
+							if (previewSelected && nonBlank(s.preview_url) == null) return true;
+							if (downloadSelected && nonBlank(s.download_url) == null) return true;
+							if (dtxSelected) return true;
+							return false;
+						});
 
-					if (simsNeedingDiscovery.length > 0) {
-						const catalogBatchPromise = batchDiscoverCatalogFiles(
-							ctx.r2,
-							simsNeedingDiscovery.map((s) => ({
-								simfileId: s.id,
-								dtxFiles: s.dtx_files,
-								publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
-							}))
-						);
-						const cache =
-							ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
-						for (const s of simsNeedingDiscovery) {
-							cache.set(
-								s.id,
-								catalogBatchPromise.then(
-									(map) =>
-										map.get(s.id) ?? {
-											previewUrl: null,
-											downloadUrl: null,
-											charts: []
-										}
-								)
+						if (simsNeedingDiscovery.length > 0) {
+							const catalogBatchPromise = batchDiscoverCatalogFiles(
+								ctx.r2,
+								simsNeedingDiscovery.map((s) => ({
+									simfileId: s.id,
+									dtxFiles: s.dtx_files,
+									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+								})),
+								ctx.logger
 							);
+							const cache =
+								ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
+							for (const s of simsNeedingDiscovery) {
+								cache.set(
+									s.id,
+									catalogBatchPromise.then(
+										(map) =>
+											map.get(s.id) ?? {
+												previewUrl: null,
+												downloadUrl: null,
+												charts: []
+											}
+									)
+								);
+							}
+							// Intentionally do NOT populate cache entries for sims that
+							// skipped discovery. Writing partial entries (DB URLs only,
+							// charts: []) would poison the request-scoped cache: if the
+							// same simfile is reached via another resolver path in this
+							// document that selects a catalog field the list path did not
+							// (e.g. an aliased `simfile(id)` query alongside the list), the
+							// field resolver would short-circuit on the partial entry and
+							// return a stale null/empty value instead of discovering R2.
+							// A cache miss in getCatalogDiscovery correctly falls through
+							// to single-sim discovery, and resolvers for skipped sims
+							// short-circuit at nonBlank(...) before ever consulting the
+							// cache, so leaving them uncached has no cost in normal flow.
 						}
-						// Intentionally do NOT populate cache entries for sims that
-						// skipped discovery. Writing partial entries (DB URLs only,
-						// charts: []) would poison the request-scoped cache: if the
-						// same simfile is reached via another resolver path in this
-						// document that selects a catalog field the list path did not
-						// (e.g. an aliased `simfile(id)` query alongside the list), the
-						// field resolver would short-circuit on the partial entry and
-						// return a stale null/empty value instead of discovering R2.
-						// A cache miss in getCatalogDiscovery correctly falls through
-						// to single-sim discovery, and resolvers for skipped sims
-						// short-circuit at nonBlank(...) before ever consulting the
-						// cache, so leaving them uncached has no cost in normal flow.
-					}
 					}
 					return c.data;
 				}

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -307,24 +307,29 @@ export const SimfileConnectionRef = builder
 							}
 						}
 
-						const needsPreviewDiscovery =
-							isFieldSelected(info, 'previewUrl') &&
-							c.data.some((s) => s.preview_url == null);
-						const needsDownloadDiscovery =
-							isFieldSelected(info, 'downloadUrl') &&
-							c.data.some((s) => s.download_url == null);
-						const needsDtxDiscovery = isNestedFieldSelected(info, 'dtxFiles', [
+						const previewSelected = isFieldSelected(info, 'previewUrl');
+						const downloadSelected = isFieldSelected(info, 'downloadUrl');
+						const dtxSelected = isNestedFieldSelected(info, 'dtxFiles', [
 							'fileUrl',
 							'fileSizeBytes',
 							'fileEncoding'
 						]);
-						const shouldBatchCatalogFiles =
-							needsPreviewDiscovery || needsDownloadDiscovery || needsDtxDiscovery;
 
-						if (shouldBatchCatalogFiles) {
+						// Per-sim filter: only sims that actually need R2 discovery are passed
+						// to the batch. Sims with both DB URLs set and no dtx file fields
+						// selected skip discovery entirely — their cache entry is pre-resolved
+						// with the existing DB values so consumers see a uniform cache API.
+						const simsNeedingDiscovery = c.data.filter((s) => {
+							if (previewSelected && s.preview_url == null) return true;
+							if (downloadSelected && s.download_url == null) return true;
+							if (dtxSelected) return true;
+							return false;
+						});
+
+						if (simsNeedingDiscovery.length > 0) {
 							const catalogBatchPromise = batchDiscoverCatalogFiles(
 								ctx.r2,
-								c.data.map((s) => ({
+								simsNeedingDiscovery.map((s) => ({
 									simfileId: s.id,
 									dtxFiles: s.dtx_files,
 									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
@@ -332,7 +337,7 @@ export const SimfileConnectionRef = builder
 							);
 							const cache =
 								ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
-							for (const s of c.data) {
+							for (const s of simsNeedingDiscovery) {
 								cache.set(
 									s.id,
 									catalogBatchPromise.then(
@@ -343,6 +348,20 @@ export const SimfileConnectionRef = builder
 												charts: []
 											}
 									)
+								);
+							}
+							// Populate cache for sims that did not need discovery so consumers
+							// always find an entry. previewUrl/downloadUrl come from the DB;
+							// charts is empty because dtx file fields were not selected.
+							for (const s of c.data) {
+								if (simsNeedingDiscovery.includes(s)) continue;
+								cache.set(
+									s.id,
+									Promise.resolve({
+										previewUrl: s.preview_url,
+										downloadUrl: s.download_url,
+										charts: []
+									})
 								);
 							}
 						}

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -132,6 +132,17 @@ type DtxFileParent = {
 	simfile: SimfileWithDtxFiles;
 };
 
+/**
+ * Returns the value if it is a non-empty, non-whitespace string; otherwise
+ * null. The DB can store `''` for preview_url/download_url because the
+ * ChartDetail form submits empty inputs as empty strings, and the update
+ * resolver passes those through verbatim. Treat such values the same as
+ * NULL so the catalog-fallback path runs and clients don't receive a
+ * blank URL.
+ */
+const nonBlank = (value: string | null | undefined): string | null =>
+	value != null && value.trim() !== '' ? value : null;
+
 const getCatalogDiscovery = (
 	ctx: Ctx,
 	simfile: SimfileWithDtxFiles
@@ -221,12 +232,12 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		downloadUrl: t.string({
 			nullable: true,
 			resolve: async (s, _args, ctx) =>
-				s.download_url ?? (await getCatalogDiscovery(ctx, s)).downloadUrl
+				nonBlank(s.download_url) ?? (await getCatalogDiscovery(ctx, s)).downloadUrl
 		}),
 		previewUrl: t.string({
 			nullable: true,
 			resolve: async (s, _args, ctx) =>
-				s.preview_url ?? (await getCatalogDiscovery(ctx, s)).previewUrl
+				nonBlank(s.preview_url) ?? (await getCatalogDiscovery(ctx, s)).previewUrl
 		}),
 		videoPreviewUrl: t.string({ nullable: true, resolve: (s) => s.video_preview_url }),
 		publishDate: t.string({ resolve: (s) => s.publish_date }),
@@ -319,12 +330,12 @@ export const SimfileConnectionRef = builder
 						// to the batch. Sims with both DB URLs set and no dtx file fields
 						// selected skip discovery entirely — their cache entry is pre-resolved
 						// with the existing DB values so consumers see a uniform cache API.
-						const simsNeedingDiscovery = c.data.filter((s) => {
-							if (previewSelected && s.preview_url == null) return true;
-							if (downloadSelected && s.download_url == null) return true;
-							if (dtxSelected) return true;
-							return false;
-						});
+					const simsNeedingDiscovery = c.data.filter((s) => {
+						if (previewSelected && nonBlank(s.preview_url) == null) return true;
+						if (downloadSelected && nonBlank(s.download_url) == null) return true;
+						if (dtxSelected) return true;
+						return false;
+					});
 
 						if (simsNeedingDiscovery.length > 0) {
 							const catalogBatchPromise = batchDiscoverCatalogFiles(

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -14,9 +14,12 @@ import {
 	enrichFiles,
 	enrichHasUploadedFiles,
 	batchEnrichHasUploadedFiles,
-	batchEnrichFiles
+	batchEnrichFiles,
+	discoverCatalogFiles
 } from '../services/r2Enrichment';
+import type { CatalogChartFile, CatalogFileDiscovery } from '../services/r2Enrichment';
 import { createSimfileWithDtx } from '../services/createSimfile';
+import type { Ctx } from '../context';
 
 /**
  * Checks whether a given field name appears in the selection set of the
@@ -61,12 +64,73 @@ export const SimfileScopeEnum = builder.enumType('SimfileScope', {
 	values: ['MINE', 'PUBLISHED'] as const
 });
 
+export const FileEncodingEnum = builder.enumType('FileEncoding', {
+	values: ['SHIFT_JIS', 'UTF_8'] as const
+});
+
 // --- object types ---
 
-const DtxFile = builder.objectRef<{ level: number; label: string }>('DtxFile').implement({
+type DtxFileParent = {
+	level: number;
+	label: string;
+	simfile: SimfileWithDtxFiles;
+};
+
+const getCatalogDiscovery = (
+	ctx: Ctx,
+	simfile: SimfileWithDtxFiles
+): Promise<CatalogFileDiscovery> => {
+	const cache = ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
+	const cached = cache.get(simfile.id);
+	if (cached) return cached;
+
+	const promise = discoverCatalogFiles(ctx.r2, {
+		simfileId: simfile.id,
+		dtxFiles: simfile.dtx_files,
+		publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+	});
+	cache.set(simfile.id, promise);
+	return promise;
+};
+
+const findCatalogChart = async (
+	ctx: Ctx,
+	parent: DtxFileParent
+): Promise<CatalogChartFile | undefined> => {
+	const discovery = await getCatalogDiscovery(ctx, parent.simfile);
+	return discovery.charts.find(
+		(chart) => chart.label === parent.label && chart.level === parent.level
+	);
+};
+
+const DtxFile = builder.objectRef<DtxFileParent>('DtxFile').implement({
 	fields: (t) => ({
 		level: t.exposeFloat('level'),
-		label: t.exposeString('label')
+		label: t.exposeString('label'),
+		fileUrl: t.string({
+			resolve: async (file, _args, ctx) => {
+				const chart = await findCatalogChart(ctx, file);
+				if (!chart?.fileUrl) {
+					throw new GraphQLError('DTX chart file not found in R2', {
+						extensions: { code: 'INTERNAL' }
+					});
+				}
+				return chart.fileUrl;
+			}
+		}),
+		fileSizeBytes: t.int({
+			resolve: async (file, _args, ctx) => {
+				const chart = await findCatalogChart(ctx, file);
+				return chart?.fileSizeBytes ?? 0;
+			}
+		}),
+		fileEncoding: t.field({
+			type: FileEncodingEnum,
+			resolve: async (file, _args, ctx) => {
+				const chart = await findCatalogChart(ctx, file);
+				return chart?.fileEncoding ?? 'SHIFT_JIS';
+			}
+		})
 	})
 });
 
@@ -89,8 +153,16 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		userId: t.id({ nullable: true, resolve: (s) => s.user_id ?? null }),
 		isPublished: t.boolean({ resolve: (s) => s.is_published }),
 		displayId: t.int({ nullable: true, resolve: (s) => s.display_id }),
-		downloadUrl: t.string({ nullable: true, resolve: (s) => s.download_url }),
-		previewUrl: t.string({ nullable: true, resolve: (s) => s.preview_url }),
+		downloadUrl: t.string({
+			nullable: true,
+			resolve: async (s, _args, ctx) =>
+				s.download_url ?? (await getCatalogDiscovery(ctx, s)).downloadUrl
+		}),
+		previewUrl: t.string({
+			nullable: true,
+			resolve: async (s, _args, ctx) =>
+				s.preview_url ?? (await getCatalogDiscovery(ctx, s)).previewUrl
+		}),
 		videoPreviewUrl: t.string({ nullable: true, resolve: (s) => s.video_preview_url }),
 		publishDate: t.string({ resolve: (s) => s.publish_date }),
 		createdAt: t.string({ resolve: (s) => s.created_at }),
@@ -98,7 +170,10 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		genre: t.string({ nullable: true, resolve: () => null }),
 		tags: t.stringList({ resolve: () => [] }),
 		durationSeconds: t.int({ nullable: true, resolve: () => null }),
-		dtxFiles: t.field({ type: [DtxFile], resolve: (s) => s.dtx_files }),
+		dtxFiles: t.field({
+			type: [DtxFile],
+			resolve: (s) => s.dtx_files.map((file) => ({ ...file, simfile: s }))
+		}),
 		files: t.field({
 			type: [R2File],
 			resolve: async (s, _args, ctx) => {

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -73,7 +73,9 @@ const isNestedFieldSelected = (
 					return sel.name.value !== '__typename' && childFields.has(sel.name.value);
 				case 'FragmentSpread': {
 					const fragment = info.fragments[sel.name.value];
-					return fragment ? checkChildSelections(fragment.selectionSet.selections) : false;
+					return fragment
+						? checkChildSelections(fragment.selectionSet.selections)
+						: false;
 				}
 				case 'InlineFragment':
 					return checkChildSelections(sel.selectionSet.selections);
@@ -94,7 +96,9 @@ const isNestedFieldSelected = (
 						: false;
 				case 'FragmentSpread': {
 					const fragment = info.fragments[sel.name.value];
-					return fragment ? checkParentSelections(fragment.selectionSet.selections) : false;
+					return fragment
+						? checkParentSelections(fragment.selectionSet.selections)
+						: false;
 				}
 				case 'InlineFragment':
 					return checkParentSelections(sel.selectionSet.selections);
@@ -155,33 +159,42 @@ const findCatalogChart = async (
 	);
 };
 
+/**
+ * Returns the catalog chart for the given DTX row, or throws an INTERNAL
+ * GraphQLError if the backing R2 object is missing. All three DTX file
+ * fields (fileUrl, fileSizeBytes, fileEncoding) describe the same R2
+ * object, so they must fail consistently — returning a fallback value
+ * (0 / SHIFT_JIS) for a missing file would mislead clients.
+ */
+const requireCatalogChart = async (
+	ctx: Ctx,
+	parent: DtxFileParent
+): Promise<Omit<CatalogChartFile, 'fileUrl' | 'fileSizeBytes'> & { fileUrl: string; fileSizeBytes: number }> => {
+	const chart = await findCatalogChart(ctx, parent);
+	if (!chart?.fileUrl) {
+		throw new GraphQLError('DTX chart file not found in R2', {
+			extensions: { code: 'INTERNAL' }
+		});
+	}
+	// fileUrl is non-null here, and fileSizeBytes is always set alongside
+	// fileUrl in discoverCatalogFiles (both derive from the same R2 object).
+	return { ...chart, fileUrl: chart.fileUrl, fileSizeBytes: chart.fileSizeBytes ?? 0 };
+};
+
 const DtxFile = builder.objectRef<DtxFileParent>('DtxFile').implement({
 	fields: (t) => ({
 		level: t.exposeFloat('level'),
 		label: t.exposeString('label'),
 		fileUrl: t.string({
-			resolve: async (file, _args, ctx) => {
-				const chart = await findCatalogChart(ctx, file);
-				if (!chart?.fileUrl) {
-					throw new GraphQLError('DTX chart file not found in R2', {
-						extensions: { code: 'INTERNAL' }
-					});
-				}
-				return chart.fileUrl;
-			}
+			resolve: async (file, _args, ctx) => (await requireCatalogChart(ctx, file)).fileUrl
 		}),
 		fileSizeBytes: t.int({
-			resolve: async (file, _args, ctx) => {
-				const chart = await findCatalogChart(ctx, file);
-				return chart?.fileSizeBytes ?? 0;
-			}
+			resolve: async (file, _args, ctx) =>
+				(await requireCatalogChart(ctx, file)).fileSizeBytes
 		}),
 		fileEncoding: t.field({
 			type: FileEncodingEnum,
-			resolve: async (file, _args, ctx) => {
-				const chart = await findCatalogChart(ctx, file);
-				return chart?.fileEncoding ?? 'SHIFT_JIS';
-			}
+			resolve: async (file, _args, ctx) => (await requireCatalogChart(ctx, file)).fileEncoding
 		})
 	})
 });
@@ -317,7 +330,8 @@ export const SimfileConnectionRef = builder
 									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
 								}))
 							);
-							const cache = ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
+							const cache =
+								ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
 							for (const s of c.data) {
 								cache.set(
 									s.id,

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -254,8 +254,14 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		displayId: t.int({ nullable: true, resolve: (s) => s.display_id }),
 		downloadUrl: t.string({
 			nullable: true,
-			resolve: async (s, _args, ctx) =>
-				nonBlank(s.download_url) ?? (await getCatalogDiscovery(ctx, s)).downloadUrl
+			// DB-only: the canonical download URL is whatever the author sets
+			// (external link or hosted full audio). The R2 listing cannot
+			// identify "the main audio" reliably because DTX simfiles contain
+			// many `#WAV` chip samples (kick.ogg, snare.wav, ...) which would
+			// otherwise be picked as the download URL. Actual file download is
+			// served by the /downloads/:id REST endpoint (ZIP stream), not by
+			// this field.
+			resolve: (s) => nonBlank(s.download_url) ?? null
 		}),
 		previewUrl: t.string({
 			nullable: true,
@@ -342,7 +348,6 @@ export const SimfileConnectionRef = builder
 						}
 
 						const previewSelected = isFieldSelected(info, 'previewUrl');
-						const downloadSelected = isFieldSelected(info, 'downloadUrl');
 						const dtxSelected = isNestedFieldSelected(info, 'dtxFiles', [
 							'fileUrl',
 							'fileSizeBytes',
@@ -354,28 +359,30 @@ export const SimfileConnectionRef = builder
 						// non-blank DB values, and whose dtx file fields were not selected,
 						// skip discovery entirely — their resolvers short-circuit at
 						// nonBlank(...) before ever consulting the cache.
+						// Note: downloadUrl is DB-only (no R2 fallback) and is therefore
+						// intentionally excluded from this filter — selecting downloadUrl
+						// alone never triggers discovery.
 						const simsNeedingDiscovery = c.data.filter((s) => {
 							if (previewSelected && nonBlank(s.preview_url) == null) return true;
-							if (downloadSelected && nonBlank(s.download_url) == null) return true;
 							if (dtxSelected) return true;
 							return false;
 						});
 
-					if (simsNeedingDiscovery.length > 0) {
-						const catalogBatchPromise = batchDiscoverCatalogFiles(
-							ctx.r2,
-							simsNeedingDiscovery.map((s) => ({
-								simfileId: s.id,
-								// When the client didn't select any dtxFiles fields,
-								// pass an empty array so discoverCatalogFiles skips
-								// the SET.DEF fetch and chart matching. The result is
-								// cached with chartsPopulated: false; chart resolvers
-								// detect this and re-discover on demand.
-								dtxFiles: dtxSelected ? s.dtx_files : [],
-								publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
-							})),
-							ctx.logger
-						);
+						if (simsNeedingDiscovery.length > 0) {
+							const catalogBatchPromise = batchDiscoverCatalogFiles(
+								ctx.r2,
+								simsNeedingDiscovery.map((s) => ({
+									simfileId: s.id,
+									// When the client didn't select any dtxFiles fields,
+									// pass an empty array so discoverCatalogFiles skips
+									// the SET.DEF fetch and chart matching. The result is
+									// cached with chartsPopulated: false; chart resolvers
+									// detect this and re-discover on demand.
+									dtxFiles: dtxSelected ? s.dtx_files : [],
+									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+								})),
+								ctx.logger
+							);
 							const cache =
 								ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
 							for (const s of simsNeedingDiscovery) {
@@ -385,7 +392,6 @@ export const SimfileConnectionRef = builder
 										(map) =>
 											map.get(s.id) ?? {
 												previewUrl: null,
-												downloadUrl: null,
 												charts: []
 											}
 									)

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -279,8 +279,7 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		durationSeconds: t.int({ nullable: true, resolve: () => null }),
 		dtxFiles: t.field({
 			type: [DtxFile],
-			resolve: (s) =>
-				s.dtx_files.map((file, index) => ({ ...file, index, simfile: s }))
+			resolve: (s) => s.dtx_files.map((file, index) => ({ ...file, index, simfile: s }))
 		}),
 		files: t.field({
 			type: [R2File],

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -15,6 +15,7 @@ import {
 	enrichHasUploadedFiles,
 	batchEnrichHasUploadedFiles,
 	batchEnrichFiles,
+	batchDiscoverCatalogFiles,
 	discoverCatalogFiles
 } from '../services/r2Enrichment';
 import type { CatalogChartFile, CatalogFileDiscovery } from '../services/r2Enrichment';
@@ -55,6 +56,57 @@ const isFieldSelected = (info: GraphQLResolveInfo, fieldName: string): boolean =
 		const selectionSet = node.selectionSet;
 		if (!selectionSet) return false;
 		return checkSelections(selectionSet.selections);
+	});
+};
+
+const isNestedFieldSelected = (
+	info: GraphQLResolveInfo,
+	parentFieldName: string,
+	childFieldNames: string[]
+): boolean => {
+	const childFields = new Set(childFieldNames);
+
+	const checkChildSelections = (selections: readonly SelectionNode[]): boolean =>
+		selections.some((sel) => {
+			switch (sel.kind) {
+				case 'Field':
+					return sel.name.value !== '__typename' && childFields.has(sel.name.value);
+				case 'FragmentSpread': {
+					const fragment = info.fragments[sel.name.value];
+					return fragment ? checkChildSelections(fragment.selectionSet.selections) : false;
+				}
+				case 'InlineFragment':
+					return checkChildSelections(sel.selectionSet.selections);
+				default:
+					return false;
+			}
+		});
+
+	const checkParentSelections = (selections: readonly SelectionNode[]): boolean =>
+		selections.some((sel) => {
+			switch (sel.kind) {
+				case 'Field':
+					if (sel.name.value === '__typename' || sel.name.value !== parentFieldName) {
+						return false;
+					}
+					return sel.selectionSet
+						? checkChildSelections(sel.selectionSet.selections)
+						: false;
+				case 'FragmentSpread': {
+					const fragment = info.fragments[sel.name.value];
+					return fragment ? checkParentSelections(fragment.selectionSet.selections) : false;
+				}
+				case 'InlineFragment':
+					return checkParentSelections(sel.selectionSet.selections);
+				default:
+					return false;
+			}
+		});
+
+	return info.fieldNodes.some((node) => {
+		const selectionSet = node.selectionSet;
+		if (!selectionSet) return false;
+		return checkParentSelections(selectionSet.selections);
 	});
 };
 
@@ -238,6 +290,40 @@ export const SimfileConnectionRef = builder
 								ctx.filesCache.set(
 									s.id,
 									filesBatchPromise.then((map) => map.get(s.id) ?? [])
+								);
+							}
+						}
+
+						const shouldBatchCatalogFiles =
+							isFieldSelected(info, 'previewUrl') ||
+							isFieldSelected(info, 'downloadUrl') ||
+							isNestedFieldSelected(info, 'dtxFiles', [
+								'fileUrl',
+								'fileSizeBytes',
+								'fileEncoding'
+							]);
+
+						if (shouldBatchCatalogFiles) {
+							const catalogBatchPromise = batchDiscoverCatalogFiles(
+								ctx.r2,
+								c.data.map((s) => ({
+									simfileId: s.id,
+									dtxFiles: s.dtx_files,
+									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+								}))
+							);
+							const cache = ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
+							for (const s of c.data) {
+								cache.set(
+									s.id,
+									catalogBatchPromise.then(
+										(map) =>
+											map.get(s.id) ?? {
+												previewUrl: null,
+												downloadUrl: null,
+												charts: []
+											}
+									)
 								);
 							}
 						}

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -327,9 +327,10 @@ export const SimfileConnectionRef = builder
 						]);
 
 						// Per-sim filter: only sims that actually need R2 discovery are passed
-						// to the batch. Sims with both DB URLs set and no dtx file fields
-						// selected skip discovery entirely — their cache entry is pre-resolved
-						// with the existing DB values so consumers see a uniform cache API.
+						// to the batch. Sims whose selected catalog-backed fields all have
+						// non-blank DB values, and whose dtx file fields were not selected,
+						// skip discovery entirely — their resolvers short-circuit at
+						// nonBlank(...) before ever consulting the cache.
 					const simsNeedingDiscovery = c.data.filter((s) => {
 						if (previewSelected && nonBlank(s.preview_url) == null) return true;
 						if (downloadSelected && nonBlank(s.download_url) == null) return true;
@@ -337,45 +338,43 @@ export const SimfileConnectionRef = builder
 						return false;
 					});
 
-						if (simsNeedingDiscovery.length > 0) {
-							const catalogBatchPromise = batchDiscoverCatalogFiles(
-								ctx.r2,
-								simsNeedingDiscovery.map((s) => ({
-									simfileId: s.id,
-									dtxFiles: s.dtx_files,
-									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
-								}))
+					if (simsNeedingDiscovery.length > 0) {
+						const catalogBatchPromise = batchDiscoverCatalogFiles(
+							ctx.r2,
+							simsNeedingDiscovery.map((s) => ({
+								simfileId: s.id,
+								dtxFiles: s.dtx_files,
+								publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+							}))
+						);
+						const cache =
+							ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
+						for (const s of simsNeedingDiscovery) {
+							cache.set(
+								s.id,
+								catalogBatchPromise.then(
+									(map) =>
+										map.get(s.id) ?? {
+											previewUrl: null,
+											downloadUrl: null,
+											charts: []
+										}
+								)
 							);
-							const cache =
-								ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
-							for (const s of simsNeedingDiscovery) {
-								cache.set(
-									s.id,
-									catalogBatchPromise.then(
-										(map) =>
-											map.get(s.id) ?? {
-												previewUrl: null,
-												downloadUrl: null,
-												charts: []
-											}
-									)
-								);
-							}
-							// Populate cache for sims that did not need discovery so consumers
-							// always find an entry. previewUrl/downloadUrl come from the DB;
-							// charts is empty because dtx file fields were not selected.
-							for (const s of c.data) {
-								if (simsNeedingDiscovery.includes(s)) continue;
-								cache.set(
-									s.id,
-									Promise.resolve({
-										previewUrl: s.preview_url,
-										downloadUrl: s.download_url,
-										charts: []
-									})
-								);
-							}
 						}
+						// Intentionally do NOT populate cache entries for sims that
+						// skipped discovery. Writing partial entries (DB URLs only,
+						// charts: []) would poison the request-scoped cache: if the
+						// same simfile is reached via another resolver path in this
+						// document that selects a catalog field the list path did not
+						// (e.g. an aliased `simfile(id)` query alongside the list), the
+						// field resolver would short-circuit on the partial entry and
+						// return a stale null/empty value instead of discovering R2.
+						// A cache miss in getCatalogDiscovery correctly falls through
+						// to single-sim discovery, and resolvers for skipped sims
+						// short-circuit at nonBlank(...) before ever consulting the
+						// cache, so leaving them uncached has no cost in normal flow.
+					}
 					}
 					return c.data;
 				}

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -173,6 +173,18 @@ const findCatalogChart = async (
 	parent: DtxFileParent
 ): Promise<CatalogChartFile | undefined> => {
 	const discovery = await getCatalogDiscovery(ctx, parent.simfile);
+	if (!discovery.chartsPopulated) {
+		// The cache entry was populated by a URL-only batch (no chart
+		// fields were selected at batch time). Invalidate and re-discover
+		// with the full dtx_files so chart matching runs. This handles
+		// the aliased-query scenario where a list (URL-only) and a
+		// detail (chart fields) share the same request-scoped cache.
+		ctx.catalogFilesCache?.delete(parent.simfile.id);
+		const fullDiscovery = await getCatalogDiscovery(ctx, parent.simfile);
+		return fullDiscovery.charts.find(
+			(chart) => chart.label === parent.label && chart.level === parent.level
+		);
+	}
 	return discovery.charts.find(
 		(chart) => chart.label === parent.label && chart.level === parent.level
 	);
@@ -349,16 +361,21 @@ export const SimfileConnectionRef = builder
 							return false;
 						});
 
-						if (simsNeedingDiscovery.length > 0) {
-							const catalogBatchPromise = batchDiscoverCatalogFiles(
-								ctx.r2,
-								simsNeedingDiscovery.map((s) => ({
-									simfileId: s.id,
-									dtxFiles: s.dtx_files,
-									publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
-								})),
-								ctx.logger
-							);
+					if (simsNeedingDiscovery.length > 0) {
+						const catalogBatchPromise = batchDiscoverCatalogFiles(
+							ctx.r2,
+							simsNeedingDiscovery.map((s) => ({
+								simfileId: s.id,
+								// When the client didn't select any dtxFiles fields,
+								// pass an empty array so discoverCatalogFiles skips
+								// the SET.DEF fetch and chart matching. The result is
+								// cached with chartsPopulated: false; chart resolvers
+								// detect this and re-discover on demand.
+								dtxFiles: dtxSelected ? s.dtx_files : [],
+								publicBaseUrl: ctx.env.PUBLIC_SIMFILE_BUCKET_URL
+							})),
+							ctx.logger
+						);
 							const cache =
 								ctx.catalogFilesCache ?? (ctx.catalogFilesCache = new Map());
 							for (const s of simsNeedingDiscovery) {

--- a/packages/dtx-api/src/schema/simfile.ts
+++ b/packages/dtx-api/src/schema/simfile.ts
@@ -133,6 +133,11 @@ export const FileEncodingEnum = builder.enumType('FileEncoding', {
 type DtxFileParent = {
 	level: number;
 	label: string;
+	/** Row index within simfile.dtx_files. Carried so the resolver can
+	 * look up the chart by position rather than by (label, level),
+	 * which is not unique — duplicate dtx_files rows with the same
+	 * label+level would otherwise all resolve to the first chart. */
+	index: number;
 	simfile: SimfileWithDtxFiles;
 };
 
@@ -181,13 +186,14 @@ const findCatalogChart = async (
 		// detail (chart fields) share the same request-scoped cache.
 		ctx.catalogFilesCache?.delete(parent.simfile.id);
 		const fullDiscovery = await getCatalogDiscovery(ctx, parent.simfile);
-		return fullDiscovery.charts.find(
-			(chart) => chart.label === parent.label && chart.level === parent.level
-		);
+		return fullDiscovery.charts[parent.index];
 	}
-	return discovery.charts.find(
-		(chart) => chart.label === parent.label && chart.level === parent.level
-	);
+	// Resolve by row index, not by (label, level) search. The charts
+	// array is built positionally (dtxFiles.map((file, index) => ...)),
+	// so charts[index] is the exact match for this dtx_files row.
+	// A .find() by label+level would return the first chart for every
+	// duplicate row, exposing the wrong R2 object for the second row.
+	return discovery.charts[parent.index];
 };
 
 /**
@@ -273,7 +279,8 @@ export const SimfileRef = builder.objectRef<SimfileWithDtxFiles>('Simfile').impl
 		durationSeconds: t.int({ nullable: true, resolve: () => null }),
 		dtxFiles: t.field({
 			type: [DtxFile],
-			resolve: (s) => s.dtx_files.map((file) => ({ ...file, simfile: s }))
+			resolve: (s) =>
+				s.dtx_files.map((file, index) => ({ ...file, index, simfile: s }))
 		}),
 		files: t.field({
 			type: [R2File],

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -4,6 +4,7 @@ import {
 	enrichHasUploadedFiles,
 	batchEnrichHasUploadedFiles,
 	batchEnrichFiles,
+	batchDiscoverCatalogFiles,
 	discoverCatalogFiles
 } from './r2Enrichment';
 import type { R2Bucket } from '@cloudflare/workers-types';
@@ -217,6 +218,39 @@ describe('batchEnrichFiles', () => {
 		const bucket = { list: listMock } as unknown as R2Bucket;
 
 		await expect(batchEnrichFiles(bucket, [1, 2])).rejects.toThrow('R2 listing failed');
+	});
+});
+
+describe('batchDiscoverCatalogFiles', () => {
+	it('returns a Map with catalog discovery for all simfiles', async () => {
+		const listMock = vi.fn(async (opts: { prefix: string }) => {
+			if (opts.prefix === '1/') {
+				return {
+					objects: [{ key: '1/song.dtx', size: 100, uploaded: new Date() }],
+					truncated: false
+				};
+			}
+			return {
+				objects: [{ key: '2/preview.mp3', size: 50, uploaded: new Date() }],
+				truncated: false
+			};
+		});
+		const bucket = { list: listMock } as unknown as R2Bucket;
+
+		const result = await batchDiscoverCatalogFiles(bucket, [
+			{ simfileId: 1, dtxFiles: [], publicBaseUrl: 'https://bucket.example' },
+			{ simfileId: 2, dtxFiles: [], publicBaseUrl: 'https://bucket.example' }
+		]);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.get(1)).toBeDefined();
+		expect(result.get(2)).toBeDefined();
+	});
+
+	it('returns empty Map for empty input', async () => {
+		const bucket = {} as unknown as R2Bucket;
+		const result = await batchDiscoverCatalogFiles(bucket, []);
+		expect(result.size).toBe(0);
 	});
 });
 

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -814,6 +814,152 @@ describe('discoverCatalogFiles', () => {
 		]);
 	});
 
+	it('resolves relative #LxFILE references against the nested set.def directory', async () => {
+		// Uploads preserve directory structure, so when the canonical
+		// top-level set.def is absent and discovery falls back to a nested
+		// copy (e.g. 42/song/set.def), sibling chart files live next to it
+		// (e.g. 42/song/basic.dtx). Relative references must resolve against
+		// the set.def's directory — not the simfile root — otherwise the
+		// chart is marked claimed-but-missing and the fileUrl resolver
+		// throws an INTERNAL error even though the object exists in R2.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/song/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/song/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/song/advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE advanced.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 1 },
+					{ label: 'Advanced', level: 5 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(bucket.get).toHaveBeenCalledWith('42/song/set.def');
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/song/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/song/advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('resolves deeply nested relative set.def references with sub-paths', async () => {
+		// set.def at 42/song/set.def references a chart in a deeper
+		// sub-folder via a relative path (sub/normal.dtx). The reference
+		// is relative to the set.def's own directory, so it should resolve
+		// to 42/song/sub/normal.dtx — not 42/sub/normal.dtx.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/song/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/song/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/song/sub/normal.dtx', size: 400, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL NORMAL\n#L2FILE sub/normal.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 1 },
+					{ label: 'Normal', level: 3 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/song/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Normal',
+				level: 3,
+				fileUrl: 'https://cdn.example.test/42/song/sub/normal.dtx',
+				fileSizeBytes: 400,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('falls back to the simfile root for legacy flat uploads with a nested set.def', async () => {
+		// Backward compat: legacy uploads where chart files were flattened
+		// to the root (42/basic.dtx) despite a nested set.def
+		// (42/assets/set.def). The root-prefix fallback ensures these
+		// legacy uploads still resolve after the baseDir fix.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/assets/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () => encodeToBuffer('#L1LABEL BASIC\n#L1FILE basic.dtx\n')
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [{ label: 'Basic', level: 1 }],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
 	it('parses set.def with case-insensitive filename discovery', async () => {
 		const bucket = {
 			...makeBucket([

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -17,6 +17,23 @@ const silentLogger: WorkerLogger = {
 	debug: vi.fn()
 };
 
+const encodeToBuffer = (text: string): ArrayBuffer => new TextEncoder().encode(text).buffer;
+
+const encodeUtf8WithBom = (text: string): ArrayBuffer => {
+	const bytes = new TextEncoder().encode(text);
+	return new Uint8Array([0xef, 0xbb, 0xbf, ...bytes]).buffer;
+};
+
+const encodeUtf16LeWithBom = (text: string): ArrayBuffer => {
+	const utf16Bytes = new Uint8Array(text.length * 2);
+	for (let i = 0; i < text.length; i++) {
+		const codeUnit = text.charCodeAt(i);
+		utf16Bytes[i * 2] = codeUnit & 0xff;
+		utf16Bytes[i * 2 + 1] = (codeUnit >> 8) & 0xff;
+	}
+	return new Uint8Array([0xff, 0xfe, ...utf16Bytes]).buffer;
+};
+
 const makeBucket = (
 	objectsPerCall: Array<Array<{ key: string; size: number; uploaded: Date }>>
 ): R2Bucket => {
@@ -368,7 +385,7 @@ describe('discoverCatalogFiles', () => {
 	});
 
 	it('skips fetching set.def when no dtx chart rows need matching', async () => {
-		const getMock = vi.fn(async () => ({ text: async () => '' }));
+		const getMock = vi.fn(async () => ({ arrayBuffer: async () => encodeToBuffer('') }));
 		const bucket = {
 			...makeBucket([
 				[
@@ -444,10 +461,12 @@ describe('discoverCatalogFiles', () => {
 					{ key: '42/sub/advanced.dtx', size: 500, uploaded: new Date() }
 				]
 			]),
-			get: vi.fn(async () => ({
-				text: async () =>
+		get: vi.fn(async () => ({
+			arrayBuffer: async () =>
+				encodeToBuffer(
 					'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE sub/advanced.dtx\n'
-			}))
+				)
+		}))
 		} as unknown as R2Bucket;
 
 		const discovery = await discoverCatalogFiles(
@@ -491,10 +510,12 @@ describe('discoverCatalogFiles', () => {
 					{ key: '42/z-basic.dtx', size: 300, uploaded: new Date() }
 				]
 			]),
-			get: vi.fn(async () => ({
-				text: async () =>
+		get: vi.fn(async () => ({
+			arrayBuffer: async () =>
+				encodeToBuffer(
 					'#L1LABEL BASIC\n#L1FILE z-basic.dtx\n#L2LABEL ADVANCED\n#L2FILE a-advanced.dtx\n'
-			}))
+				)
+		}))
 		} as unknown as R2Bucket;
 
 		const discovery = await discoverCatalogFiles(
@@ -620,7 +641,7 @@ describe('discoverCatalogFiles', () => {
 		]);
 	});
 
-	it('falls back to sorted pairing when set.def object.text() throws', async () => {
+	it('falls back to sorted pairing when set.def body read throws', async () => {
 		const logger = {
 			info: vi.fn(),
 			warn: vi.fn(),
@@ -635,7 +656,7 @@ describe('discoverCatalogFiles', () => {
 				]
 			]),
 			get: vi.fn(async () => ({
-				text: async () => {
+				arrayBuffer: async () => {
 					throw new Error('body read error');
 				}
 			}))
@@ -660,6 +681,112 @@ describe('discoverCatalogFiles', () => {
 				label: 'Basic',
 				level: 1,
 				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('parses set.def encoded with UTF-8 BOM (strips BOM before regex match)', async () => {
+		// Without BOM stripping, the first directive would start with \uFEFF
+		// and the label regex `^#L(\d+)LABEL\s+(.+)$` would silently miss it,
+		// causing row 1 to fall back to sorted-key pairing.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeUtf8WithBom(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE advanced.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 1 },
+					{ label: 'Advanced', level: 5 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('parses set.def encoded with UTF-16LE BOM (matches desktop export format)', async () => {
+		// The desktop app writes set.def with UTF-16LE BOM
+		// (see packages/dtx-desktop/src/main/index.ts). Without BOM-aware
+		// decoding, every ASCII byte interleaves with 0x00 and the regex
+		// matches nothing, silently falling back to sorted-key pairing.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/z-basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/a-advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeUtf16LeWithBom(
+						'#L1LABEL BASIC\n#L1FILE z-basic.dtx\n#L2LABEL ADVANCED\n#L2FILE a-advanced.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Advanced', level: 5 },
+					{ label: 'Basic', level: 1 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		// Labels intentionally assigned in reverse key-sort order so the test
+		// fails if BOM detection is broken (sorted fallback would pair
+		// Advanced→z-basic and Basic→a-advanced).
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/a-advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/z-basic.dtx',
 				fileSizeBytes: 300,
 				fileEncoding: 'SHIFT_JIS'
 			}

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -339,14 +339,19 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/assets/PREVIEW.MP3');
 	});
 
-	it('selects non-preview ogg before mp3, wav, and flac for downloadUrl', async () => {
+	it('prefers the canonical top-level preview.mp3 over a nested asset with the same basename', async () => {
+		// DTX simfiles routinely ship packaged `#WAV` samples under
+		// `assets/` (e.g. 42/assets/preview.mp3). The public preview
+		// contract is the canonical top-level key {simfileId}/preview.mp3,
+		// so when both exist the top-level key must win — selecting by
+		// basename alone plus alphabetic sort would return the nested
+		// asset first because '42/assets/preview.mp3' sorts before
+		// '42/preview.mp3'.
 		const bucket = makeBucket([
 			[
-				{ key: '42/preview.mp3', size: 10, uploaded: new Date() },
-				{ key: '42/full.wav', size: 20, uploaded: new Date() },
-				{ key: '42/full.mp3', size: 30, uploaded: new Date() },
-				{ key: '42/full.flac', size: 40, uploaded: new Date() },
-				{ key: '42/full.ogg', size: 50, uploaded: new Date() }
+				{ key: '42/assets/preview.mp3', size: 10, uploaded: new Date() },
+				{ key: '42/preview.mp3', size: 100, uploaded: new Date() },
+				{ key: '42/song.dtx', size: 200, uploaded: new Date() }
 			]
 		]);
 
@@ -355,19 +360,45 @@ describe('discoverCatalogFiles', () => {
 			{
 				simfileId: 42,
 				dtxFiles: [],
-				publicBaseUrl: 'https://cdn.example.test/'
+				publicBaseUrl: 'https://cdn.example.test'
 			},
 			silentLogger
 		);
 
-		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.ogg');
+		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/preview.mp3');
 	});
 
-	it('excludes preview.mp3 case-insensitively from downloadUrl', async () => {
+	it('falls back to a nested preview.mp3 when the canonical top-level key is missing', async () => {
+		// Backward compat: existing simfiles that only have a nested
+		// preview.mp3 (e.g. legacy uploads under assets/) still resolve
+		// to that key.
 		const bucket = makeBucket([
 			[
-				{ key: '42/PREVIEW.MP3', size: 10, uploaded: new Date() },
-				{ key: '42/full.wav', size: 20, uploaded: new Date() }
+				{ key: '42/assets/preview.mp3', size: 100, uploaded: new Date() },
+				{ key: '42/song.dtx', size: 200, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/assets/preview.mp3');
+	});
+
+	it('matches the canonical preview.mp3 case-insensitively', async () => {
+		//Uploader and desktop export may write PREVIEW.MP3 or preview.mp3;
+		//both must be treated as canonical.
+		const bucket = makeBucket([
+			[
+				{ key: '42/PREVIEW.MP3', size: 100, uploaded: new Date() },
+				{ key: '42/assets/preview.mp3', size: 10, uploaded: new Date() }
 			]
 		]);
 
@@ -382,7 +413,6 @@ describe('discoverCatalogFiles', () => {
 		);
 
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/PREVIEW.MP3');
-		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.wav');
 	});
 
 	it('skips fetching set.def when no dtx chart rows need matching', async () => {
@@ -407,7 +437,7 @@ describe('discoverCatalogFiles', () => {
 			silentLogger
 		);
 
-		// previewUrl/downloadUrl still resolve from the listing, but set.def
+		// previewUrl still resolves from the listing, but set.def
 		// must not be fetched because no chart rows need label-to-file matching.
 		expect(getMock).not.toHaveBeenCalled();
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/preview.mp3');
@@ -417,7 +447,7 @@ describe('discoverCatalogFiles', () => {
 
 	it('skips fetching set.def for URL-only discovery even with .dtx files in R2', async () => {
 		// Simulates the list-page scenario: the caller passes dtxFiles: []
-		// because the client only selected previewUrl/downloadUrl, but R2
+		// because the client only selected previewUrl, but R2
 		// contains set.def and .dtx files. SET.DEF must not be fetched.
 		const getMock = vi.fn(async () => ({ arrayBuffer: async () => encodeToBuffer('') }));
 		const bucket = {
@@ -496,12 +526,12 @@ describe('discoverCatalogFiles', () => {
 					{ key: '42/sub/advanced.dtx', size: 500, uploaded: new Date() }
 				]
 			]),
-		get: vi.fn(async () => ({
-			arrayBuffer: async () =>
-				encodeToBuffer(
-					'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE sub/advanced.dtx\n'
-				)
-		}))
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE sub/advanced.dtx\n'
+					)
+			}))
 		} as unknown as R2Bucket;
 
 		const discovery = await discoverCatalogFiles(
@@ -546,12 +576,12 @@ describe('discoverCatalogFiles', () => {
 					{ key: '42/z-basic.dtx', size: 300, uploaded: new Date() }
 				]
 			]),
-		get: vi.fn(async () => ({
-			arrayBuffer: async () =>
-				encodeToBuffer(
-					'#L1LABEL BASIC\n#L1FILE z-basic.dtx\n#L2LABEL ADVANCED\n#L2FILE a-advanced.dtx\n'
-				)
-		}))
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE z-basic.dtx\n#L2LABEL ADVANCED\n#L2FILE a-advanced.dtx\n'
+					)
+			}))
 		} as unknown as R2Bucket;
 
 		const discovery = await discoverCatalogFiles(
@@ -601,12 +631,12 @@ describe('discoverCatalogFiles', () => {
 					{ key: '42/a-advanced.dtx', size: 500, uploaded: new Date() }
 				]
 			]),
-		get: vi.fn(async () => ({
-			arrayBuffer: async () =>
-				encodeToBuffer(
-					'#L1LABEL: BASIC\n#L1FILE: z-basic.dtx\n#L2LABEL:ADVANCED\n#L2FILE :a-advanced.dtx\n'
-				)
-		}))
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL: BASIC\n#L1FILE: z-basic.dtx\n#L2LABEL:ADVANCED\n#L2FILE :a-advanced.dtx\n'
+					)
+			}))
 		} as unknown as R2Bucket;
 
 		const discovery = await discoverCatalogFiles(

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -383,6 +383,57 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/song.mp3');
 	});
 
+	it('prefers top-level full audio over a nested sample with the same extension for downloadUrl', async () => {
+		// DTX simfiles ship individual drum sample chips under assets/
+		// (e.g. 42/assets/kick.ogg). When a top-level full-audio file
+		// (e.g. 42/song.ogg) exists alongside a nested sample, the
+		// downloadUrl must point at the full-audio file — not the sample
+		// chip. Lexicographic sort alone would return the nested asset
+		// first because '42/assets/kick.ogg' sorts before '42/song.ogg'.
+		const bucket = makeBucket([
+			[
+				{ key: '42/assets/kick.ogg', size: 10, uploaded: new Date() },
+				{ key: '42/assets/snare.ogg', size: 10, uploaded: new Date() },
+				{ key: '42/song.ogg', size: 5000, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/song.ogg');
+	});
+
+	it('falls back to a nested sample when no top-level audio exists for downloadUrl', async () => {
+		// Backward compat: legacy uploads that only have nested audio
+		// still resolve to that key rather than null.
+		const bucket = makeBucket([
+			[
+				{ key: '42/assets/kick.ogg', size: 10, uploaded: new Date() },
+				{ key: '42/song.dtx', size: 200, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/assets/kick.ogg');
+	});
+
 	it('returns null downloadUrl when no suitable audio object exists', async () => {
 		const bucket = makeBucket([
 			[

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -632,6 +632,111 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.chartsPopulated).toBe(true);
 	});
 
+	it('prefers the canonical top-level set.def over a nested asset with the same basename', async () => {
+		// DTX simfiles routinely ship packaged assets under `assets/`.
+		// When both `42/set.def` and `42/assets/set.def` exist, R2 lists
+		// them in lexicographic order (`assets/` < `set.def`), so
+		// basename-only matching would pick the nested (possibly empty
+		// or wrong) copy first. The canonical top-level key must win.
+		const bucket = {
+			...makeBucket([
+				[
+					// nested copy intentionally placed first in array to
+					// match R2's lexicographic ordering and prove that
+					// basename-first find() would return it.
+					{ key: '42/assets/set.def', size: 10, uploaded: new Date() },
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async (key: string) => {
+				// Only the canonical top-level key has real content;
+				// the nested copy is empty (simulating a stray asset).
+				if (key === '42/set.def') {
+					return {
+						arrayBuffer: async () =>
+							encodeToBuffer(
+								'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE advanced.dtx\n'
+							)
+					};
+				}
+				return { arrayBuffer: async () => encodeToBuffer('') };
+			})
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 1 },
+					{ label: 'Advanced', level: 5 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(bucket.get).toHaveBeenCalledWith('42/set.def');
+		expect(bucket.get).not.toHaveBeenCalledWith('42/assets/set.def');
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+		expect(discovery.chartsPopulated).toBe(true);
+	});
+
+	it('falls back to a nested set.def when the canonical top-level key is missing', async () => {
+		// Backward compat: legacy uploads that only have a nested
+		// set.def still resolve to that key.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/assets/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer('#L1LABEL BASIC\n#L1FILE basic.dtx\n')
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [{ label: 'Basic', level: 1 }],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(bucket.get).toHaveBeenCalledWith('42/assets/set.def');
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
 	it('parses set.def with case-insensitive filename discovery', async () => {
 		const bucket = {
 			...makeBucket([

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -584,6 +584,58 @@ describe('discoverCatalogFiles', () => {
 		]);
 	});
 
+	it('does not remap set.def-referenced rows via fallback when the object is missing', async () => {
+		// set.def maps ADVANCED → advanced.dtx, but advanced.dtx is absent
+		// from R2. The sorted-key fallback must NOT assign another .dtx
+		// key (other.dtx) to the Advanced row — it should return null so
+		// the client sees the chart as unavailable.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/other.dtx', size: 999, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE advanced.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 1 },
+					{ label: 'Advanced', level: 5 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: null,
+				fileSizeBytes: null,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
 	it('falls back to sorted pairing when set.def read throws a transient R2 error', async () => {
 		const logger = {
 			info: vi.fn(),

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -1260,4 +1260,121 @@ describe('discoverCatalogFiles', () => {
 		]);
 		expect(discovery.chartsPopulated).toBe(true);
 	});
+
+	it('preserves duplicate set.def labels matching distinct DB rows to distinct files', async () => {
+		// SET.def legitimately uses the same label "BASIC" on two L-slots
+		// pointing at different files. Without per-label accumulation the
+		// second entry overwrites the first and both DB rows resolve to the
+		// same R2 object (orphaning the other file). Each row must claim a
+		// distinct file.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/basic2.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL BASIC\n#L2FILE basic2.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 50 },
+					{ label: 'Basic', level: 70 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 50,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 70,
+				fileUrl: 'https://cdn.example.test/42/basic2.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+		expect(discovery.chartsPopulated).toBe(true);
+	});
+
+	it('falls extra duplicate-label rows through to sorted-key fallback when SET.def entries are exhausted', async () => {
+		// Three DB rows share label "BASIC" but SET.def only defines two
+		// L-slots for that label. The third row has no remaining SET.def
+		// entry to consume and must fall through to the sorted-key fallback.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/basic2.dtx', size: 500, uploaded: new Date() },
+					{ key: '42/basic3.dtx', size: 700, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer(
+						'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL BASIC\n#L2FILE basic2.dtx\n'
+					)
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 50 },
+					{ label: 'Basic', level: 60 },
+					{ label: 'Basic', level: 70 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		// Rows 0 and 1 are claimed by SET.def (basic.dtx, basic2.dtx).
+		// Row 2 is not claimed by SET.def — it falls through to sorted-key
+		// fallback and gets the only remaining unused key: basic3.dtx.
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 50,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 60,
+				fileUrl: 'https://cdn.example.test/42/basic2.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 70,
+				fileUrl: 'https://cdn.example.test/42/basic3.dtx',
+				fileSizeBytes: 700,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
 });

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -8,6 +8,14 @@ import {
 	discoverCatalogFiles
 } from './r2Enrichment';
 import type { R2Bucket } from '@cloudflare/workers-types';
+import type { WorkerLogger } from '@dtx/common/server';
+
+const silentLogger: WorkerLogger = {
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn()
+};
 
 const makeBucket = (
 	objectsPerCall: Array<Array<{ key: string; size: number; uploaded: Date }>>
@@ -237,10 +245,14 @@ describe('batchDiscoverCatalogFiles', () => {
 		});
 		const bucket = { list: listMock } as unknown as R2Bucket;
 
-		const result = await batchDiscoverCatalogFiles(bucket, [
-			{ simfileId: 1, dtxFiles: [], publicBaseUrl: 'https://bucket.example' },
-			{ simfileId: 2, dtxFiles: [], publicBaseUrl: 'https://bucket.example' }
-		]);
+		const result = await batchDiscoverCatalogFiles(
+			bucket,
+			[
+				{ simfileId: 1, dtxFiles: [], publicBaseUrl: 'https://bucket.example' },
+				{ simfileId: 2, dtxFiles: [], publicBaseUrl: 'https://bucket.example' }
+			],
+			silentLogger
+		);
 
 		expect(result).toBeInstanceOf(Map);
 		expect(result.get(1)).toBeDefined();
@@ -249,7 +261,7 @@ describe('batchDiscoverCatalogFiles', () => {
 
 	it('returns empty Map for empty input', async () => {
 		const bucket = {} as unknown as R2Bucket;
-		const result = await batchDiscoverCatalogFiles(bucket, []);
+		const result = await batchDiscoverCatalogFiles(bucket, [], silentLogger);
 		expect(result.size).toBe(0);
 	});
 });
@@ -266,11 +278,15 @@ describe('discoverCatalogFiles', () => {
 			]
 		]);
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [{ label: 'Basic', level: 1 }],
-			publicBaseUrl: 'https://cdn.example.test/simfiles/'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [{ label: 'Basic', level: 1 }],
+				publicBaseUrl: 'https://cdn.example.test/simfiles/'
+			},
+			silentLogger
+		);
 
 		expect(discovery.charts).toEqual([
 			{
@@ -292,11 +308,15 @@ describe('discoverCatalogFiles', () => {
 			]
 		]);
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [{ label: 'Basic', level: 1 }],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [{ label: 'Basic', level: 1 }],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/assets/PREVIEW.MP3');
 	});
@@ -312,11 +332,15 @@ describe('discoverCatalogFiles', () => {
 			]
 		]);
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [],
-			publicBaseUrl: 'https://cdn.example.test/'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test/'
+			},
+			silentLogger
+		);
 
 		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.ogg');
 	});
@@ -329,11 +353,15 @@ describe('discoverCatalogFiles', () => {
 			]
 		]);
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/PREVIEW.MP3');
 		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.wav');
@@ -351,11 +379,15 @@ describe('discoverCatalogFiles', () => {
 			get: getMock
 		} as unknown as R2Bucket;
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		// previewUrl/downloadUrl still resolve from the listing, but set.def
 		// must not be fetched because no chart rows need label-to-file matching.
@@ -372,14 +404,18 @@ describe('discoverCatalogFiles', () => {
 			]
 		]);
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [
-				{ label: 'Advanced', level: 5 },
-				{ label: 'Basic', level: 1 }
-			],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Advanced', level: 5 },
+					{ label: 'Basic', level: 1 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		expect(discovery.charts).toEqual([
 			{
@@ -414,14 +450,18 @@ describe('discoverCatalogFiles', () => {
 			}))
 		} as unknown as R2Bucket;
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [
-				{ label: 'Advanced', level: 5 },
-				{ label: 'Basic', level: 1 }
-			],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Advanced', level: 5 },
+					{ label: 'Basic', level: 1 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		expect(bucket.get).toHaveBeenCalledWith('42/set.def');
 		expect(discovery.charts).toEqual([
@@ -457,14 +497,18 @@ describe('discoverCatalogFiles', () => {
 			}))
 		} as unknown as R2Bucket;
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [
-				{ label: 'Advanced', level: 5 },
-				{ label: 'Basic', level: 1 }
-			],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Advanced', level: 5 },
+					{ label: 'Basic', level: 1 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		expect(bucket.get).toHaveBeenCalledWith('42/SET.DEF');
 		expect(discovery.charts).toEqual([
@@ -488,14 +532,18 @@ describe('discoverCatalogFiles', () => {
 	it('returns an unmatched chart entry when a required dtx object is missing', async () => {
 		const bucket = makeBucket([[{ key: '42/basic.dtx', size: 300, uploaded: new Date() }]]);
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [
-				{ label: 'Basic', level: 1 },
-				{ label: 'Advanced', level: 5 }
-			],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Basic', level: 1 },
+					{ label: 'Advanced', level: 5 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
 
 		expect(discovery.charts).toEqual([
 			{
@@ -516,6 +564,12 @@ describe('discoverCatalogFiles', () => {
 	});
 
 	it('falls back to sorted pairing when set.def read throws a transient R2 error', async () => {
+		const logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn()
+		};
 		const bucket = {
 			...makeBucket([
 				[
@@ -529,16 +583,24 @@ describe('discoverCatalogFiles', () => {
 			})
 		} as unknown as R2Bucket;
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [
-				{ label: 'Advanced', level: 5 },
-				{ label: 'Basic', level: 1 }
-			],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Advanced', level: 5 },
+					{ label: 'Basic', level: 1 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			logger
+		);
 
 		expect(bucket.get).toHaveBeenCalledWith('42/set.def');
+		expect(logger.warn).toHaveBeenCalledWith(
+			'set.def read failed; falling back to sorted-key matching',
+			expect.objectContaining({ setDefKey: '42/set.def', error: 'R2 transient error' })
+		);
 		// Should fall through to sorted-key fallback instead of throwing
 		expect(discovery.charts).toEqual([
 			{
@@ -559,6 +621,12 @@ describe('discoverCatalogFiles', () => {
 	});
 
 	it('falls back to sorted pairing when set.def object.text() throws', async () => {
+		const logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn()
+		};
 		const bucket = {
 			...makeBucket([
 				[
@@ -573,12 +641,20 @@ describe('discoverCatalogFiles', () => {
 			}))
 		} as unknown as R2Bucket;
 
-		const discovery = await discoverCatalogFiles(bucket, {
-			simfileId: 42,
-			dtxFiles: [{ label: 'Basic', level: 1 }],
-			publicBaseUrl: 'https://cdn.example.test'
-		});
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [{ label: 'Basic', level: 1 }],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			logger
+		);
 
+		expect(logger.warn).toHaveBeenCalledWith(
+			'set.def read failed; falling back to sorted-key matching',
+			expect.objectContaining({ setDefKey: '42/set.def', error: 'body read error' })
+		);
 		expect(discovery.charts).toEqual([
 			{
 				label: 'Basic',

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -3,7 +3,8 @@ import {
 	enrichFiles,
 	enrichHasUploadedFiles,
 	batchEnrichHasUploadedFiles,
-	batchEnrichFiles
+	batchEnrichFiles,
+	discoverCatalogFiles
 } from './r2Enrichment';
 import type { R2Bucket } from '@cloudflare/workers-types';
 
@@ -216,5 +217,242 @@ describe('batchEnrichFiles', () => {
 		const bucket = { list: listMock } as unknown as R2Bucket;
 
 		await expect(batchEnrichFiles(bucket, [1, 2])).rejects.toThrow('R2 listing failed');
+	});
+});
+
+describe('discoverCatalogFiles', () => {
+	it('encodes each R2 key path segment against the public bucket URL', async () => {
+		const bucket = makeBucket([
+			[
+				{
+					key: '42/charts with space/basic#chart.dtx',
+					size: 1234,
+					uploaded: new Date()
+				}
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [{ label: 'Basic', level: 1 }],
+			publicBaseUrl: 'https://cdn.example.test/simfiles/'
+		});
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl:
+					'https://cdn.example.test/simfiles/42/charts%20with%20space/basic%23chart.dtx',
+				fileSizeBytes: 1234,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('selects preview.mp3 for previewUrl case-insensitively', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/assets/PREVIEW.MP3', size: 100, uploaded: new Date() },
+				{ key: '42/song.dtx', size: 200, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [{ label: 'Basic', level: 1 }],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/assets/PREVIEW.MP3');
+	});
+
+	it('selects non-preview ogg before mp3, wav, and flac for downloadUrl', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/preview.mp3', size: 10, uploaded: new Date() },
+				{ key: '42/full.wav', size: 20, uploaded: new Date() },
+				{ key: '42/full.mp3', size: 30, uploaded: new Date() },
+				{ key: '42/full.flac', size: 40, uploaded: new Date() },
+				{ key: '42/full.ogg', size: 50, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [],
+			publicBaseUrl: 'https://cdn.example.test/'
+		});
+
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.ogg');
+	});
+
+	it('excludes preview.mp3 case-insensitively from downloadUrl', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/PREVIEW.MP3', size: 10, uploaded: new Date() },
+				{ key: '42/full.wav', size: 20, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/PREVIEW.MP3');
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.wav');
+	});
+
+	it('matches dtx rows by sorted fallback when set.def is unavailable', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/z-advanced.dtx', size: 500, uploaded: new Date() },
+				{ key: '42/a-basic.dtx', size: 300, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [
+				{ label: 'Advanced', level: 5 },
+				{ label: 'Basic', level: 1 }
+			],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/z-advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/a-basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('parses set.def and matches labels to filenames when available', async () => {
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/sub/advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				text: async () =>
+					'#L1LABEL BASIC\n#L1FILE basic.dtx\n#L2LABEL ADVANCED\n#L2FILE sub/advanced.dtx\n'
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [
+				{ label: 'Advanced', level: 5 },
+				{ label: 'Basic', level: 1 }
+			],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(bucket.get).toHaveBeenCalledWith('42/set.def');
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/sub/advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('parses set.def with case-insensitive filename discovery', async () => {
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/SET.DEF', size: 90, uploaded: new Date() },
+					{ key: '42/a-advanced.dtx', size: 500, uploaded: new Date() },
+					{ key: '42/z-basic.dtx', size: 300, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				text: async () =>
+					'#L1LABEL BASIC\n#L1FILE z-basic.dtx\n#L2LABEL ADVANCED\n#L2FILE a-advanced.dtx\n'
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [
+				{ label: 'Advanced', level: 5 },
+				{ label: 'Basic', level: 1 }
+			],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(bucket.get).toHaveBeenCalledWith('42/SET.DEF');
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/a-advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/z-basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('returns an unmatched chart entry when a required dtx object is missing', async () => {
+		const bucket = makeBucket([[{ key: '42/basic.dtx', size: 300, uploaded: new Date() }]]);
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [
+				{ label: 'Basic', level: 1 },
+				{ label: 'Advanced', level: 5 }
+			],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: null,
+				fileSizeBytes: null,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
 	});
 });

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -411,6 +411,33 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/song.ogg');
 	});
 
+	it('prefers a top-level .mp3 backing track over nested .ogg/.wav sample chips for downloadUrl', async () => {
+		// Extension priority (.ogg < .mp3 < .wav) must not override the
+		// top-level preference. A top-level .mp3 is the full backing
+		// track; nested .ogg/.wav files under assets/ are individual drum
+		// sample chips. Checking extension first would return the nested
+		// .ogg chip; the top-level check must win.
+		const bucket = makeBucket([
+			[
+				{ key: '42/assets/kick.ogg', size: 10, uploaded: new Date() },
+				{ key: '42/assets/snare.wav', size: 10, uploaded: new Date() },
+				{ key: '42/song.mp3', size: 5000, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/song.mp3');
+	});
+
 	it('falls back to a nested sample when no top-level audio exists for downloadUrl', async () => {
 		// Backward compat: legacy uploads that only have nested audio
 		// still resolve to that key rather than null.

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -315,6 +315,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('selects preview.mp3 for previewUrl case-insensitively', async () => {
@@ -411,6 +412,39 @@ describe('discoverCatalogFiles', () => {
 		expect(getMock).not.toHaveBeenCalled();
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/preview.mp3');
 		expect(discovery.charts).toEqual([]);
+		expect(discovery.chartsPopulated).toBe(false);
+	});
+
+	it('skips fetching set.def for URL-only discovery even with .dtx files in R2', async () => {
+		// Simulates the list-page scenario: the caller passes dtxFiles: []
+		// because the client only selected previewUrl/downloadUrl, but R2
+		// contains set.def and .dtx files. SET.DEF must not be fetched.
+		const getMock = vi.fn(async () => ({ arrayBuffer: async () => encodeToBuffer('') }));
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/preview.mp3', size: 100, uploaded: new Date() }
+				]
+			]),
+			get: getMock
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(getMock).not.toHaveBeenCalled();
+		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/preview.mp3');
+		expect(discovery.charts).toEqual([]);
+		expect(discovery.chartsPopulated).toBe(false);
 	});
 
 	it('matches dtx rows by sorted fallback when set.def is unavailable', async () => {
@@ -450,6 +484,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('parses set.def and matches labels to filenames when available', async () => {
@@ -499,6 +534,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('parses set.def with case-insensitive filename discovery', async () => {
@@ -548,6 +584,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('parses set.def using colon separator (matches editor loader)', async () => {
@@ -601,6 +638,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('returns an unmatched chart entry when a required dtx object is missing', async () => {
@@ -635,6 +673,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('does not remap set.def-referenced rows via fallback when the object is missing', async () => {
@@ -687,6 +726,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('falls back to sorted pairing when set.def read throws a transient R2 error', async () => {
@@ -744,6 +784,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('falls back to sorted pairing when set.def body read throws', async () => {
@@ -790,6 +831,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('parses set.def encoded with UTF-8 BOM (strips BOM before regex match)', async () => {
@@ -841,6 +883,7 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 
 	it('parses set.def encoded with UTF-16LE BOM (matches desktop export format)', async () => {
@@ -896,5 +939,6 @@ describe('discoverCatalogFiles', () => {
 				fileEncoding: 'SHIFT_JIS'
 			}
 		]);
+		expect(discovery.chartsPopulated).toBe(true);
 	});
 });

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -865,6 +865,47 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.chartsPopulated).toBe(true);
 	});
 
+	it('matches SET.DEF FILE references case-insensitively against R2 keys', async () => {
+		// SET.DEF says BASIC.DTX (uppercase) but R2 stores basic.dtx (lowercase).
+		// This is common with uploads from case-insensitive filesystems
+		// (Windows, default macOS). Without the case-insensitive fallback
+		// the chart would be marked as claimed-by-SET.DEF but missing,
+		// raising an INTERNAL error even though the object exists.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				arrayBuffer: async () =>
+					encodeToBuffer('#L1LABEL BASIC\n#L1FILE BASIC.DTX\n')
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [{ label: 'BASIC', level: 1 }],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'BASIC',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+		expect(discovery.chartsPopulated).toBe(true);
+	});
+
 	it('parses set.def using colon separator (matches editor loader)', async () => {
 		// The editor loader at packages/dtx-web/.../editor/+page.server.ts
 		// accepts both `#L1LABEL BASIC` and `#L1LABEL: BASIC`. Catalog

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -339,6 +339,31 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/full.wav');
 	});
 
+	it('skips fetching set.def when no dtx chart rows need matching', async () => {
+		const getMock = vi.fn(async () => ({ text: async () => '' }));
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/preview.mp3', size: 100, uploaded: new Date() }
+				]
+			]),
+			get: getMock
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		// previewUrl/downloadUrl still resolve from the listing, but set.def
+		// must not be fetched because no chart rows need label-to-file matching.
+		expect(getMock).not.toHaveBeenCalled();
+		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/preview.mp3');
+		expect(discovery.charts).toEqual([]);
+	});
+
 	it('matches dtx rows by sorted fallback when set.def is unavailable', async () => {
 		const bucket = makeBucket([
 			[

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -788,8 +788,7 @@ describe('discoverCatalogFiles', () => {
 				]
 			]),
 			get: vi.fn(async () => ({
-				arrayBuffer: async () =>
-					encodeToBuffer('#L1LABEL BASIC\n#L1FILE basic.dtx\n')
+				arrayBuffer: async () => encodeToBuffer('#L1LABEL BASIC\n#L1FILE basic.dtx\n')
 			}))
 		} as unknown as R2Bucket;
 
@@ -879,8 +878,7 @@ describe('discoverCatalogFiles', () => {
 				]
 			]),
 			get: vi.fn(async () => ({
-				arrayBuffer: async () =>
-					encodeToBuffer('#L1LABEL BASIC\n#L1FILE BASIC.DTX\n')
+				arrayBuffer: async () => encodeToBuffer('#L1LABEL BASIC\n#L1FILE BASIC.DTX\n')
 			}))
 		} as unknown as R2Bucket;
 

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -550,6 +550,59 @@ describe('discoverCatalogFiles', () => {
 		]);
 	});
 
+	it('parses set.def using colon separator (matches editor loader)', async () => {
+		// The editor loader at packages/dtx-web/.../editor/+page.server.ts
+		// accepts both `#L1LABEL BASIC` and `#L1LABEL: BASIC`. Catalog
+		// discovery must accept the same forms; otherwise filesByLabel
+		// stays empty and falls back to sorted-key matching, which can
+		// pair the wrong chart when key order differs from level order.
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/z-basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/a-advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+		get: vi.fn(async () => ({
+			arrayBuffer: async () =>
+				encodeToBuffer(
+					'#L1LABEL: BASIC\n#L1FILE: z-basic.dtx\n#L2LABEL:ADVANCED\n#L2FILE :a-advanced.dtx\n'
+				)
+		}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [
+					{ label: 'Advanced', level: 5 },
+					{ label: 'Basic', level: 1 }
+				],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/a-advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/z-basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
 	it('returns an unmatched chart entry when a required dtx object is missing', async () => {
 		const bucket = makeBucket([[{ key: '42/basic.dtx', size: 300, uploaded: new Date() }]]);
 

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -489,4 +489,79 @@ describe('discoverCatalogFiles', () => {
 			}
 		]);
 	});
+
+	it('falls back to sorted pairing when set.def read throws a transient R2 error', async () => {
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/a-basic.dtx', size: 300, uploaded: new Date() },
+					{ key: '42/b-advanced.dtx', size: 500, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => {
+				throw new Error('R2 transient error');
+			})
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [
+				{ label: 'Advanced', level: 5 },
+				{ label: 'Basic', level: 1 }
+			],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(bucket.get).toHaveBeenCalledWith('42/set.def');
+		// Should fall through to sorted-key fallback instead of throwing
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Advanced',
+				level: 5,
+				fileUrl: 'https://cdn.example.test/42/b-advanced.dtx',
+				fileSizeBytes: 500,
+				fileEncoding: 'SHIFT_JIS'
+			},
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/a-basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
+
+	it('falls back to sorted pairing when set.def object.text() throws', async () => {
+		const bucket = {
+			...makeBucket([
+				[
+					{ key: '42/set.def', size: 90, uploaded: new Date() },
+					{ key: '42/basic.dtx', size: 300, uploaded: new Date() }
+				]
+			]),
+			get: vi.fn(async () => ({
+				text: async () => {
+					throw new Error('body read error');
+				}
+			}))
+		} as unknown as R2Bucket;
+
+		const discovery = await discoverCatalogFiles(bucket, {
+			simfileId: 42,
+			dtxFiles: [{ label: 'Basic', level: 1 }],
+			publicBaseUrl: 'https://cdn.example.test'
+		});
+
+		expect(discovery.charts).toEqual([
+			{
+				label: 'Basic',
+				level: 1,
+				fileUrl: 'https://cdn.example.test/42/basic.dtx',
+				fileSizeBytes: 300,
+				fileEncoding: 'SHIFT_JIS'
+			}
+		]);
+	});
 });

--- a/packages/dtx-api/src/services/r2Enrichment.test.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.test.ts
@@ -339,6 +339,71 @@ describe('discoverCatalogFiles', () => {
 		expect(discovery.previewUrl).toBe('https://cdn.example.test/42/assets/PREVIEW.MP3');
 	});
 
+	it('selects non-preview .ogg before .mp3, .wav, and .flac for downloadUrl', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/song.mp3', size: 200, uploaded: new Date() },
+				{ key: '42/music.ogg', size: 150, uploaded: new Date() },
+				{ key: '42/song.wav', size: 300, uploaded: new Date() },
+				{ key: '42/song.flac', size: 400, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/music.ogg');
+	});
+
+	it('ignores preview.mp3 when selecting full audio for downloadUrl', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/preview.mp3', size: 100, uploaded: new Date() },
+				{ key: '42/song.mp3', size: 200, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.downloadUrl).toBe('https://cdn.example.test/42/song.mp3');
+	});
+
+	it('returns null downloadUrl when no suitable audio object exists', async () => {
+		const bucket = makeBucket([
+			[
+				{ key: '42/song.dtx', size: 200, uploaded: new Date() },
+				{ key: '42/preview.mp3', size: 100, uploaded: new Date() }
+			]
+		]);
+
+		const discovery = await discoverCatalogFiles(
+			bucket,
+			{
+				simfileId: 42,
+				dtxFiles: [],
+				publicBaseUrl: 'https://cdn.example.test'
+			},
+			silentLogger
+		);
+
+		expect(discovery.downloadUrl).toBeNull();
+	});
+
 	it('prefers the canonical top-level preview.mp3 over a nested asset with the same basename', async () => {
 		// DTX simfiles routinely ship packaged `#WAV` samples under
 		// `assets/` (e.g. 42/assets/preview.mp3). The public preview

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -183,15 +183,20 @@ export const discoverCatalogFiles = async (
 	// '42/assets/...' sorts before '42/song.ogg' — mirroring the
 	// canonical-vs-nested preference used for preview.mp3 and set.def.
 	const isTopLevelKey = (key: string): boolean => !key.slice(prefix.length).includes('/');
+	// Top-level must win over extension: a top-level .mp3 backing track
+	// is the full-audio download candidate even when nested .ogg sample
+	// chips exist, because .ogg has higher extension priority. Checking
+	// extension first would sort the nested sample ahead of the backing
+	// track and point downloadUrl at a drum chip instead of full audio.
 	const audioObjects = objects
 		.filter((obj: R2ObjectMeta) => isAudio(obj.key))
 		.sort((a, b) => {
-			const aExt = audioExts.findIndex((ext) => a.key.toLowerCase().endsWith(ext));
-			const bExt = audioExts.findIndex((ext) => b.key.toLowerCase().endsWith(ext));
-			if (aExt !== bExt) return aExt - bExt;
 			const aTop = isTopLevelKey(a.key);
 			const bTop = isTopLevelKey(b.key);
 			if (aTop !== bTop) return aTop ? -1 : 1;
+			const aExt = audioExts.findIndex((ext) => a.key.toLowerCase().endsWith(ext));
+			const bExt = audioExts.findIndex((ext) => b.key.toLowerCase().endsWith(ext));
+			if (aExt !== bExt) return aExt - bExt;
 			return a.key.localeCompare(b.key);
 		});
 	const downloadObject = audioObjects[0];

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -76,14 +76,7 @@ const isPreviewMp3Key = (key: string): boolean => getFileName(key).toLowerCase()
 
 const normalizeSetDefValue = (value: string): string => value.trim().replaceAll('\\', '/');
 
-const resolveSetDefFileKey = (prefix: string, fileName: string): string => {
-	const normalizedFileName = normalizeSetDefValue(fileName);
-	return normalizedFileName.startsWith(prefix)
-		? normalizedFileName
-		: `${prefix}${normalizedFileName}`;
-};
-
-const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string, string[]> => {
+const parseSetDefFilesByLabel = (setDefText: string): Map<string, string[]> => {
 	const entries = new Map<string, { label?: string; file?: string }>();
 	// Match the separator accepted by the editor loader at
 	// packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/+page.server.ts
@@ -98,7 +91,16 @@ const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string
 		if (kind.toUpperCase() === 'LABEL') {
 			entry.label = value.trim();
 		} else {
-			entry.file = resolveSetDefFileKey(prefix, value);
+			// Store the raw normalized filename only. Path resolution is
+			// deferred to the caller (discoverCatalogFiles), which has
+			// access to the R2 object map and can try the set.def's
+			// directory first with a simfile-root fallback. This matches
+			// the DTX convention — confirmed by the desktop parser at
+			// packages/dtx-desktop/src/main/simfile-service.ts which reads
+			// set.def and .dtx files from the SAME folder — that #LxFILE
+			// references are relative to the set.def's directory, not the
+			// simfile root.
+			entry.file = normalizeSetDefValue(value);
 		}
 		entries.set(level, entry);
 	}
@@ -128,7 +130,6 @@ const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string
 const readSetDefFilesByLabel = async (
 	bucket: R2Bucket,
 	setDefKey: string | undefined,
-	prefix: string,
 	logger: WorkerLogger
 ): Promise<Map<string, string[]>> => {
 	if (!setDefKey) return new Map();
@@ -143,7 +144,7 @@ const readSetDefFilesByLabel = async (
 		// directive, causing the regex match to miss and silently fall back to
 		// sorted-key pairing.
 		const setDefText = decodeArrayBufferWithBomDetection(await object.arrayBuffer());
-		return parseSetDefFilesByLabel(setDefText, prefix);
+		return parseSetDefFilesByLabel(setDefText);
 	} catch (err) {
 		// Transient R2 errors or unexpected body issues: fall through
 		// to the deterministic sorted-key fallback instead of failing
@@ -247,8 +248,17 @@ export const discoverCatalogFiles = async (
 	// requests never read filesByLabel, so we avoid an unnecessary R2 GET.
 	const filesByLabel =
 		dtxFiles.length > 0
-			? await readSetDefFilesByLabel(bucket, setDefKey, prefix, logger)
+			? await readSetDefFilesByLabel(bucket, setDefKey, logger)
 			: new Map<string, string[]>();
+	// Derive the directory that contains the selected set.def so relative
+	// #LxFILE references resolve against it (e.g. 42/song/basic.dtx when
+	// set.def is 42/song/set.def) instead of always the simfile root.
+	// Uploads preserve directory structure, so sibling chart files live
+	// next to the set.def. Falls back to the simfile root when set.def is
+	// at the top level or not found.
+	const setDefBaseDir = setDefKey
+		? setDefKey.slice(0, setDefKey.lastIndexOf('/') + 1) || prefix
+		: prefix;
 
 	const matchedKeysByRowIndex = new Map<number, string>();
 	// Rows with an explicit set.def label→file mapping are "claimed" by
@@ -263,20 +273,33 @@ export const discoverCatalogFiles = async (
 		// last-inserted entry. Files are accumulated in L-slot order (see
 		// parseSetDefFilesByLabel), so the first matching row gets the first
 		// slot's file, the second row gets the second, etc.
-		const setDefKeyForFile = filesByLabel.get(file.label.toLowerCase())?.shift();
-		if (setDefKeyForFile) {
+		const setDefFile = filesByLabel.get(file.label.toLowerCase())?.shift();
+		if (setDefFile) {
 			rowsClaimedBySetDef.add(index);
+			// Resolve relative #LxFILE references: absolute paths (already
+			// include the simfile id) are kept as-is; relative names are
+			// resolved against the set.def's directory first, then the
+			// simfile root prefix as a fallback for legacy flat uploads
+			// where chart files live at the root despite a nested set.def.
 			// Exact match first; fall back to a case-insensitive lookup so
 			// that SET.DEF references like BASIC.DTX still resolve when the
-			// R2 key is basic.dtx. Without this fallback the row is marked
+			// R2 key is basic.dtx. Without these fallbacks the row is marked
 			// as claimed-but-missing, which surfaces as an INTERNAL error
 			// via requireCatalogChart even though the chart object exists.
-			const exactObject = objectsByKey.get(setDefKeyForFile);
-			const matchedObject =
-				exactObject ?? objectsByKeyLower.get(setDefKeyForFile.toLowerCase());
-			if (matchedObject) {
-				matchedKeysByRowIndex.set(index, matchedObject.key);
-				usedDtxKeys.add(matchedObject.key);
+			const candidates = setDefFile.startsWith(prefix)
+				? [setDefFile]
+				: setDefBaseDir === prefix
+					? [`${prefix}${setDefFile}`]
+					: [`${setDefBaseDir}${setDefFile}`, `${prefix}${setDefFile}`];
+			for (const candidateKey of candidates) {
+				const exactObject = objectsByKey.get(candidateKey);
+				const matchedObject =
+					exactObject ?? objectsByKeyLower.get(candidateKey.toLowerCase());
+				if (matchedObject) {
+					matchedKeysByRowIndex.set(index, matchedObject.key);
+					usedDtxKeys.add(matchedObject.key);
+					break;
+				}
 			}
 		}
 	}

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -190,17 +190,26 @@ export const discoverCatalogFiles = async (
 			: new Map<string, string>();
 
 	const matchedKeysByRowIndex = new Map<number, string>();
+	// Rows with an explicit set.def label→file mapping are "claimed" by
+	// set.def regardless of whether the referenced R2 object exists. This
+	// prevents the sorted-key fallback from assigning an unrelated .dtx
+	// key to a chart whose intended file is missing — which would silently
+	// serve the wrong chart instead of the correct missing-chart null.
+	const rowsClaimedBySetDef = new Set<number>();
 	for (const [index, file] of dtxFiles.entries()) {
 		const setDefKeyForFile = filesByLabel.get(file.label.toLowerCase());
-		if (setDefKeyForFile && objectsByKey.has(setDefKeyForFile)) {
-			matchedKeysByRowIndex.set(index, setDefKeyForFile);
-			usedDtxKeys.add(setDefKeyForFile);
+		if (setDefKeyForFile) {
+			rowsClaimedBySetDef.add(index);
+			if (objectsByKey.has(setDefKeyForFile)) {
+				matchedKeysByRowIndex.set(index, setDefKeyForFile);
+				usedDtxKeys.add(setDefKeyForFile);
+			}
 		}
 	}
 
 	const fallbackRows = dtxFiles
 		.map((file, index) => ({ file, index }))
-		.filter(({ index }) => !matchedKeysByRowIndex.has(index))
+		.filter(({ index }) => !rowsClaimedBySetDef.has(index))
 		.sort(
 			(a, b) =>
 				a.file.level - b.file.level ||

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -154,6 +154,16 @@ export const discoverCatalogFiles = async (
 		(obj: R2ObjectMeta) => obj.key.length > prefix.length
 	);
 	const objectsByKey = new Map(objects.map((obj: R2ObjectMeta) => [obj.key, obj]));
+	// Case-insensitive fallback map: SET.DEF file references may use a
+	// different case than the actual R2 object key (e.g. SET.DEF says
+	// BASIC.DTX while R2 stores 42/basic.dtx). Uploads from case-
+	// insensitive filesystems (Windows, default macOS) routinely produce
+	// this mismatch. The desktop parseDtxFiles path lowercases both sides
+	// of the comparison; we mirror that here as a fallback after exact
+	// match to avoid marking valid charts as missing.
+	const objectsByKeyLower = new Map(
+		objects.map((obj: R2ObjectMeta) => [obj.key.toLowerCase(), obj])
+	);
 
 	// Preview selection: prefer the canonical top-level key
 	// `{simfileId}/preview.mp3` (case-insensitive) over any nested
@@ -238,9 +248,17 @@ export const discoverCatalogFiles = async (
 		const setDefKeyForFile = filesByLabel.get(file.label.toLowerCase());
 		if (setDefKeyForFile) {
 			rowsClaimedBySetDef.add(index);
-			if (objectsByKey.has(setDefKeyForFile)) {
-				matchedKeysByRowIndex.set(index, setDefKeyForFile);
-				usedDtxKeys.add(setDefKeyForFile);
+			// Exact match first; fall back to a case-insensitive lookup so
+			// that SET.DEF references like BASIC.DTX still resolve when the
+			// R2 key is basic.dtx. Without this fallback the row is marked
+			// as claimed-but-missing, which surfaces as an INTERNAL error
+			// via requireCatalogChart even though the chart object exists.
+			const exactObject = objectsByKey.get(setDefKeyForFile);
+			const matchedObject =
+				exactObject ?? objectsByKeyLower.get(setDefKeyForFile.toLowerCase());
+			if (matchedObject) {
+				matchedKeysByRowIndex.set(index, matchedObject.key);
+				usedDtxKeys.add(matchedObject.key);
 			}
 		}
 	}

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -40,6 +40,7 @@ export type CatalogChartFile = CatalogChartFilePresent | CatalogChartFileMissing
 
 export type CatalogFileDiscovery = {
 	previewUrl: string | null;
+	downloadUrl: string | null;
 	charts: CatalogChartFile[];
 	/**
 	 * False when the caller passed an empty `dtxFiles` array (URL-only
@@ -167,6 +168,22 @@ export const discoverCatalogFiles = async (
 		objects.find((obj: R2ObjectMeta) => isPreviewMp3Key(obj.key));
 	const previewUrl = previewObject ? toPublicUrl(publicBaseUrl, previewObject.key) : null;
 
+	const audioExts = ['.ogg', '.mp3', '.wav', '.flac'];
+	const isAudio = (key: string): boolean => {
+		const lower = key.toLowerCase();
+		return audioExts.some((ext) => lower.endsWith(ext)) && !isPreviewMp3Key(key);
+	};
+	const audioObjects = objects
+		.filter((obj: R2ObjectMeta) => isAudio(obj.key))
+		.sort((a, b) => {
+			const aExt = audioExts.findIndex((ext) => a.key.toLowerCase().endsWith(ext));
+			const bExt = audioExts.findIndex((ext) => b.key.toLowerCase().endsWith(ext));
+			if (aExt !== bExt) return aExt - bExt;
+			return a.key.localeCompare(b.key);
+		});
+	const downloadObject = audioObjects[0];
+	const downloadUrl = downloadObject ? toPublicUrl(publicBaseUrl, downloadObject.key) : null;
+
 	const dtxObjects = objects
 		.filter((obj: R2ObjectMeta) => obj.key.toLowerCase().endsWith('.dtx'))
 		.sort((a: R2ObjectMeta, b: R2ObjectMeta) => a.key.localeCompare(b.key));
@@ -232,7 +249,7 @@ export const discoverCatalogFiles = async (
 		};
 	});
 
-	return { previewUrl, charts, chartsPopulated: dtxFiles.length > 0 };
+	return { previewUrl, downloadUrl, charts, chartsPopulated: dtxFiles.length > 0 };
 };
 
 export const batchDiscoverCatalogFiles = async (

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -83,7 +83,7 @@ const resolveSetDefFileKey = (prefix: string, fileName: string): string => {
 		: `${prefix}${normalizedFileName}`;
 };
 
-const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string, string> => {
+const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string, string[]> => {
 	const entries = new Map<string, { label?: string; file?: string }>();
 	// Match the separator accepted by the editor loader at
 	// packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/+page.server.ts
@@ -103,10 +103,23 @@ const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string
 		entries.set(level, entry);
 	}
 
-	const filesByLabel = new Map<string, string>();
+	// A single label can legitimately appear on multiple L-slots (e.g. two
+	// charts both labelled "BASIC"). Collecting an array per label — rather
+	// than a single value keyed by label alone — preserves every distinct
+	// file so the consumer can assign one file per matching DB row instead
+	// of overwriting earlier entries and silently collapsing two rows onto
+	// the same R2 object. The `entries` map is keyed by L-slot and iterated
+	// in insertion order (L1 before L2 …), so the array stays in slot order.
+	const filesByLabel = new Map<string, string[]>();
 	for (const entry of entries.values()) {
 		if (entry.label && entry.file) {
-			filesByLabel.set(entry.label.toLowerCase(), entry.file);
+			const key = entry.label.toLowerCase();
+			const list = filesByLabel.get(key);
+			if (list) {
+				list.push(entry.file);
+			} else {
+				filesByLabel.set(key, [entry.file]);
+			}
 		}
 	}
 	return filesByLabel;
@@ -117,7 +130,7 @@ const readSetDefFilesByLabel = async (
 	setDefKey: string | undefined,
 	prefix: string,
 	logger: WorkerLogger
-): Promise<Map<string, string>> => {
+): Promise<Map<string, string[]>> => {
 	if (!setDefKey) return new Map();
 
 	try {
@@ -235,7 +248,7 @@ export const discoverCatalogFiles = async (
 	const filesByLabel =
 		dtxFiles.length > 0
 			? await readSetDefFilesByLabel(bucket, setDefKey, prefix, logger)
-			: new Map<string, string>();
+			: new Map<string, string[]>();
 
 	const matchedKeysByRowIndex = new Map<number, string>();
 	// Rows with an explicit set.def label→file mapping are "claimed" by
@@ -245,7 +258,12 @@ export const discoverCatalogFiles = async (
 	// serve the wrong chart instead of the correct missing-chart null.
 	const rowsClaimedBySetDef = new Set<number>();
 	for (const [index, file] of dtxFiles.entries()) {
-		const setDefKeyForFile = filesByLabel.get(file.label.toLowerCase());
+		// Consume one SET.def file per matching row so that duplicate labels
+		// each claim a distinct R2 object instead of all collapsing onto the
+		// last-inserted entry. Files are accumulated in L-slot order (see
+		// parseSetDefFilesByLabel), so the first matching row gets the first
+		// slot's file, the second row gets the second, etc.
+		const setDefKeyForFile = filesByLabel.get(file.label.toLowerCase())?.shift();
 		if (setDefKeyForFile) {
 			rowsClaimedBySetDef.add(index);
 			// Exact match first; fall back to a case-insensitive lookup so

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -97,10 +97,16 @@ const readSetDefFilesByLabel = async (
 ): Promise<Map<string, string>> => {
 	if (!setDefKey) return new Map();
 
-	const object = await bucket.get(setDefKey);
-	if (!object) return new Map();
-
-	return parseSetDefFilesByLabel(await object.text(), prefix);
+	try {
+		const object = await bucket.get(setDefKey);
+		if (!object) return new Map();
+		return parseSetDefFilesByLabel(await object.text(), prefix);
+	} catch {
+		// Transient R2 errors or unexpected body issues: fall through
+		// to the deterministic sorted-key fallback instead of failing
+		// the entire catalog discovery.
+		return new Map();
+	}
 };
 
 export const discoverCatalogFiles = async (

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -184,6 +184,27 @@ export const discoverCatalogFiles = async (
 	return { previewUrl, downloadUrl, charts };
 };
 
+export const batchDiscoverCatalogFiles = async (
+	bucket: R2Bucket,
+	options: CatalogDiscoveryOptions[]
+): Promise<Map<number, CatalogFileDiscovery>> => {
+	const results = new Map<number, CatalogFileDiscovery>();
+	if (options.length === 0) return results;
+
+	let nextIndex = 0;
+	const worker: () => Promise<void> = async () => {
+		while (nextIndex < options.length) {
+			const option = options[nextIndex++];
+			results.set(option.simfileId, await discoverCatalogFiles(bucket, option));
+		}
+	};
+
+	await Promise.all(
+		Array.from({ length: Math.min(MAX_CONCURRENT_R2_LIST, options.length) }, () => worker())
+	);
+	return results;
+};
+
 export const enrichFiles = async (bucket: R2Bucket, simfileId: number): Promise<R2FileEntry[]> => {
 	const prefix = `${simfileId}/`;
 	const objects = await listAllR2Objects(bucket, prefix);

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -40,7 +40,6 @@ export type CatalogChartFile = CatalogChartFilePresent | CatalogChartFileMissing
 
 export type CatalogFileDiscovery = {
 	previewUrl: string | null;
-	downloadUrl: string | null;
 	charts: CatalogChartFile[];
 	/**
 	 * False when the caller passed an empty `dtxFiles` array (URL-only
@@ -64,7 +63,6 @@ export type CatalogDiscoveryOptions = {
  * dtx-web REST endpoint (MAX_CONCURRENT_R2_CHECKS = 4).
  */
 const MAX_CONCURRENT_R2_LIST = 4;
-const DOWNLOAD_EXTENSION_PRIORITY = ['.ogg', '.mp3', '.wav', '.flac'] as const;
 
 const toPublicUrl = (publicBaseUrl: string, key: string): string => {
 	const baseUrl = publicBaseUrl.replace(/\/+$/, '');
@@ -74,12 +72,6 @@ const toPublicUrl = (publicBaseUrl: string, key: string): string => {
 const getFileName = (key: string): string => key.split('/').at(-1) ?? '';
 
 const isPreviewMp3Key = (key: string): boolean => getFileName(key).toLowerCase() === 'preview.mp3';
-
-const getExtension = (key: string): string => {
-	const fileName = getFileName(key);
-	const dotIndex = fileName.lastIndexOf('.');
-	return dotIndex === -1 ? '' : fileName.slice(dotIndex).toLowerCase();
-};
 
 const normalizeSetDefValue = (value: string): string => value.trim().replaceAll('\\', '/');
 
@@ -162,25 +154,18 @@ export const discoverCatalogFiles = async (
 	);
 	const objectsByKey = new Map(objects.map((obj: R2ObjectMeta) => [obj.key, obj]));
 
-	const previewObject = objects
-		.slice()
-		.sort((a: R2ObjectMeta, b: R2ObjectMeta) => a.key.localeCompare(b.key))
-		.find((obj: R2ObjectMeta) => isPreviewMp3Key(obj.key));
+	// Preview selection: prefer the canonical top-level key
+	// `{simfileId}/preview.mp3` (case-insensitive) over any nested
+	// `preview.mp3` (e.g. `42/assets/preview.mp3`). DTX simfiles routinely
+	// ship packaged sample chips under `assets/` and the public preview
+	// contract is the top-level path — selecting by basename alone plus
+	// alphabetic sort would return the nested asset first because
+	// `42/assets/preview.mp3` sorts before `42/preview.mp3`.
+	const canonicalPreviewKey = `${prefix}preview.mp3`.toLowerCase();
+	const previewObject =
+		objects.find((obj: R2ObjectMeta) => obj.key.toLowerCase() === canonicalPreviewKey) ??
+		objects.find((obj: R2ObjectMeta) => isPreviewMp3Key(obj.key));
 	const previewUrl = previewObject ? toPublicUrl(publicBaseUrl, previewObject.key) : null;
-
-	const downloadObject = objects
-		.filter((obj: R2ObjectMeta) => !isPreviewMp3Key(obj.key))
-		.map((obj: R2ObjectMeta) => ({
-			object: obj,
-			priority: DOWNLOAD_EXTENSION_PRIORITY.indexOf(
-				getExtension(obj.key) as (typeof DOWNLOAD_EXTENSION_PRIORITY)[number]
-			)
-		}))
-		.filter(({ priority }) => priority !== -1)
-		.sort(
-			(a, b) => a.priority - b.priority || a.object.key.localeCompare(b.object.key)
-		)[0]?.object;
-	const downloadUrl = downloadObject ? toPublicUrl(publicBaseUrl, downloadObject.key) : null;
 
 	const dtxObjects = objects
 		.filter((obj: R2ObjectMeta) => obj.key.toLowerCase().endsWith('.dtx'))
@@ -191,7 +176,7 @@ export const discoverCatalogFiles = async (
 	const setDefKey = objects.find(
 		(obj: R2ObjectMeta) => getFileName(obj.key).toLowerCase() === 'set.def'
 	)?.key;
-	// Skip fetching set.def when no chart rows need matching — preview/download-only
+	// Skip fetching set.def when no chart rows need matching — preview-only
 	// requests never read filesByLabel, so we avoid an unnecessary R2 GET.
 	const filesByLabel =
 		dtxFiles.length > 0
@@ -247,7 +232,7 @@ export const discoverCatalogFiles = async (
 		};
 	});
 
-	return { previewUrl, downloadUrl, charts, chartsPopulated: dtxFiles.length > 0 };
+	return { previewUrl, charts, chartsPopulated: dtxFiles.length > 0 };
 };
 
 export const batchDiscoverCatalogFiles = async (

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -1,4 +1,9 @@
-import { listAllR2Objects, isPreviewKey, type R2ObjectMeta } from '@dtx/common/server';
+import {
+	listAllR2Objects,
+	isPreviewKey,
+	type R2ObjectMeta,
+	type WorkerLogger
+} from '@dtx/common/server';
 import type { R2Bucket } from '@cloudflare/workers-types';
 
 export type R2FileEntry = {
@@ -12,11 +17,25 @@ export type CatalogDtxFileInput = {
 	level: number;
 };
 
-export type CatalogChartFile = CatalogDtxFileInput & {
-	fileUrl: string | null;
-	fileSizeBytes: number | null;
+/**
+ * Catalog chart file with the fileUrl/fileSizeBytes coupling invariant
+ * expressed in the type: both fields are either set (R2 object present)
+ * or null (R2 object missing). fileEncoding is always set because the
+ * parser treats absence as SHIFT_JIS.
+ */
+export type CatalogChartFilePresent = CatalogDtxFileInput & {
+	fileUrl: string;
+	fileSizeBytes: number;
 	fileEncoding: 'SHIFT_JIS';
 };
+
+export type CatalogChartFileMissing = CatalogDtxFileInput & {
+	fileUrl: null;
+	fileSizeBytes: null;
+	fileEncoding: 'SHIFT_JIS';
+};
+
+export type CatalogChartFile = CatalogChartFilePresent | CatalogChartFileMissing;
 
 export type CatalogFileDiscovery = {
 	previewUrl: string | null;
@@ -93,7 +112,8 @@ const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string
 const readSetDefFilesByLabel = async (
 	bucket: R2Bucket,
 	setDefKey: string | undefined,
-	prefix: string
+	prefix: string,
+	logger: WorkerLogger
 ): Promise<Map<string, string>> => {
 	if (!setDefKey) return new Map();
 
@@ -101,17 +121,23 @@ const readSetDefFilesByLabel = async (
 		const object = await bucket.get(setDefKey);
 		if (!object) return new Map();
 		return parseSetDefFilesByLabel(await object.text(), prefix);
-	} catch {
+	} catch (err) {
 		// Transient R2 errors or unexpected body issues: fall through
 		// to the deterministic sorted-key fallback instead of failing
-		// the entire catalog discovery.
+		// the entire catalog discovery. Logged (not rethrown) because
+		// the fallback is the intended graceful-degradation path.
+		logger.warn('set.def read failed; falling back to sorted-key matching', {
+			setDefKey,
+			error: err instanceof Error ? err.message : String(err)
+		});
 		return new Map();
 	}
 };
 
 export const discoverCatalogFiles = async (
 	bucket: R2Bucket,
-	{ simfileId, dtxFiles, publicBaseUrl }: CatalogDiscoveryOptions
+	{ simfileId, dtxFiles, publicBaseUrl }: CatalogDiscoveryOptions,
+	logger: WorkerLogger
 ): Promise<CatalogFileDiscovery> => {
 	const prefix = `${simfileId}/`;
 	const objects = (await listAllR2Objects(bucket, prefix)).filter(
@@ -152,7 +178,7 @@ export const discoverCatalogFiles = async (
 	// requests never read filesByLabel, so we avoid an unnecessary R2 GET.
 	const filesByLabel =
 		dtxFiles.length > 0
-			? await readSetDefFilesByLabel(bucket, setDefKey, prefix)
+			? await readSetDefFilesByLabel(bucket, setDefKey, prefix, logger)
 			: new Map<string, string>();
 
 	const matchedKeysByRowIndex = new Map<number, string>();
@@ -184,10 +210,13 @@ export const discoverCatalogFiles = async (
 	const charts = dtxFiles.map((file, index): CatalogChartFile => {
 		const key = matchedKeysByRowIndex.get(index);
 		const object = key ? objectsByKey.get(key) : undefined;
+		if (!object) {
+			return { ...file, fileUrl: null, fileSizeBytes: null, fileEncoding: 'SHIFT_JIS' };
+		}
 		return {
 			...file,
-			fileUrl: object ? toPublicUrl(publicBaseUrl, object.key) : null,
-			fileSizeBytes: object ? object.size : null,
+			fileUrl: toPublicUrl(publicBaseUrl, object.key),
+			fileSizeBytes: object.size,
 			fileEncoding: 'SHIFT_JIS'
 		};
 	});
@@ -197,7 +226,8 @@ export const discoverCatalogFiles = async (
 
 export const batchDiscoverCatalogFiles = async (
 	bucket: R2Bucket,
-	options: CatalogDiscoveryOptions[]
+	options: CatalogDiscoveryOptions[],
+	logger: WorkerLogger
 ): Promise<Map<number, CatalogFileDiscovery>> => {
 	const results = new Map<number, CatalogFileDiscovery>();
 	if (options.length === 0) return results;
@@ -206,7 +236,7 @@ export const batchDiscoverCatalogFiles = async (
 	const worker: () => Promise<void> = async () => {
 		while (nextIndex < options.length) {
 			const option = options[nextIndex++];
-			results.set(option.simfileId, await discoverCatalogFiles(bucket, option));
+			results.set(option.simfileId, await discoverCatalogFiles(bucket, option, logger));
 		}
 	};
 

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -190,9 +190,18 @@ export const discoverCatalogFiles = async (
 	const dtxObjectKeys = dtxObjects.map((obj: R2ObjectMeta) => obj.key);
 	const usedDtxKeys = new Set<string>();
 
-	const setDefKey = objects.find(
-		(obj: R2ObjectMeta) => getFileName(obj.key).toLowerCase() === 'set.def'
-	)?.key;
+	// Prefer the canonical top-level key `{simfileId}/set.def`
+	// (case-insensitive) over any nested `set.def` (e.g.
+	// `42/assets/set.def`). DTX simfiles routinely ship packaged
+	// sample chips and other assets under `assets/`, and basename-only
+	// matching would pick the nested copy first because
+	// `42/assets/set.def` sorts before `42/set.def` — causing chart
+	// labels to be read from the wrong/empty SET.DEF and `fileUrl`
+	// pairing to fall back to incorrect sorted-key matching.
+	const canonicalSetDefKey = `${prefix}set.def`.toLowerCase();
+	const setDefKey =
+		objects.find((obj: R2ObjectMeta) => obj.key.toLowerCase() === canonicalSetDefKey)?.key ??
+		objects.find((obj: R2ObjectMeta) => getFileName(obj.key).toLowerCase() === 'set.def')?.key;
 	// Skip fetching set.def when no chart rows need matching — preview-only
 	// requests never read filesByLabel, so we avoid an unnecessary R2 GET.
 	const filesByLabel =

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -148,7 +148,12 @@ export const discoverCatalogFiles = async (
 	const setDefKey = objects.find(
 		(obj: R2ObjectMeta) => getFileName(obj.key).toLowerCase() === 'set.def'
 	)?.key;
-	const filesByLabel = await readSetDefFilesByLabel(bucket, setDefKey, prefix);
+	// Skip fetching set.def when no chart rows need matching — preview/download-only
+	// requests never read filesByLabel, so we avoid an unnecessary R2 GET.
+	const filesByLabel =
+		dtxFiles.length > 0
+			? await readSetDefFilesByLabel(bucket, setDefKey, prefix)
+			: new Map<string, string>();
 
 	const matchedKeysByRowIndex = new Map<number, string>();
 	for (const [index, file] of dtxFiles.entries()) {

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -42,6 +42,14 @@ export type CatalogFileDiscovery = {
 	previewUrl: string | null;
 	downloadUrl: string | null;
 	charts: CatalogChartFile[];
+	/**
+	 * False when the caller passed an empty `dtxFiles` array (URL-only
+	 * discovery), meaning `charts` is empty because chart matching was
+	 * intentionally skipped — not because no .dtx files exist in R2.
+	 * Chart resolvers check this flag to detect stale URL-only cache
+	 * entries and trigger a full re-discovery on demand.
+	 */
+	chartsPopulated: boolean;
 };
 
 export type CatalogDiscoveryOptions = {
@@ -239,7 +247,7 @@ export const discoverCatalogFiles = async (
 		};
 	});
 
-	return { previewUrl, downloadUrl, charts };
+	return { previewUrl, downloadUrl, charts, chartsPopulated: dtxFiles.length > 0 };
 };
 
 export const batchDiscoverCatalogFiles = async (

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -7,12 +7,182 @@ export type R2FileEntry = {
 	uploaded: string;
 };
 
+export type CatalogDtxFileInput = {
+	label: string;
+	level: number;
+};
+
+export type CatalogChartFile = CatalogDtxFileInput & {
+	fileUrl: string | null;
+	fileSizeBytes: number | null;
+	fileEncoding: 'SHIFT_JIS';
+};
+
+export type CatalogFileDiscovery = {
+	previewUrl: string | null;
+	downloadUrl: string | null;
+	charts: CatalogChartFile[];
+};
+
+export type CatalogDiscoveryOptions = {
+	simfileId: number;
+	dtxFiles: CatalogDtxFileInput[];
+	publicBaseUrl: string;
+};
+
 /**
  * Maximum number of concurrent R2 list calls when batch-enriching
  * hasUploadedFiles for a list of simfiles. Matches the cap used in the
  * dtx-web REST endpoint (MAX_CONCURRENT_R2_CHECKS = 4).
  */
 const MAX_CONCURRENT_R2_LIST = 4;
+const DOWNLOAD_EXTENSION_PRIORITY = ['.ogg', '.mp3', '.wav', '.flac'] as const;
+
+const toPublicUrl = (publicBaseUrl: string, key: string): string => {
+	const baseUrl = publicBaseUrl.replace(/\/+$/, '');
+	return `${baseUrl}/${key.split('/').map(encodeURIComponent).join('/')}`;
+};
+
+const getFileName = (key: string): string => key.split('/').at(-1) ?? '';
+
+const isPreviewMp3Key = (key: string): boolean => getFileName(key).toLowerCase() === 'preview.mp3';
+
+const getExtension = (key: string): string => {
+	const fileName = getFileName(key);
+	const dotIndex = fileName.lastIndexOf('.');
+	return dotIndex === -1 ? '' : fileName.slice(dotIndex).toLowerCase();
+};
+
+const normalizeSetDefValue = (value: string): string => value.trim().replaceAll('\\', '/');
+
+const resolveSetDefFileKey = (prefix: string, fileName: string): string => {
+	const normalizedFileName = normalizeSetDefValue(fileName);
+	return normalizedFileName.startsWith(prefix)
+		? normalizedFileName
+		: `${prefix}${normalizedFileName}`;
+};
+
+const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string, string> => {
+	const entries = new Map<string, { label?: string; file?: string }>();
+	for (const line of setDefText.split(/\r?\n/)) {
+		const labelMatch = line.match(/^#L(\d+)LABEL\s+(.+)$/i);
+		if (labelMatch) {
+			const entry = entries.get(labelMatch[1]) ?? {};
+			entry.label = labelMatch[2].trim();
+			entries.set(labelMatch[1], entry);
+			continue;
+		}
+
+		const fileMatch = line.match(/^#L(\d+)FILE\s+(.+)$/i);
+		if (fileMatch) {
+			const entry = entries.get(fileMatch[1]) ?? {};
+			entry.file = resolveSetDefFileKey(prefix, fileMatch[2]);
+			entries.set(fileMatch[1], entry);
+		}
+	}
+
+	const filesByLabel = new Map<string, string>();
+	for (const entry of entries.values()) {
+		if (entry.label && entry.file) {
+			filesByLabel.set(entry.label.toLowerCase(), entry.file);
+		}
+	}
+	return filesByLabel;
+};
+
+const readSetDefFilesByLabel = async (
+	bucket: R2Bucket,
+	setDefKey: string | undefined,
+	prefix: string
+): Promise<Map<string, string>> => {
+	if (!setDefKey) return new Map();
+
+	const object = await bucket.get(setDefKey);
+	if (!object) return new Map();
+
+	return parseSetDefFilesByLabel(await object.text(), prefix);
+};
+
+export const discoverCatalogFiles = async (
+	bucket: R2Bucket,
+	{ simfileId, dtxFiles, publicBaseUrl }: CatalogDiscoveryOptions
+): Promise<CatalogFileDiscovery> => {
+	const prefix = `${simfileId}/`;
+	const objects = (await listAllR2Objects(bucket, prefix)).filter(
+		(obj: R2ObjectMeta) => obj.key.length > prefix.length
+	);
+	const objectsByKey = new Map(objects.map((obj: R2ObjectMeta) => [obj.key, obj]));
+
+	const previewObject = objects
+		.slice()
+		.sort((a: R2ObjectMeta, b: R2ObjectMeta) => a.key.localeCompare(b.key))
+		.find((obj: R2ObjectMeta) => isPreviewMp3Key(obj.key));
+	const previewUrl = previewObject ? toPublicUrl(publicBaseUrl, previewObject.key) : null;
+
+	const downloadObject = objects
+		.filter((obj: R2ObjectMeta) => !isPreviewMp3Key(obj.key))
+		.map((obj: R2ObjectMeta) => ({
+			object: obj,
+			priority: DOWNLOAD_EXTENSION_PRIORITY.indexOf(
+				getExtension(obj.key) as (typeof DOWNLOAD_EXTENSION_PRIORITY)[number]
+			)
+		}))
+		.filter(({ priority }) => priority !== -1)
+		.sort(
+			(a, b) => a.priority - b.priority || a.object.key.localeCompare(b.object.key)
+		)[0]?.object;
+	const downloadUrl = downloadObject ? toPublicUrl(publicBaseUrl, downloadObject.key) : null;
+
+	const dtxObjects = objects
+		.filter((obj: R2ObjectMeta) => obj.key.toLowerCase().endsWith('.dtx'))
+		.sort((a: R2ObjectMeta, b: R2ObjectMeta) => a.key.localeCompare(b.key));
+	const dtxObjectKeys = dtxObjects.map((obj: R2ObjectMeta) => obj.key);
+	const usedDtxKeys = new Set<string>();
+
+	const setDefKey = objects.find(
+		(obj: R2ObjectMeta) => getFileName(obj.key).toLowerCase() === 'set.def'
+	)?.key;
+	const filesByLabel = await readSetDefFilesByLabel(bucket, setDefKey, prefix);
+
+	const matchedKeysByRowIndex = new Map<number, string>();
+	for (const [index, file] of dtxFiles.entries()) {
+		const setDefKeyForFile = filesByLabel.get(file.label.toLowerCase());
+		if (setDefKeyForFile && objectsByKey.has(setDefKeyForFile)) {
+			matchedKeysByRowIndex.set(index, setDefKeyForFile);
+			usedDtxKeys.add(setDefKeyForFile);
+		}
+	}
+
+	const fallbackRows = dtxFiles
+		.map((file, index) => ({ file, index }))
+		.filter(({ index }) => !matchedKeysByRowIndex.has(index))
+		.sort(
+			(a, b) =>
+				a.file.level - b.file.level ||
+				a.file.label.localeCompare(b.file.label) ||
+				a.index - b.index
+		);
+	const fallbackKeys = dtxObjectKeys.filter((key) => !usedDtxKeys.has(key));
+	for (const [fallbackIndex, row] of fallbackRows.entries()) {
+		const key = fallbackKeys[fallbackIndex];
+		if (key) {
+			matchedKeysByRowIndex.set(row.index, key);
+		}
+	}
+
+	const charts = dtxFiles.map((file, index): CatalogChartFile => {
+		const key = matchedKeysByRowIndex.get(index);
+		const object = key ? objectsByKey.get(key) : undefined;
+		return {
+			...file,
+			fileUrl: object ? toPublicUrl(publicBaseUrl, object.key) : null,
+			fileSizeBytes: object ? object.size : null,
+			fileEncoding: 'SHIFT_JIS'
+		};
+	});
+
+	return { previewUrl, downloadUrl, charts };
+};
 
 export const enrichFiles = async (bucket: R2Bucket, simfileId: number): Promise<R2FileEntry[]> => {
 	const prefix = `${simfileId}/`;

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -1,6 +1,7 @@
 import {
 	listAllR2Objects,
 	isPreviewKey,
+	decodeArrayBufferWithBomDetection,
 	type R2ObjectMeta,
 	type WorkerLogger
 } from '@dtx/common/server';
@@ -120,7 +121,14 @@ const readSetDefFilesByLabel = async (
 	try {
 		const object = await bucket.get(setDefKey);
 		if (!object) return new Map();
-		return parseSetDefFilesByLabel(await object.text(), prefix);
+		// Decode with BOM detection: set.def files in this app are routinely
+		// written as UTF-16LE with BOM (see packages/dtx-desktop/src/main/index.ts)
+		// or UTF-8 with BOM. The default R2 text() path decodes as UTF-8 and
+		// would either garble UTF-16LE content or leave a BOM on the first
+		// directive, causing the regex match to miss and silently fall back to
+		// sorted-key pairing.
+		const setDefText = decodeArrayBufferWithBomDetection(await object.arrayBuffer());
+		return parseSetDefFilesByLabel(setDefText, prefix);
 	} catch (err) {
 		// Transient R2 errors or unexpected body issues: fall through
 		// to the deterministic sorted-key fallback instead of failing

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -173,12 +173,25 @@ export const discoverCatalogFiles = async (
 		const lower = key.toLowerCase();
 		return audioExts.some((ext) => lower.endsWith(ext)) && !isPreviewMp3Key(key);
 	};
+	// A top-level audio file lives directly under the simfile prefix
+	// (e.g. 42/song.ogg) rather than in a subdirectory (e.g.
+	// 42/assets/kick.ogg). DTX simfiles ship individual drum sample
+	// chips under assets/, which are not full-audio files. When
+	// selecting a downloadUrl fallback we must prefer the top-level
+	// full-audio candidate over nested samples, otherwise lexicographic
+	// sort would return the sample chip first because
+	// '42/assets/...' sorts before '42/song.ogg' — mirroring the
+	// canonical-vs-nested preference used for preview.mp3 and set.def.
+	const isTopLevelKey = (key: string): boolean => !key.slice(prefix.length).includes('/');
 	const audioObjects = objects
 		.filter((obj: R2ObjectMeta) => isAudio(obj.key))
 		.sort((a, b) => {
 			const aExt = audioExts.findIndex((ext) => a.key.toLowerCase().endsWith(ext));
 			const bExt = audioExts.findIndex((ext) => b.key.toLowerCase().endsWith(ext));
 			if (aExt !== bExt) return aExt - bExt;
+			const aTop = isTopLevelKey(a.key);
+			const bTop = isTopLevelKey(b.key);
+			if (aTop !== bTop) return aTop ? -1 : 1;
 			return a.key.localeCompare(b.key);
 		});
 	const downloadObject = audioObjects[0];

--- a/packages/dtx-api/src/services/r2Enrichment.ts
+++ b/packages/dtx-api/src/services/r2Enrichment.ts
@@ -84,21 +84,22 @@ const resolveSetDefFileKey = (prefix: string, fileName: string): string => {
 
 const parseSetDefFilesByLabel = (setDefText: string, prefix: string): Map<string, string> => {
 	const entries = new Map<string, { label?: string; file?: string }>();
+	// Match the separator accepted by the editor loader at
+	// packages/dtx-web/src/routes/(game)/editor/[[simfileID]]/+page.server.ts
+	// so set.def files written with the colon form (#L1LABEL: BASIC) are
+	// parsed the same way here as they are in the editor.
+	const levelLinePattern = /^#L(\d+)(LABEL|FILE)(?:\s*:\s*|\s+)(.+)$/i;
 	for (const line of setDefText.split(/\r?\n/)) {
-		const labelMatch = line.match(/^#L(\d+)LABEL\s+(.+)$/i);
-		if (labelMatch) {
-			const entry = entries.get(labelMatch[1]) ?? {};
-			entry.label = labelMatch[2].trim();
-			entries.set(labelMatch[1], entry);
-			continue;
+		const match = line.match(levelLinePattern);
+		if (!match) continue;
+		const [, level, kind, value] = match;
+		const entry = entries.get(level) ?? {};
+		if (kind.toUpperCase() === 'LABEL') {
+			entry.label = value.trim();
+		} else {
+			entry.file = resolveSetDefFileKey(prefix, value);
 		}
-
-		const fileMatch = line.match(/^#L(\d+)FILE\s+(.+)$/i);
-		if (fileMatch) {
-			const entry = entries.get(fileMatch[1]) ?? {};
-			entry.file = resolveSetDefFileKey(prefix, fileMatch[2]);
-			entries.set(fileMatch[1], entry);
-		}
+		entries.set(level, entry);
 	}
 
 	const filesByLabel = new Map<string, string>();

--- a/packages/dtx-api/vitest.config.ts
+++ b/packages/dtx-api/vitest.config.ts
@@ -13,8 +13,10 @@ export default defineConfig({
 		include: ['src/**/*.test.ts'],
 		coverage: {
 			provider: 'v8',
+			reporter: ['text', 'json', 'html', 'lcov'],
 			include: ['src/**/*.ts'],
-			exclude: ['**/*.test.ts']
+			exclude: ['**/*.test.ts'],
+			all: true
 		}
 	}
 });


### PR DESCRIPTION
## Summary

This PR introduces simfile catalog metadata enrichment and public file discovery from R2, improving GraphQL compatibility for the simfile API.

- **Expose simfile catalog metadata defaults** — adds default values for catalog-related fields on simfiles.
- **Discover public catalog files in R2** — implements R2-based discovery of public catalog files for enrichment.
- **Expose public file metadata on simfiles** — surfaces discovered public file metadata in the simfile schema.
- **Batch catalog file discovery** — batches R2 catalog lookups to improve performance.
- **Avoid unnecessary catalog discovery for DB URLs** — skips catalog enrichment when files are already stored in the database.

## Files changed

- `packages/dtx-api/src/context.ts`
- `packages/dtx-api/src/schema/simfile.ts`
- `packages/dtx-api/src/schema/simfile.test.ts`
- `packages/dtx-api/src/services/r2Enrichment.ts`
- `packages/dtx-api/src/services/r2Enrichment.test.ts`

#### Test plan

- [ ] Unit tests pass (`bun run --filter=dtx-api test`)
- [ ] Type checks pass (`bun run --filter=dtx-api check`)

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GraphQL exposes compatibility metadata defaults and catalog-backed chart fields (file URL, size, encoding). Preview/download URL discovery uses public asset storage with DB-value fallbacks and batch discovery for lists.
  * Added BOM-aware decoding utility for chart text.

* **Documentation**
  * Added design and implementation plans for the compatibility API and resolver/caching behavior.

* **Tests**
  * Expanded tests for metadata defaults, URL discovery, chart matching, BOM decoding, batch discovery, and error handling.

* **Chores**
  * CI/test scripts and coverage config updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->