### PR TITLE
feat(desktop): enable continuous releases from main

### DIFF
--- a/.github/workflows/desktop-build-deploy.yml
+++ b/.github/workflows/desktop-build-deploy.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - preview
+      - main
     tags:
       - 'v*'
   workflow_dispatch: # Allows manual triggering
@@ -31,6 +32,14 @@ on:
 #   option_env! to capture it during `tauri build`. VITE_DTX_SERVER_URL is also
 #   required by the Vite renderer (authService login redirect) and is inlined at
 #   frontend build time.
+# - Push to main is a CONTINUOUS RELEASE channel: every merge builds SIGNED
+#   updater artifacts and uploads them (plus latest.json) to R2, using the
+#   version committed in tauri.conf.json. Bump that version in the merge to
+#   actually offer an update to installed clients; merges that don't bump it
+#   re-publish the same version (a no-op for the updater). This requires the
+#   TAURI_SIGNING_PRIVATE_KEY(/_PASSWORD) secrets in the Desktop environment,
+#   or the signed main build will hard-fail. main and tagged releases share one
+#   R2 bucket / latest.json, so each main merge overwrites the previous upload.
 
 jobs:
   build-windows:
@@ -74,15 +83,22 @@ jobs:
         run: bun run --filter=@dtx/common build
 
       - name: Set Release Version
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
+          CONF="packages/dtx-desktop/src-tauri/tauri.conf.json"
+          CARGO="packages/dtx-desktop/src-tauri/Cargo.toml"
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
-          else
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
             VERSION="${INPUT_VERSION}"
+          else
+            # Push to main (continuous release): use the version committed in
+            # tauri.conf.json. Bump it in the merge to offer a real update;
+            # an unchanged version re-publishes the same release (updater no-op).
+            VERSION="$(jq -r '.version' "$CONF")"
           fi
           VERSION="${VERSION#v}"
           if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
@@ -93,11 +109,9 @@ jobs:
           # time and the updater compares latest.json against it. Without this,
           # a manifest with 1.0.1 and a binary still reporting 1.0.0 causes
           # clients to re-offer the same update indefinitely.
-          CONF="packages/dtx-desktop/src-tauri/tauri.conf.json"
           tmp=$(mktemp)
           jq --tab --arg v "$VERSION" '.version = $v' "$CONF" > "$tmp" && mv "$tmp" "$CONF"
           # Keep Cargo.toml in sync (first 'version =' is the package version).
-          CARGO="packages/dtx-desktop/src-tauri/Cargo.toml"
           tmp=$(mktemp)
           awk -v v="\"$VERSION\"" '/^version = / && !done {print "version = " v; done=1; next} {print}' "$CARGO" > "$tmp" && mv "$tmp" "$CARGO"
           # Re-enable updater artifact generation for this signed release build.
@@ -105,9 +119,10 @@ jobs:
           # so that PR builds (which deliberately run WITHOUT the signing key)
           # and local builds without TAURI_SIGNING_PRIVATE_KEY don't hard-fail:
           # Tauri errors out whenever an updater-enabled target (nsis) is built
-          # with a configured pubkey but no private key. Only this release-only
-          # step (tag/workflow_dispatch) flips it back on, where the signing key
-          # is present and the deploy job actually consumes the .sig sidecars.
+          # with a configured pubkey but no private key. Only signed release
+          # builds (tag / workflow_dispatch / push to main) flip it back on,
+          # where the signing key is present and the deploy job consumes the
+          # .sig sidecars.
           tmp=$(mktemp)
           jq --tab '.bundle.createUpdaterArtifacts = true' "$CONF" > "$tmp" && mv "$tmp" "$CONF"
           echo "Baked release version $VERSION into tauri.conf.json and Cargo.toml"
@@ -189,25 +204,29 @@ jobs:
         run: bun run --filter=@dtx/common build
 
       - name: Set Release Version
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
+          CONF="packages/dtx-desktop/src-tauri/tauri.conf.json"
+          CARGO="packages/dtx-desktop/src-tauri/Cargo.toml"
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
-          else
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
             VERSION="${INPUT_VERSION}"
+          else
+            # Push to main (continuous release): use the committed tauri.conf.json
+            # version. See the Windows job for the full rationale.
+            VERSION="$(jq -r '.version' "$CONF")"
           fi
           VERSION="${VERSION#v}"
           if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
             echo "::error::Release version '$VERSION' is not valid SemVer (expected MAJOR.MINOR.PATCH, e.g. 1.0.1)."
             exit 1
           fi
-          CONF="packages/dtx-desktop/src-tauri/tauri.conf.json"
           tmp=$(mktemp)
           jq --tab --arg v "$VERSION" '.version = $v' "$CONF" > "$tmp" && mv "$tmp" "$CONF"
-          CARGO="packages/dtx-desktop/src-tauri/Cargo.toml"
           tmp=$(mktemp)
           awk -v v="\"$VERSION\"" '/^version = / && !done {print "version = " v; done=1; next} {print}' "$CARGO" > "$tmp" && mv "$tmp" "$CARGO"
           # Re-enable updater artifact generation for this signed release build.
@@ -255,7 +274,7 @@ jobs:
     name: Deploy to Cloudflare R2
     needs: [build-windows, build-mac]
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout Repository
@@ -284,8 +303,13 @@ jobs:
         run: |
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
-          else
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
             VERSION="${INPUT_VERSION}"
+          else
+            # Push to main (continuous release): read the committed version the
+            # build jobs baked into the binaries and bundle filenames, so
+            # latest.json matches exactly what the updater compares against.
+            VERSION="$(jq -r '.version' packages/dtx-desktop/src-tauri/tauri.conf.json)"
           fi
           # Strip an optional leading 'v'. Tauri's updater requires a SemVer
           # version (MAJOR.MINOR.PATCH) in latest.json; a bare timestamp or a

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -174,11 +174,12 @@
 			if (!simfileId) {
 				throw new Error('Simfile ID is required for uploads');
 			}
+			if (!uploadFile) {
+				throw new Error('Upload handler is required for desktop uploads');
+			}
 
 			// Host process will construct the full path from the selected file name.
-			const result = uploadFile
-				? await uploadFile(fileName, songFolderPath, simfileId)
-				: await invokeIpc('upload-file', fileName, songFolderPath, simfileId);
+			const result = await uploadFile(fileName, songFolderPath, simfileId);
 
 			if (!result || !result.success) {
 				throw new Error(result?.error || 'Upload failed');
@@ -298,20 +299,6 @@
 		}
 
 		return merged;
-	}
-
-	// Helper function to safely invoke IPC channels
-	function invokeIpc(
-		channel: string,
-		...args: unknown[]
-	): Promise<{ success: boolean; error?: string }> {
-		const ipcRenderer = (
-			window as { electron?: { ipcRenderer?: { invoke: typeof invokeIpc } } }
-		).electron?.ipcRenderer;
-		if (!ipcRenderer) {
-			throw new Error('IPC Renderer is not available');
-		}
-		return ipcRenderer.invoke(channel, ...args);
 	}
 </script>
 

--- a/packages/common/src/lib/components/UploadedAssetFiles.test.ts
+++ b/packages/common/src/lib/components/UploadedAssetFiles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Use the real testing library (override global setup mock)
 vi.mock('@testing-library/svelte', async () => await vi.importActual('@testing-library/svelte'));
@@ -45,15 +45,6 @@ const makeProps = (overrides = {}) => ({
 describe('UploadedAssetFiles', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-	});
-
-	afterEach(() => {
-		// Restore window.electron to undefined to prevent state leakage between tests
-		Object.defineProperty(window, 'electron', {
-			value: undefined,
-			writable: true,
-			configurable: true
-		});
 	});
 
 	it('renders without crashing when no simfileId provided', () => {
@@ -271,49 +262,7 @@ describe('UploadedAssetFiles', () => {
 		});
 	});
 
-	it('calls uploadSelectedFiles when bulk upload button clicked (desktop, IPC success)', async () => {
-		const ipcInvoke = vi.fn().mockResolvedValue({ success: true });
-		// Set electron on the existing window object (don't replace the whole window)
-		Object.defineProperty(window, 'electron', {
-			value: { ipcRenderer: { invoke: ipcInvoke } },
-			writable: true,
-			configurable: true
-		});
-
-		const dtxFile = new File(['content'], 'song.dtx', { type: 'text/plain' });
-		const loadAssetFiles = vi.fn().mockResolvedValue([]);
-		render(UploadedAssetFiles, {
-			props: makeProps({
-				simfileId: 'sim-1',
-				isDesktop: true,
-				songFolderPath: '/songs/sim-1',
-				userFiles: [dtxFile],
-				loadAssetFiles
-			})
-		});
-
-		await waitFor(() => {
-			expect(screen.getByRole('button', { name: /Bulk Upload/i })).toBeInTheDocument();
-		});
-
-		await fireEvent.click(screen.getByRole('button', { name: /Bulk Upload/i }));
-
-		await waitFor(() => {
-			expect(ipcInvoke).toHaveBeenCalledWith(
-				'upload-file',
-				'song.dtx',
-				'/songs/sim-1',
-				'sim-1'
-			);
-		});
-	});
-
-	it('uses injected uploadFile handler for desktop bulk uploads when Electron IPC is unavailable', async () => {
-		Object.defineProperty(window, 'electron', {
-			value: undefined,
-			writable: true,
-			configurable: true
-		});
+	it('calls the injected uploadFile handler for desktop bulk uploads', async () => {
 		const uploadFile = vi.fn().mockResolvedValue({ success: true });
 
 		const dtxFile = new File(['content'], 'song.dtx', { type: 'text/plain' });
@@ -341,13 +290,8 @@ describe('UploadedAssetFiles', () => {
 		});
 	});
 
-	it('shows "Failed" status when IPC upload returns an error', async () => {
-		const ipcInvoke = vi.fn().mockResolvedValue({ success: false, error: 'Upload failed' });
-		Object.defineProperty(window, 'electron', {
-			value: { ipcRenderer: { invoke: ipcInvoke } },
-			writable: true,
-			configurable: true
-		});
+	it('shows "Failed" status when the uploadFile handler returns an error', async () => {
+		const uploadFile = vi.fn().mockResolvedValue({ success: false, error: 'Upload failed' });
 
 		const dtxFile = new File(['content'], 'song.dtx', { type: 'text/plain' });
 		const loadAssetFiles = vi.fn().mockResolvedValue([]);
@@ -357,7 +301,8 @@ describe('UploadedAssetFiles', () => {
 				isDesktop: true,
 				songFolderPath: '/songs/sim-1',
 				userFiles: [dtxFile],
-				loadAssetFiles
+				loadAssetFiles,
+				uploadFile
 			})
 		});
 
@@ -369,14 +314,7 @@ describe('UploadedAssetFiles', () => {
 		});
 	});
 
-	it('shows "Failed" status when IPC renderer is not available (invokeIpc throws)', async () => {
-		// Ensure window.electron is undefined → invokeIpc throws "IPC Renderer is not available"
-		Object.defineProperty(window, 'electron', {
-			value: undefined,
-			writable: true,
-			configurable: true
-		});
-
+	it('shows "Failed" status when no uploadFile handler is provided', async () => {
 		const dtxFile = new File(['content'], 'song.dtx', { type: 'text/plain' });
 		const loadAssetFiles = vi.fn().mockResolvedValue([]);
 		render(UploadedAssetFiles, {

--- a/packages/common/src/lib/services/fileProvider.ts
+++ b/packages/common/src/lib/services/fileProvider.ts
@@ -3,7 +3,7 @@
  *
  * This interface abstracts file operations to support different implementations:
  * - dtx-web: Files stored in browser memory via FileManager
- * - dtx-desktop: Files cached in Electron main process, accessed via IPC
+ * - dtx-desktop: Files cached in the Tauri Rust backend, accessed via IPC commands
  */
 
 export interface IFileProvider {


### PR DESCRIPTION
## Summary
- Add `main` to the desktop release trigger so every merge builds signed updater artifacts and deploys them to R2.
- Rework version selection in `desktop-build-deploy.yml` to read the committed `tauri.conf.json` version when no tag or `workflow_dispatch` input is provided.
- Remove the obsolete Electron IPC fallback from `UploadedAssetFiles` and require the `uploadFile` prop for desktop uploads.
- Clean up `UploadedAssetFiles` tests and `fileProvider` to match the Tauri model.

#### Test plan
- [ ] `bun run --filter=dtx-desktop test`
- [ ] `bun run --filter=@dtx/common test`
- [ ] `bun run lint`
- [ ] `bun run --filter=dtx-desktop typecheck`
- [ ] Verify the `desktop-build-deploy.yml` workflow succeeds after merging to `main`.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Main branch now supports continuous release deployment for desktop applications, automatically versioning builds from configuration files.

* **Refactoring**
  * File upload component refactored to require explicit upload handler configuration for desktop uploads. Simplified internal upload logic by removing fallback mechanisms.

* **Documentation**
  * Updated file provider service documentation to accurately reflect current backend implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->