### PR TITLE
feat(web): Google account linking and login flow

### DIFF
--- a/docs/superpowers/specs/2026-07-02-google-auth-linking-design.md
+++ b/docs/superpowers/specs/2026-07-02-google-auth-linking-design.md
@@ -1,0 +1,127 @@
+# Google Auth and Account Linking Design
+
+## Goal
+
+Add Google authentication to Drumery without opening public signup.
+
+Existing password users must be able to connect a Google account, including a Google account whose email address differs from the existing Drumery account email. The linked account must preserve the existing Supabase user id so existing Drumery data keyed by `simfiles.user_id` and `user_profiles.user_id` remains attached.
+
+## Current Context
+
+Drumery already uses Supabase Auth across the web, desktop, and API surfaces:
+
+- `packages/dtx-web` uses `@supabase/ssr` in `hooks.server.ts` and the root layout to manage Supabase cookie sessions.
+- `/login` currently supports only email/password through `supabase.auth.signInWithPassword`.
+- `packages/dtx-desktop` opens the web login URL and receives a Supabase magic-link handoff through the existing `dtx://auth-callback` or local callback bridge.
+- `packages/dtx-api` does not own identity state. It validates Supabase bearer tokens and uses the resulting Supabase user id for authorization.
+- D1 ownership is keyed directly by Supabase user id, so creating a second Supabase user for an existing person would orphan their existing content from the new login.
+
+Supabase manual identity linking is the intended mechanism for connecting a different-email Google identity to an already signed-in user. This requires manual linking to be enabled in Supabase Auth configuration.
+
+## Chosen Approach
+
+Use Supabase-native Google OAuth plus Supabase manual identity linking.
+
+This keeps Supabase as the sole auth authority, preserves the existing Drumery API token model, and avoids a separate Drumery-owned OAuth/user-linking table. Google sign-in and Google account linking are separate flows:
+
+- Logged-out users use Google sign-in only for accounts that already have a linked Google identity.
+- Logged-in password users use an account page to connect Google to their current Supabase user.
+
+## Deployment Prerequisites
+
+The Supabase project must be configured before release:
+
+- Google OAuth provider enabled with the correct production and local redirect URLs.
+- New user signup disabled. Users can still be created by existing admin/invite/manual processes, but Google must not create public self-service accounts.
+- Manual identity linking enabled so signed-in users can link OAuth identities whose email differs from their current account email.
+- The web app OAuth callback URL registered in Supabase and Google OAuth configuration.
+
+The app should treat missing manual linking support as a configuration error. It must not silently fall back to creating users or changing D1 ownership.
+
+## Web Login Flow
+
+`/login` keeps the existing email/password form and adds a Google option.
+
+The Google button starts Supabase OAuth with `provider: 'google'` and a redirect back to the Drumery-owned `/auth/callback` route. The callback exchanges the OAuth code with Supabase using the existing SSR client so Supabase session cookies are written normally.
+
+Successful callback redirects:
+
+- Standard web login: `/app`
+- Desktop login: `/app?redirect=desktop`
+
+Failed callback redirects back to `/login` with a sanitized, user-facing error. For unknown Google users rejected by the signup-disabled Supabase configuration, the message should say that Google sign-in is available only for existing linked accounts.
+
+The login page must not include signup copy, signup links, or a "create account with Google" path.
+
+## Account Linking Flow
+
+Add a protected account/profile destination under the authenticated web app.
+
+The account page should show:
+
+- Current account email.
+- Linked providers, including whether Google is connected.
+- A "Connect Google" action when Google is not linked.
+
+The connect action uses `supabase.auth.linkIdentity({ provider: 'google', options: { redirectTo } })` from an authenticated session. Because the user is already signed in, Supabase links the selected Google identity to the current Supabase user id, even when the Google email is different.
+
+After the OAuth return, the page reloads identities and shows Google as connected. The page should surface these error cases:
+
+- Manual linking disabled: configuration error.
+- Google identity already linked to another Supabase user: conflict message.
+- OAuth cancelled or failed: non-destructive retry message.
+
+No D1 migration or ownership rewrite should happen as part of account linking.
+
+## Desktop Flow
+
+Desktop keeps the current web-mediated login path.
+
+The desktop renderer opens `/login?redirect=desktop`. The user may authenticate with password or, after linking, with Google. Once the web app has a Supabase session, `/app?redirect=desktop` continues to generate the existing magic link and redirects to the configured desktop callback URL with `magic_link=...`.
+
+The Tauri Rust callback parser and magic-link verification path should remain unchanged unless implementation testing proves the Google session has a different shape. The expected result is the same Supabase session payload and user object.
+
+## API Boundary
+
+`dtx-api` should remain bearer-token based. It should not add OAuth provider logic, duplicate user identity tables, or provider-specific authorization paths.
+
+API changes are only in scope if the web account UI needs server-owned metadata that cannot be obtained from Supabase Auth client APIs. The initial design assumes the web client can read linked identities directly from Supabase.
+
+## Security Guardrails
+
+- Do not call `supabase.auth.signUp`.
+- Do not add a public signup route.
+- Do not describe Google as account creation.
+- Do not allow anonymous users to link identities.
+- Do not create or migrate D1 ownership rows during auth.
+- Do not expose raw OAuth errors, provider tokens, magic links, or token hashes in UI or logs.
+- Treat Supabase signup-disabled behavior as the primary no-open-signup enforcement, with app messaging layered on top.
+
+## Testing Plan
+
+Targeted tests should cover:
+
+- `/login` renders password and Google sign-in options without signup copy.
+- Google login initiation passes the expected provider and redirect target.
+- OAuth callback exchanges `code`, redirects to `/app`, and preserves desktop redirects.
+- OAuth callback errors return to `/login` with a sanitized message.
+- Account page shows linked provider state.
+- Connect Google calls `linkIdentity`, not `signInWithOAuth`.
+- Manual-linking-disabled and provider-conflict errors render clear messages.
+
+Verification commands:
+
+- `bun run --filter=dtx-web test -- <relevant test files>`
+- `bun run --filter=dtx-web check`
+- `bun run --filter=dtx-desktop test -- authService.test.ts` only if desktop login URL or redirect behavior changes.
+
+Per repository guidance, do not run broad development servers or full builds unless explicitly requested.
+
+## Out Of Scope
+
+- Opening public signup.
+- Replacing password login.
+- Reworking desktop auth callbacks.
+- Changing `dtx-api` token verification.
+- D1 ownership migration.
+- Admin invite/user-creation tooling.

--- a/packages/dtx-web/src/lib/auth/google.test.ts
+++ b/packages/dtx-web/src/lib/auth/google.test.ts
@@ -41,6 +41,17 @@ describe('google auth helpers', () => {
 		expect(safeAppRedirectPath('/app/chart')).toBe('/app/chart');
 	});
 
+	it('normalizes ../ traversal that would escape the /app prefix', () => {
+		expect(safeAppRedirectPath('/app/../etc')).toBe('/app/account');
+		expect(safeAppRedirectPath('/app/account/../../etc')).toBe('/app/account');
+		expect(safeAppRedirectPath('/app/foo/../chart')).toBe('/app/chart');
+	});
+
+	it('preserves query strings on safe /app paths', () => {
+		expect(safeAppRedirectPath('/app/account?tab=security')).toBe('/app/account?tab=security');
+		expect(safeAppRedirectPath('/app?redirect=desktop')).toBe('/app?redirect=desktop');
+	});
+
 	it('builds login error redirects while preserving desktop intent', () => {
 		expect(buildLoginErrorRedirect('Sign-in failed')).toBe('/login?error=Sign-in+failed');
 		expect(buildLoginErrorRedirect('Sign-in failed', 'desktop')).toBe(
@@ -79,6 +90,16 @@ describe('google auth helpers', () => {
 		expect(sanitizeGoogleAuthError('identity already linked to another user')).toBe(
 			GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE
 		);
+	});
+
+	it('maps cancelled/canceled/denied OAuth errors to the generic retry message', () => {
+		expect(sanitizeGoogleAuthError('User cancelled the OAuth flow')).toBe(
+			GOOGLE_AUTH_GENERIC_MESSAGE
+		);
+		expect(sanitizeGoogleAuthError('The user canceled sign-in')).toBe(
+			GOOGLE_AUTH_GENERIC_MESSAGE
+		);
+		expect(sanitizeGoogleAuthError('access_denied')).toBe(GOOGLE_AUTH_GENERIC_MESSAGE);
 	});
 
 	it('uses a generic sanitized message for unknown errors', () => {

--- a/packages/dtx-web/src/lib/auth/google.test.ts
+++ b/packages/dtx-web/src/lib/auth/google.test.ts
@@ -35,6 +35,8 @@ describe('google auth helpers', () => {
 		expect(safeAppRedirectPath('https://evil.example')).toBe('/app/account');
 		expect(safeAppRedirectPath('//evil.example')).toBe('/app/account');
 		expect(safeAppRedirectPath('/login')).toBe('/app/account');
+		expect(safeAppRedirectPath('/application')).toBe('/app/account');
+		expect(safeAppRedirectPath('/app.evil')).toBe('/app/account');
 		expect(safeAppRedirectPath('/app/chart')).toBe('/app/chart');
 	});
 

--- a/packages/dtx-web/src/lib/auth/google.test.ts
+++ b/packages/dtx-web/src/lib/auth/google.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	GOOGLE_AUTH_GENERIC_MESSAGE,
 	GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
 	GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE,
 	GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
@@ -81,8 +82,6 @@ describe('google auth helpers', () => {
 	});
 
 	it('uses a generic sanitized message for unknown errors', () => {
-		expect(sanitizeGoogleAuthError('raw provider token abc')).toBe(
-			GOOGLE_AUTH_UNAVAILABLE_MESSAGE
-		);
+		expect(sanitizeGoogleAuthError('raw provider token abc')).toBe(GOOGLE_AUTH_GENERIC_MESSAGE);
 	});
 });

--- a/packages/dtx-web/src/lib/auth/google.test.ts
+++ b/packages/dtx-web/src/lib/auth/google.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+	GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
+	GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE,
+	GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
+	appendSearchParam,
+	buildAccountCallbackUrl,
+	buildAuthCallbackUrl,
+	buildLoginErrorRedirect,
+	buildLinkedAccountRedirect,
+	safeAppRedirectPath,
+	sanitizeGoogleAuthError
+} from './google';
+
+describe('google auth helpers', () => {
+	it('builds a standard auth callback URL', () => {
+		expect(buildAuthCallbackUrl('https://dtx.example')).toBe(
+			'https://dtx.example/auth/callback'
+		);
+	});
+
+	it('builds a desktop auth callback URL', () => {
+		expect(buildAuthCallbackUrl('https://dtx.example/', 'desktop')).toBe(
+			'https://dtx.example/auth/callback?redirect=desktop'
+		);
+	});
+
+	it('builds an account-linking callback URL', () => {
+		expect(buildAccountCallbackUrl('https://dtx.example')).toBe(
+			'https://dtx.example/auth/callback?link=google&next=%2Fapp%2Faccount'
+		);
+	});
+
+	it('rejects open redirects outside the app', () => {
+		expect(safeAppRedirectPath('https://evil.example')).toBe('/app/account');
+		expect(safeAppRedirectPath('//evil.example')).toBe('/app/account');
+		expect(safeAppRedirectPath('/login')).toBe('/app/account');
+		expect(safeAppRedirectPath('/app/chart')).toBe('/app/chart');
+	});
+
+	it('builds login error redirects while preserving desktop intent', () => {
+		expect(buildLoginErrorRedirect('Sign-in failed')).toBe('/login?error=Sign-in+failed');
+		expect(buildLoginErrorRedirect('Sign-in failed', 'desktop')).toBe(
+			'/login?redirect=desktop&error=Sign-in+failed'
+		);
+	});
+
+	it('builds linked account redirects with success and error messages', () => {
+		expect(buildLinkedAccountRedirect('/app/account', 'connected')).toBe(
+			'/app/account?linked=google'
+		);
+		expect(buildLinkedAccountRedirect('/app/account', 'error', 'Denied')).toBe(
+			'/app/account?auth_error=Denied'
+		);
+	});
+
+	it('appends search params to paths with existing params', () => {
+		expect(appendSearchParam('/app/account?tab=security', 'linked', 'google')).toBe(
+			'/app/account?tab=security&linked=google'
+		);
+	});
+
+	it('sanitizes signup-disabled style errors for login', () => {
+		expect(sanitizeGoogleAuthError('Signups not allowed for this instance')).toBe(
+			GOOGLE_AUTH_UNAVAILABLE_MESSAGE
+		);
+	});
+
+	it('sanitizes manual-linking-disabled errors for account linking', () => {
+		expect(sanitizeGoogleAuthError('manual_linking_disabled')).toBe(
+			GOOGLE_AUTH_LINKING_CONFIG_MESSAGE
+		);
+	});
+
+	it('sanitizes provider conflict errors for account linking', () => {
+		expect(sanitizeGoogleAuthError('identity already linked to another user')).toBe(
+			GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE
+		);
+	});
+
+	it('uses a generic sanitized message for unknown errors', () => {
+		expect(sanitizeGoogleAuthError('raw provider token abc')).toBe(
+			GOOGLE_AUTH_UNAVAILABLE_MESSAGE
+		);
+	});
+});

--- a/packages/dtx-web/src/lib/auth/google.ts
+++ b/packages/dtx-web/src/lib/auth/google.ts
@@ -1,0 +1,100 @@
+export const GOOGLE_PROVIDER = 'google' as const;
+export const GOOGLE_OAUTH_SCOPES = 'openid email profile';
+
+export const GOOGLE_AUTH_UNAVAILABLE_MESSAGE =
+	'Google sign-in is only available for existing linked accounts.';
+export const GOOGLE_AUTH_GENERIC_MESSAGE = 'Google authentication failed. Please try again.';
+export const GOOGLE_AUTH_LINKING_CONFIG_MESSAGE =
+	'Google account linking is not enabled for this Drumery environment.';
+export const GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE =
+	'That Google account is already connected to another Drumery account.';
+
+export type GoogleRedirectIntent = 'web' | 'desktop';
+
+export const buildAuthCallbackUrl = (
+	origin: string,
+	intent: GoogleRedirectIntent = 'web'
+): string => {
+	const callbackUrl = new URL('/auth/callback', origin);
+	if (intent === 'desktop') {
+		callbackUrl.searchParams.set('redirect', 'desktop');
+	}
+	return callbackUrl.toString();
+};
+
+export const buildAccountCallbackUrl = (origin: string): string => {
+	const callbackUrl = new URL('/auth/callback', origin);
+	callbackUrl.searchParams.set('link', GOOGLE_PROVIDER);
+	callbackUrl.searchParams.set('next', '/app/account');
+	return callbackUrl.toString();
+};
+
+export const safeAppRedirectPath = (value: string | null | undefined): string => {
+	if (!value || value.startsWith('//')) return '/app/account';
+	if (!value.startsWith('/app')) return '/app/account';
+	return value;
+};
+
+export const appendSearchParam = (path: string, key: string, value: string): string => {
+	const [pathname, search = ''] = path.split('?');
+	const params = new URLSearchParams(search);
+	params.set(key, value);
+	const query = params.toString();
+	return query ? `${pathname}?${query}` : pathname;
+};
+
+export const buildLoginErrorRedirect = (
+	message: string,
+	intent: GoogleRedirectIntent = 'web'
+): string => {
+	const params = new URLSearchParams();
+	if (intent === 'desktop') {
+		params.set('redirect', 'desktop');
+	}
+	params.set('error', message);
+	return `/login?${params.toString()}`;
+};
+
+export const buildLinkedAccountRedirect = (
+	nextPath: string,
+	result: 'connected' | 'error',
+	message?: string
+): string => {
+	const safeNext = safeAppRedirectPath(nextPath);
+	if (result === 'connected') {
+		return appendSearchParam(safeNext, 'linked', GOOGLE_PROVIDER);
+	}
+	return appendSearchParam(safeNext, 'auth_error', message || GOOGLE_AUTH_GENERIC_MESSAGE);
+};
+
+export const sanitizeGoogleAuthError = (message: string | null | undefined): string => {
+	const lower = (message ?? '').toLowerCase();
+
+	if (
+		lower.includes('signup') ||
+		lower.includes('sign up') ||
+		lower.includes('user not allowed') ||
+		lower.includes('not allowed')
+	) {
+		return GOOGLE_AUTH_UNAVAILABLE_MESSAGE;
+	}
+
+	if (lower.includes('manual_linking_disabled') || lower.includes('manual linking')) {
+		return GOOGLE_AUTH_LINKING_CONFIG_MESSAGE;
+	}
+
+	if (
+		lower.includes('already linked') ||
+		lower.includes('already connected') ||
+		lower.includes('identity is already linked') ||
+		lower.includes('identity already linked')
+	) {
+		return GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE;
+	}
+
+	if (lower.includes('cancelled') || lower.includes('canceled') || lower.includes('denied')) {
+		return GOOGLE_AUTH_GENERIC_MESSAGE;
+	}
+
+	return GOOGLE_AUTH_UNAVAILABLE_MESSAGE;
+};

--- a/packages/dtx-web/src/lib/auth/google.ts
+++ b/packages/dtx-web/src/lib/auth/google.ts
@@ -96,5 +96,5 @@ export const sanitizeGoogleAuthError = (message: string | null | undefined): str
 		return GOOGLE_AUTH_GENERIC_MESSAGE;
 	}
 
-	return GOOGLE_AUTH_UNAVAILABLE_MESSAGE;
+	return GOOGLE_AUTH_GENERIC_MESSAGE;
 };

--- a/packages/dtx-web/src/lib/auth/google.ts
+++ b/packages/dtx-web/src/lib/auth/google.ts
@@ -9,11 +9,6 @@ export const GOOGLE_AUTH_LINKING_CONFIG_MESSAGE =
 export const GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE =
 	'That Google account is already connected to another Drumery account.';
 
-/**
- * Allow-list of trusted, server-sanitized Google auth error messages that may
- * be rendered from a query param. Any other value is discarded to prevent
- * attacker-crafted URLs from phishing/misleading users.
- */
 export const GOOGLE_AUTH_ERROR_MESSAGES = [
 	GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
 	GOOGLE_AUTH_GENERIC_MESSAGE,
@@ -43,8 +38,16 @@ export const buildAccountCallbackUrl = (origin: string): string => {
 
 export const safeAppRedirectPath = (value: string | null | undefined): string => {
 	if (!value || value.startsWith('//')) return '/app/account';
-	if (value !== '/app' && !value.startsWith('/app/')) return '/app/account';
-	return value;
+	let resolved: URL;
+	try {
+		resolved = new URL(value, 'http://local.invalid');
+	} catch {
+		return '/app/account';
+	}
+	if (resolved.pathname !== '/app' && !resolved.pathname.startsWith('/app/')) {
+		return '/app/account';
+	}
+	return `${resolved.pathname}${resolved.search}`;
 };
 
 export const appendSearchParam = (path: string, key: string, value: string): string => {

--- a/packages/dtx-web/src/lib/auth/google.ts
+++ b/packages/dtx-web/src/lib/auth/google.ts
@@ -31,7 +31,7 @@ export const buildAccountCallbackUrl = (origin: string): string => {
 
 export const safeAppRedirectPath = (value: string | null | undefined): string => {
 	if (!value || value.startsWith('//')) return '/app/account';
-	if (!value.startsWith('/app')) return '/app/account';
+	if (value !== '/app' && !value.startsWith('/app/')) return '/app/account';
 	return value;
 };
 

--- a/packages/dtx-web/src/lib/auth/google.ts
+++ b/packages/dtx-web/src/lib/auth/google.ts
@@ -9,6 +9,18 @@ export const GOOGLE_AUTH_LINKING_CONFIG_MESSAGE =
 export const GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE =
 	'That Google account is already connected to another Drumery account.';
 
+/**
+ * Allow-list of trusted, server-sanitized Google auth error messages that may
+ * be rendered from a query param. Any other value is discarded to prevent
+ * attacker-crafted URLs from phishing/misleading users.
+ */
+export const GOOGLE_AUTH_ERROR_MESSAGES = [
+	GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
+	GOOGLE_AUTH_GENERIC_MESSAGE,
+	GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
+	GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE
+] as const;
+
 export type GoogleRedirectIntent = 'web' | 'desktop';
 
 export const buildAuthCallbackUrl = (
@@ -73,8 +85,7 @@ export const sanitizeGoogleAuthError = (message: string | null | undefined): str
 	if (
 		lower.includes('signup') ||
 		lower.includes('sign up') ||
-		lower.includes('user not allowed') ||
-		lower.includes('not allowed')
+		lower.includes('user not allowed')
 	) {
 		return GOOGLE_AUTH_UNAVAILABLE_MESSAGE;
 	}

--- a/packages/dtx-web/src/routes/(app)/+layout.svelte
+++ b/packages/dtx-web/src/routes/(app)/+layout.svelte
@@ -16,8 +16,7 @@
 	};
 
 	const navigateToProfile = () => {
-		console.log('Profile clicked');
-		// Navigate to profile page
+		goto('/app/account');
 	};
 </script>
 

--- a/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
@@ -49,22 +49,30 @@
 		error = '';
 		message = '';
 
-		const { data: linkData, error: linkError } = await supabase.auth.linkIdentity({
-			provider: 'google',
-			options: {
-				redirectTo: buildAccountCallbackUrl(window.location.origin),
-				scopes: GOOGLE_OAUTH_SCOPES,
-				skipBrowserRedirect: true
+		try {
+			const { data: linkData, error: linkError } = await supabase.auth.linkIdentity({
+				provider: 'google',
+				options: {
+					redirectTo: buildAccountCallbackUrl(window.location.origin),
+					scopes: GOOGLE_OAUTH_SCOPES,
+					skipBrowserRedirect: true
+				}
+			});
+
+			if (linkError || !linkData?.url) {
+				error = sanitizeGoogleAuthError(linkError?.message);
+				return;
 			}
-		});
 
-		if (linkError || !linkData?.url) {
-			error = sanitizeGoogleAuthError(linkError?.message);
+			window.location.href = linkData.url;
+		} catch (caughtError) {
+			console.error('Google link identity failed:', caughtError);
+			error = sanitizeGoogleAuthError(
+				caughtError instanceof Error ? caughtError.message : undefined
+			);
+		} finally {
 			isConnecting = false;
-			return;
 		}
-
-		window.location.href = linkData.url;
 	};
 
 	onMount(() => {

--- a/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
@@ -31,17 +31,23 @@
 
 	const loadIdentities = async () => {
 		isLoading = true;
-		const { data: identityData, error: identityError } =
-			await supabase.auth.getUserIdentities();
+		try {
+			const { data: identityData, error: identityError } =
+				await supabase.auth.getUserIdentities();
 
-		if (identityError) {
+			if (identityError) {
+				error = 'Unable to load linked account providers.';
+				identities = [];
+			} else {
+				identities = identityData?.identities ?? [];
+			}
+		} catch (caughtError) {
+			console.error('Failed to load account identities:', caughtError);
 			error = 'Unable to load linked account providers.';
 			identities = [];
-		} else {
-			identities = identityData?.identities ?? [];
+		} finally {
+			isLoading = false;
 		}
-
-		isLoading = false;
 	};
 
 	const handleConnectGoogle = async () => {

--- a/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
@@ -2,22 +2,19 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { replaceState } from '$app/navigation';
+	import type { UserIdentity } from '@supabase/supabase-js';
 	import { AlertCircle, CheckCircle2, Loader } from '@lucide/svelte';
 	import {
+		GOOGLE_AUTH_ERROR_MESSAGES,
 		GOOGLE_OAUTH_SCOPES,
 		buildAccountCallbackUrl,
 		sanitizeGoogleAuthError
 	} from '$lib/auth/google';
 
-	type LinkedIdentity = {
-		provider: string;
-		identity_data?: { email?: unknown } | null;
-	};
-
 	let { data } = $props();
 	let { supabase, user } = $derived(data);
 
-	let identities = $state<LinkedIdentity[]>([]);
+	let identities = $state<UserIdentity[]>([]);
 	let isLoading = $state(true);
 	let isConnecting = $state(false);
 	let error = $state('');
@@ -75,9 +72,11 @@
 		if (params.get('linked') === 'google') {
 			message = 'Google account connected.';
 		} else {
+			// Only display trusted, allow-listed messages from the auth_error
+			// query param; discard attacker-crafted values.
 			const callbackError = params.get('auth_error');
 			if (callbackError) {
-				error = callbackError;
+				error = GOOGLE_AUTH_ERROR_MESSAGES.find((m) => m === callbackError) || '';
 			}
 		}
 

--- a/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { replaceState } from '$app/navigation';
 	import { AlertCircle, CheckCircle2, Loader } from '@lucide/svelte';
 	import {
 		GOOGLE_OAUTH_SCOPES,
@@ -70,13 +71,22 @@
 	};
 
 	onMount(() => {
-		if ($page.url.searchParams.get('linked') === 'google') {
+		const params = $page.url.searchParams;
+		if (params.get('linked') === 'google') {
 			message = 'Google account connected.';
 		} else {
-			const callbackError = $page.url.searchParams.get('auth_error');
+			const callbackError = params.get('auth_error');
 			if (callbackError) {
 				error = callbackError;
 			}
+		}
+
+		// Clear callback params so the banner does not persist on refresh.
+		if (params.has('linked') || params.has('auth_error')) {
+			const cleanUrl = new URL($page.url);
+			cleanUrl.searchParams.delete('linked');
+			cleanUrl.searchParams.delete('auth_error');
+			replaceState(cleanUrl, {});
 		}
 
 		loadIdentities();
@@ -89,6 +99,7 @@
 	{#if message}
 		<div
 			class="mb-4 rounded-lg border border-emerald-400/30 bg-emerald-950/30 p-4 text-emerald-100"
+			role="status"
 		>
 			<div class="flex items-center gap-2">
 				<CheckCircle2 size={18} />
@@ -98,7 +109,10 @@
 	{/if}
 
 	{#if error}
-		<div class="mb-4 rounded-lg border border-red-400/30 bg-red-950/30 p-4 text-red-100">
+		<div
+			class="mb-4 rounded-lg border border-red-400/30 bg-red-950/30 p-4 text-red-100"
+			role="alert"
+		>
 			<div class="flex items-center gap-2">
 				<AlertCircle size={18} />
 				<p>{error}</p>
@@ -141,7 +155,7 @@
 								type="button"
 								onclick={handleConnectGoogle}
 								disabled={isConnecting}
-								class="rounded-md bg-cyan-600 px-4 py-2 font-medium text-white hover:bg-cyan-500 focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950 focus:outline-none disabled:opacity-50"
+								class="connect-google-btn"
 							>
 								{isConnecting ? 'Connecting...' : 'Connect Google'}
 							</button>
@@ -152,3 +166,11 @@
 		</div>
 	</div>
 </section>
+
+<style>
+	@reference 'tailwindcss';
+
+	.connect-google-btn {
+		@apply rounded-md bg-cyan-600 px-4 py-2 font-medium text-white hover:bg-cyan-500 focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950 focus:outline-none disabled:opacity-50;
+	}
+</style>

--- a/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
@@ -33,7 +33,6 @@
 
 	const loadIdentities = async () => {
 		isLoading = true;
-		error = '';
 		const { data: identityData, error: identityError } =
 			await supabase.auth.getUserIdentities();
 

--- a/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/account/+page.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { AlertCircle, CheckCircle2, Loader } from '@lucide/svelte';
+	import {
+		GOOGLE_OAUTH_SCOPES,
+		buildAccountCallbackUrl,
+		sanitizeGoogleAuthError
+	} from '$lib/auth/google';
+
+	type LinkedIdentity = {
+		provider: string;
+		identity_data?: { email?: unknown } | null;
+	};
+
+	let { data } = $props();
+	let { supabase, user } = $derived(data);
+
+	let identities = $state<LinkedIdentity[]>([]);
+	let isLoading = $state(true);
+	let isConnecting = $state(false);
+	let error = $state('');
+	let message = $state('');
+
+	let googleIdentity = $derived(
+		identities.find((identity) => identity.provider === 'google') ?? null
+	);
+	let googleEmail = $derived(
+		(typeof googleIdentity?.identity_data?.email === 'string'
+			? googleIdentity.identity_data.email
+			: null) ?? ''
+	);
+
+	const loadIdentities = async () => {
+		isLoading = true;
+		error = '';
+		const { data: identityData, error: identityError } =
+			await supabase.auth.getUserIdentities();
+
+		if (identityError) {
+			error = 'Unable to load linked account providers.';
+			identities = [];
+		} else {
+			identities = identityData?.identities ?? [];
+		}
+
+		isLoading = false;
+	};
+
+	const handleConnectGoogle = async () => {
+		isConnecting = true;
+		error = '';
+		message = '';
+
+		const { data: linkData, error: linkError } = await supabase.auth.linkIdentity({
+			provider: 'google',
+			options: {
+				redirectTo: buildAccountCallbackUrl(window.location.origin),
+				scopes: GOOGLE_OAUTH_SCOPES,
+				skipBrowserRedirect: true
+			}
+		});
+
+		if (linkError || !linkData?.url) {
+			error = sanitizeGoogleAuthError(linkError?.message);
+			isConnecting = false;
+			return;
+		}
+
+		window.location.href = linkData.url;
+	};
+
+	onMount(() => {
+		if ($page.url.searchParams.get('linked') === 'google') {
+			message = 'Google account connected.';
+		} else {
+			const callbackError = $page.url.searchParams.get('auth_error');
+			if (callbackError) {
+				error = callbackError;
+			}
+		}
+
+		loadIdentities();
+	});
+</script>
+
+<section class="container mx-auto max-w-3xl p-6 text-white">
+	<h1 class="mb-6 text-3xl font-bold">Account</h1>
+
+	{#if message}
+		<div
+			class="mb-4 rounded-lg border border-emerald-400/30 bg-emerald-950/30 p-4 text-emerald-100"
+		>
+			<div class="flex items-center gap-2">
+				<CheckCircle2 size={18} />
+				<p>{message}</p>
+			</div>
+		</div>
+	{/if}
+
+	{#if error}
+		<div class="mb-4 rounded-lg border border-red-400/30 bg-red-950/30 p-4 text-red-100">
+			<div class="flex items-center gap-2">
+				<AlertCircle size={18} />
+				<p>{error}</p>
+			</div>
+		</div>
+	{/if}
+
+	<div class="rounded-lg border border-purple-500/20 bg-slate-950/60 p-6">
+		<div class="mb-6">
+			<h2 class="mb-2 text-xl font-semibold">Profile</h2>
+			<p class="text-sm text-slate-400">Primary account email</p>
+			<p class="mt-1 text-slate-100">{user?.email ?? 'Unknown email'}</p>
+		</div>
+
+		<div>
+			<h2 class="mb-4 text-xl font-semibold">Connected providers</h2>
+
+			{#if isLoading}
+				<div class="flex items-center gap-3 text-slate-300">
+					<Loader size={18} class="animate-spin" />
+					<span>Loading providers...</span>
+				</div>
+			{:else}
+				<div class="rounded-md border border-slate-700 bg-slate-900/80 p-4">
+					<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<div>
+							<p class="font-medium">Google</p>
+							{#if googleIdentity}
+								<p class="text-sm text-emerald-300">Google is connected</p>
+								{#if googleEmail}
+									<p class="mt-1 text-sm text-slate-400">{googleEmail}</p>
+								{/if}
+							{:else}
+								<p class="text-sm text-slate-400">Google is not connected</p>
+							{/if}
+						</div>
+
+						{#if !googleIdentity}
+							<button
+								type="button"
+								onclick={handleConnectGoogle}
+								disabled={isConnecting}
+								class="rounded-md bg-cyan-600 px-4 py-2 font-medium text-white hover:bg-cyan-500 focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950 focus:outline-none disabled:opacity-50"
+							>
+								{isConnecting ? 'Connecting...' : 'Connect Google'}
+							</button>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+</section>

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -139,6 +139,23 @@ describe('/app/account page', () => {
 		});
 	});
 
+	it('surfaces error and resets loading when linkIdentity rejects', async () => {
+		const { data, mockSupabase } = makeData();
+		mockSupabase.auth.linkIdentity.mockRejectedValueOnce(new Error('network failure'));
+
+		render(AccountPage, { props: { data } });
+
+		const button = await screen.findByRole('button', { name: 'Connect Google' });
+		await fireEvent.click(button);
+
+		await vi.waitFor(() => {
+			expect(
+				screen.getByText('Google authentication failed. Please try again.')
+			).toBeInTheDocument();
+			expect(button).not.toBeDisabled();
+		});
+	});
+
 	it('shows callback success and error messages from query params', async () => {
 		pageMock.url = new URL('http://localhost/app/account?linked=google&auth_error=ignored');
 		const { data } = makeData();

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -145,4 +145,20 @@ describe('/app/account page', () => {
 			expect(screen.getByText('Google account connected.')).toBeInTheDocument();
 		});
 	});
+
+	it('keeps callback error visible after providers load', async () => {
+		pageMock.url = new URL(
+			'http://localhost/app/account?auth_error=Google+authentication+failed.+Please+try+again.'
+		);
+		const { data } = makeData();
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(screen.getByText('Google is not connected')).toBeInTheDocument();
+		});
+		expect(
+			screen.getByText('Google authentication failed. Please try again.')
+		).toBeInTheDocument();
+	});
 });

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -214,4 +214,20 @@ describe('/app/account page', () => {
 		expect(screen.getByText('Google is not connected')).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Connect Google' })).toBeInTheDocument();
 	});
+
+	it('surfaces error and resets loading when getUserIdentities rejects', async () => {
+		const { data, mockSupabase } = makeData();
+		mockSupabase.auth.getUserIdentities.mockRejectedValueOnce(new Error('network failure'));
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(
+				screen.getByText('Unable to load linked account providers.')
+			).toBeInTheDocument();
+		});
+		expect(screen.getByText('Google is not connected')).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Connect Google' })).toBeInTheDocument();
+		expect(screen.queryByText('Loading providers...')).not.toBeInTheDocument();
+	});
 });

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -34,9 +34,10 @@ const makeData = (identities: Array<Record<string, unknown>> = []) => {
 
 	return {
 		data: {
+			session: null,
 			user: { email: 'owner@example.com' },
 			supabase: mockSupabase
-		},
+		} as any,
 		mockSupabase
 	};
 };

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+
+const pageMock = vi.hoisted(() => ({
+	url: new URL('http://localhost/app/account')
+}));
+
+vi.mock('$app/stores', () => ({
+	page: {
+		subscribe: (run: (value: unknown) => void) => {
+			run({ url: pageMock.url });
+			return () => {};
+		}
+	}
+}));
+
+vi.mock('@lucide/svelte');
+
+import AccountPage from './+page.svelte';
+
+const makeData = (identities: Array<Record<string, unknown>> = []) => {
+	const mockSupabase = {
+		auth: {
+			getUserIdentities: vi.fn().mockResolvedValue({
+				data: { identities },
+				error: null
+			}),
+			linkIdentity: vi.fn().mockResolvedValue({
+				data: { provider: 'google', url: 'https://supabase.example/link-google' },
+				error: null
+			})
+		}
+	};
+
+	return {
+		data: {
+			user: { email: 'owner@example.com' },
+			supabase: mockSupabase
+		},
+		mockSupabase
+	};
+};
+
+describe('/app/account page', () => {
+	const originalLocation = window.location;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		pageMock.url = new URL('http://localhost/app/account');
+		Object.defineProperty(window, 'location', {
+			value: { href: '', origin: 'http://localhost' },
+			writable: true,
+			configurable: true
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true
+		});
+	});
+
+	it('loads and displays account email plus unconnected Google state', async () => {
+		const { data, mockSupabase } = makeData();
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(mockSupabase.auth.getUserIdentities).toHaveBeenCalledOnce();
+			expect(screen.getByText('owner@example.com')).toBeInTheDocument();
+			expect(screen.getByText('Google is not connected')).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Connect Google' })).toBeInTheDocument();
+		});
+	});
+
+	it('shows connected Google identity email', async () => {
+		const { data } = makeData([
+			{
+				provider: 'google',
+				identity_data: { email: 'google@example.com' }
+			}
+		]);
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(screen.getByText('Google is connected')).toBeInTheDocument();
+			expect(screen.getByText('google@example.com')).toBeInTheDocument();
+		});
+		expect(screen.queryByRole('button', { name: 'Connect Google' })).not.toBeInTheDocument();
+	});
+
+	it('starts Google identity linking and redirects to Supabase URL', async () => {
+		const { data, mockSupabase } = makeData();
+
+		render(AccountPage, { props: { data } });
+
+		const button = await screen.findByRole('button', { name: 'Connect Google' });
+		await fireEvent.click(button);
+
+		await vi.waitFor(() => {
+			expect(mockSupabase.auth.linkIdentity).toHaveBeenCalledWith({
+				provider: 'google',
+				options: {
+					redirectTo: 'http://localhost/auth/callback?link=google&next=%2Fapp%2Faccount',
+					scopes: 'openid email profile',
+					skipBrowserRedirect: true
+				}
+			});
+			expect(window.location.href).toBe('https://supabase.example/link-google');
+		});
+	});
+
+	it('shows sanitized linking errors', async () => {
+		const { data, mockSupabase } = makeData();
+		mockSupabase.auth.linkIdentity.mockResolvedValueOnce({
+			data: { provider: 'google', url: null },
+			error: new Error('manual_linking_disabled')
+		});
+
+		render(AccountPage, { props: { data } });
+
+		const button = await screen.findByRole('button', { name: 'Connect Google' });
+		await fireEvent.click(button);
+
+		await vi.waitFor(() => {
+			expect(
+				screen.getByText(
+					'Google account linking is not enabled for this Drumery environment.'
+				)
+			).toBeInTheDocument();
+		});
+	});
+
+	it('shows callback success and error messages from query params', async () => {
+		pageMock.url = new URL('http://localhost/app/account?linked=google&auth_error=ignored');
+		const { data } = makeData();
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(screen.getByText('Google account connected.')).toBeInTheDocument();
+		});
+	});
+});

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -14,6 +14,10 @@ vi.mock('$app/stores', () => ({
 	}
 }));
 
+vi.mock('$app/navigation', () => ({
+	replaceState: vi.fn()
+}));
+
 vi.mock('@lucide/svelte');
 
 import AccountPage from './+page.svelte';
@@ -160,5 +164,23 @@ describe('/app/account page', () => {
 		expect(
 			screen.getByText('Google authentication failed. Please try again.')
 		).toBeInTheDocument();
+	});
+
+	it('shows fallback message when loadIdentities fails', async () => {
+		const { data, mockSupabase } = makeData();
+		mockSupabase.auth.getUserIdentities.mockResolvedValueOnce({
+			data: null,
+			error: new Error('network failure')
+		});
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(
+				screen.getByText('Unable to load linked account providers.')
+			).toBeInTheDocument();
+		});
+		expect(screen.getByText('Google is not connected')).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Connect Google' })).toBeInTheDocument();
 	});
 });

--- a/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts
@@ -166,6 +166,20 @@ describe('/app/account page', () => {
 		).toBeInTheDocument();
 	});
 
+	it('discards non-allow-listed auth_error values from query params', async () => {
+		pageMock.url = new URL(
+			'http://localhost/app/account?auth_error=Click+here+to+reset+your+password'
+		);
+		const { data } = makeData();
+
+		render(AccountPage, { props: { data } });
+
+		await vi.waitFor(() => {
+			expect(screen.getByText('Google is not connected')).toBeInTheDocument();
+		});
+		expect(screen.queryByText('Click here to reset your password')).not.toBeInTheDocument();
+	});
+
 	it('shows fallback message when loadIdentities fails', async () => {
 		const { data, mockSupabase } = makeData();
 		mockSupabase.auth.getUserIdentities.mockResolvedValueOnce({

--- a/packages/dtx-web/src/routes/(app)/layout.svelte.test.ts
+++ b/packages/dtx-web/src/routes/(app)/layout.svelte.test.ts
@@ -86,15 +86,13 @@ describe('(app)/+layout.svelte', () => {
 		});
 	});
 
-	it('calls navigateToProfile when Profile is clicked', async () => {
-		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	it('navigates to /app/account when Profile is clicked', async () => {
 		const { data } = makeData();
 		render(AppLayout, { props: { data, children: noopChildren } });
 
 		const profileBtn = screen.getByText('Profile').closest('button')!;
 		await fireEvent.click(profileBtn);
 
-		expect(consoleSpy).toHaveBeenCalledWith('Profile clicked');
-		consoleSpy.mockRestore();
+		expect(gotoMock).toHaveBeenCalledWith('/app/account');
 	});
 });

--- a/packages/dtx-web/src/routes/(login)/login/+page.server.ts
+++ b/packages/dtx-web/src/routes/(login)/login/+page.server.ts
@@ -1,4 +1,9 @@
 import { redirect, fail } from '@sveltejs/kit';
+import {
+	GOOGLE_OAUTH_SCOPES,
+	buildAuthCallbackUrl,
+	sanitizeGoogleAuthError
+} from '$lib/auth/google';
 
 import type { Actions } from './$types';
 
@@ -25,5 +30,30 @@ export const actions: Actions = {
 		} else {
 			redirect(303, '/app');
 		}
+	},
+
+	google: async ({ request, url, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const redirectToDesktop = formData.get('redirect') === 'desktop';
+		const redirectTo = buildAuthCallbackUrl(url.origin, redirectToDesktop ? 'desktop' : 'web');
+
+		const { data, error } = await supabase.auth.signInWithOAuth({
+			provider: 'google',
+			options: {
+				redirectTo,
+				scopes: GOOGLE_OAUTH_SCOPES,
+				skipBrowserRedirect: true
+			}
+		});
+
+		if (error || !data?.url) {
+			console.error('Google login error:', error);
+			return fail(400, {
+				success: false,
+				error: sanitizeGoogleAuthError(error?.message)
+			});
+		}
+
+		redirect(303, data.url);
 	}
 };

--- a/packages/dtx-web/src/routes/(login)/login/+page.svelte
+++ b/packages/dtx-web/src/routes/(login)/login/+page.svelte
@@ -2,20 +2,9 @@
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
+	import { replaceState } from '$app/navigation';
 	import { Loader } from '@lucide/svelte';
-	import {
-		GOOGLE_AUTH_GENERIC_MESSAGE,
-		GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
-		GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE,
-		GOOGLE_AUTH_UNAVAILABLE_MESSAGE
-	} from '$lib/auth/google';
-
-	const GOOGLE_AUTH_ERROR_MESSAGES = [
-		GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
-		GOOGLE_AUTH_GENERIC_MESSAGE,
-		GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
-		GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE
-	] as const;
+	import { GOOGLE_AUTH_ERROR_MESSAGES } from '$lib/auth/google';
 
 	// Get form action data which may contain error messages
 	let { form } = $props();
@@ -26,19 +15,29 @@
 	let redirectToDesktop = $state(false);
 	let isCheckingAuthState = $state(true);
 
-	// Include server action errors and sanitized callback errors.
-	// Only display trusted, allow-listed messages from the error query param.
-	let error = $derived(
-		form?.error ||
-			GOOGLE_AUTH_ERROR_MESSAGES.find((m) => m === $page.url.searchParams.get('error')) ||
-			''
-	);
+	// Capture the allow-listed URL error once on mount so we can clear the
+	// query param (preventing it from persisting on refresh) without losing
+	// the message. Server action errors still flow through `form?.error`.
+	let urlError = $state('');
+	let error = $derived(form?.error || urlError);
 
 	// Check for desktop redirect parameter
 	onMount(() => {
 		if (browser) {
+			const params = $page.url.searchParams;
+
+			// Only display trusted, allow-listed messages from the error query param.
+			urlError = GOOGLE_AUTH_ERROR_MESSAGES.find((m) => m === params.get('error')) || '';
+
+			// Clear callback error param so the banner does not persist on refresh.
+			if (params.has('error')) {
+				const cleanUrl = new URL($page.url);
+				cleanUrl.searchParams.delete('error');
+				replaceState(cleanUrl, {});
+			}
+
 			// Check if we're redirecting from desktop app
-			const redirectParam = $page.url.searchParams.get('redirect');
+			const redirectParam = params.get('redirect');
 			redirectToDesktop = redirectParam === 'desktop';
 			isCheckingAuthState = false;
 		}

--- a/packages/dtx-web/src/routes/(login)/login/+page.svelte
+++ b/packages/dtx-web/src/routes/(login)/login/+page.svelte
@@ -13,8 +13,8 @@
 	let redirectToDesktop = $state(false);
 	let isCheckingAuthState = $state(true);
 
-	// Use derived state to include server-side errors
-	let error = $derived(form?.error || '');
+	// Include server action errors and sanitized callback errors.
+	let error = $derived(form?.error || $page.url.searchParams.get('error') || '');
 
 	// Check for desktop redirect parameter
 	onMount(() => {
@@ -105,6 +105,28 @@
 					</button>
 				</div>
 			</form>
+
+			<div class="my-6 flex items-center gap-3">
+				<div class="h-px flex-1 bg-gray-200"></div>
+				<span class="text-xs font-medium text-gray-500 uppercase">or</span>
+				<div class="h-px flex-1 bg-gray-200"></div>
+			</div>
+
+			<form action="?/google" method="POST" onsubmit={handleSubmit}>
+				{#if redirectToDesktop}
+					<input type="hidden" name="redirect" value="desktop" />
+				{/if}
+				<button
+					type="submit"
+					disabled={isLoading}
+					class="w-full rounded-md border border-gray-300 bg-white px-4 py-2 font-medium text-gray-800 hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
+				>
+					Continue with Google
+				</button>
+			</form>
+			<p class="mt-3 text-center text-xs text-gray-500">
+				Google sign-in is only available for existing linked accounts.
+			</p>
 
 			{#if redirectToDesktop}
 				<div class="mt-6 text-center text-sm text-gray-500">

--- a/packages/dtx-web/src/routes/(login)/login/+page.svelte
+++ b/packages/dtx-web/src/routes/(login)/login/+page.svelte
@@ -3,6 +3,19 @@
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import { Loader } from '@lucide/svelte';
+	import {
+		GOOGLE_AUTH_GENERIC_MESSAGE,
+		GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
+		GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE,
+		GOOGLE_AUTH_UNAVAILABLE_MESSAGE
+	} from '$lib/auth/google';
+
+	const GOOGLE_AUTH_ERROR_MESSAGES = [
+		GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
+		GOOGLE_AUTH_GENERIC_MESSAGE,
+		GOOGLE_AUTH_LINKING_CONFIG_MESSAGE,
+		GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE
+	] as const;
 
 	// Get form action data which may contain error messages
 	let { form } = $props();
@@ -14,7 +27,12 @@
 	let isCheckingAuthState = $state(true);
 
 	// Include server action errors and sanitized callback errors.
-	let error = $derived(form?.error || $page.url.searchParams.get('error') || '');
+	// Only display trusted, allow-listed messages from the error query param.
+	let error = $derived(
+		form?.error ||
+			GOOGLE_AUTH_ERROR_MESSAGES.find((m) => m === $page.url.searchParams.get('error')) ||
+			''
+	);
 
 	// Check for desktop redirect parameter
 	onMount(() => {

--- a/packages/dtx-web/src/routes/(login)/login/+page.svelte
+++ b/packages/dtx-web/src/routes/(login)/login/+page.svelte
@@ -46,7 +46,6 @@
 	// Handle form submission
 	const handleSubmit = () => {
 		isLoading = true;
-		return true; // Allow the form to submit
 	};
 </script>
 

--- a/packages/dtx-web/src/routes/(login)/login/login-page.test.ts
+++ b/packages/dtx-web/src/routes/(login)/login/login-page.test.ts
@@ -104,4 +104,45 @@ describe('Login Page', () => {
 			expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
 		});
 	});
+
+	it('shows Google sign-in for existing linked accounts', async () => {
+		envMock.browser = true;
+		render(LoginPage);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', { name: 'Continue with Google' })
+			).toBeInTheDocument();
+		});
+		expect(
+			screen.getByText('Google sign-in is only available for existing linked accounts.')
+		).toBeInTheDocument();
+	});
+
+	it('does not show signup copy', async () => {
+		envMock.browser = true;
+		render(LoginPage);
+
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Login' })).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/sign up/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/create account/i)).not.toBeInTheDocument();
+	});
+
+	it('shows sanitized Google errors from query params', async () => {
+		envMock.browser = true;
+		pageMock.url = new URL(
+			'http://localhost/login?error=Google+sign-in+is+only+available+for+existing+linked+accounts.'
+		);
+		render(LoginPage);
+
+		await waitFor(() => {
+			expect(
+				screen.getAllByText(
+					'Google sign-in is only available for existing linked accounts.'
+				).length
+			).toBeGreaterThan(0);
+		});
+	});
 });

--- a/packages/dtx-web/src/routes/(login)/login/login-page.test.ts
+++ b/packages/dtx-web/src/routes/(login)/login/login-page.test.ts
@@ -16,6 +16,9 @@ vi.mock('$app/stores', () => ({
 		}
 	}
 }));
+vi.mock('$app/navigation', () => ({
+	replaceState: vi.fn()
+}));
 
 import LoginPage from './+page.svelte';
 

--- a/packages/dtx-web/src/routes/(login)/login/login-page.test.ts
+++ b/packages/dtx-web/src/routes/(login)/login/login-page.test.ts
@@ -148,4 +148,15 @@ describe('Login Page', () => {
 			).toBeGreaterThan(0);
 		});
 	});
+
+	it('discards non-allow-listed error values from query params', async () => {
+		envMock.browser = true;
+		pageMock.url = new URL('http://localhost/login?error=Click+here+to+reset+your+password');
+		render(LoginPage);
+
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Login' })).toBeInTheDocument();
+		});
+		expect(screen.queryByText('Click here to reset your password')).not.toBeInTheDocument();
+	});
 });

--- a/packages/dtx-web/src/routes/(login)/login/page.server.test.ts
+++ b/packages/dtx-web/src/routes/(login)/login/page.server.test.ts
@@ -15,6 +15,7 @@ vi.mock('@sveltejs/kit', () => ({
 	redirect: mockRedirect
 }));
 
+import { GOOGLE_AUTH_UNAVAILABLE_MESSAGE } from '$lib/auth/google';
 import { actions } from './+page.server';
 
 const makeEvent = (fields: Record<string, string>, signInError: Error | null = null) => ({
@@ -23,10 +24,15 @@ const makeEvent = (fields: Record<string, string>, signInError: Error | null = n
 			get: (key: string) => fields[key] ?? null
 		})
 	},
+	url: new URL('http://localhost/login'),
 	locals: {
 		supabase: {
 			auth: {
-				signInWithPassword: vi.fn().mockResolvedValue({ error: signInError })
+				signInWithPassword: vi.fn().mockResolvedValue({ error: signInError }),
+				signInWithOAuth: vi.fn().mockResolvedValue({
+					data: { url: 'https://supabase.example/auth/google' },
+					error: null
+				})
 			}
 		}
 	}
@@ -71,6 +77,61 @@ describe('login/+page.server actions', () => {
 
 			await expect(actions.login(event as any)).rejects.toMatchObject({
 				location: '/app?redirect=desktop'
+			});
+		});
+	});
+
+	describe('google action', () => {
+		it('starts Google OAuth with a web callback', async () => {
+			const event = makeEvent({ redirect: '' });
+
+			await expect(actions.google(event as any)).rejects.toMatchObject({
+				location: 'https://supabase.example/auth/google'
+			});
+
+			expect(event.locals.supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+				provider: 'google',
+				options: {
+					redirectTo: 'http://localhost/auth/callback',
+					scopes: 'openid email profile',
+					skipBrowserRedirect: true
+				}
+			});
+		});
+
+		it('starts Google OAuth with a desktop callback when redirect=desktop is set', async () => {
+			const event = makeEvent({ redirect: 'desktop' });
+
+			await expect(actions.google(event as any)).rejects.toMatchObject({
+				location: 'https://supabase.example/auth/google'
+			});
+
+			expect(event.locals.supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+				provider: 'google',
+				options: {
+					redirectTo: 'http://localhost/auth/callback?redirect=desktop',
+					scopes: 'openid email profile',
+					skipBrowserRedirect: true
+				}
+			});
+		});
+
+		it('returns a sanitized failure when Supabase rejects Google OAuth', async () => {
+			const event = makeEvent({ redirect: '' });
+			event.locals.supabase.auth.signInWithOAuth.mockResolvedValueOnce({
+				data: { url: null },
+				error: new Error('Signups not allowed for this instance')
+			});
+
+			const result = await actions.google(event as any);
+
+			expect(mockFail).toHaveBeenCalledWith(400, {
+				success: false,
+				error: GOOGLE_AUTH_UNAVAILABLE_MESSAGE
+			});
+			expect(result).toEqual({
+				status: 400,
+				data: { success: false, error: GOOGLE_AUTH_UNAVAILABLE_MESSAGE }
 			});
 		});
 	});

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import type { AuthTokenResponse } from '@supabase/supabase-js';
 import {
 	GOOGLE_AUTH_GENERIC_MESSAGE,
 	GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
@@ -16,6 +17,16 @@ const callbackIntent = (url: URL): GoogleRedirectIntent =>
 
 const isAccountLinkCallback = (url: URL): boolean => url.searchParams.get('link') === 'google';
 
+const buildCallbackErrorRedirect = (
+	accountLink: boolean,
+	nextPath: string,
+	message: string,
+	intent: GoogleRedirectIntent
+): string =>
+	accountLink
+		? buildLinkedAccountRedirect(nextPath, 'error', message)
+		: buildLoginErrorRedirect(message, intent);
+
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	const intent = callbackIntent(url);
 	const nextPath = safeAppRedirectPath(url.searchParams.get('next'));
@@ -25,57 +36,45 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 
 	if (providerError) {
 		const message = sanitizeGoogleAuthError(providerError);
-		redirect(
-			303,
-			accountLink
-				? buildLinkedAccountRedirect(nextPath, 'error', message)
-				: buildLoginErrorRedirect(message, intent)
-		);
+		redirect(303, buildCallbackErrorRedirect(accountLink, nextPath, message, intent));
 	}
 
 	const code = url.searchParams.get('code');
 	if (!code) {
 		redirect(
 			303,
-			accountLink
-				? buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
-				: buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent)
+			buildCallbackErrorRedirect(accountLink, nextPath, GOOGLE_AUTH_GENERIC_MESSAGE, intent)
 		);
 	}
 
-	let exchangeResult;
+	let exchangeResult: AuthTokenResponse;
 	try {
 		exchangeResult = await supabase.auth.exchangeCodeForSession(code);
-	} catch {
+	} catch (error) {
+		console.error('Auth callback exchange error:', error);
 		redirect(
 			303,
-			accountLink
-				? buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
-				: buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent)
+			buildCallbackErrorRedirect(accountLink, nextPath, GOOGLE_AUTH_GENERIC_MESSAGE, intent)
 		);
 	}
 	const { error } = exchangeResult;
 	if (error) {
+		console.error('Auth callback exchange returned error:', error);
 		const message = sanitizeGoogleAuthError(error.message);
-		redirect(
-			303,
-			accountLink
-				? buildLinkedAccountRedirect(nextPath, 'error', message)
-				: buildLoginErrorRedirect(message, intent)
-		);
+		redirect(303, buildCallbackErrorRedirect(accountLink, nextPath, message, intent));
 	}
 
-	// Validate the post-exchange identity for both login and linking callbacks.
-	// `link` is a client-controllable query param, so an unauthenticated user can
-	// initiate a Google OAuth flow with `redirectTo=/auth/callback?link=google`
-	// and, if Google signups are enabled, land here with a fresh Google-only
-	// session. A genuine linkIdentity flow adds Google to an already-authenticated
-	// user, who must therefore have a non-Google identity as well. Reject any
-	// Google-only session regardless of the `link` flag.
 	let identitiesResult;
 	try {
 		identitiesResult = await supabase.auth.getUserIdentities();
-	} catch {
+	} catch (error) {
+		console.error('Auth callback identity lookup error:', error);
+		if (accountLink) {
+			redirect(
+				303,
+				buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
+			);
+		}
 		await supabase.auth.signOut();
 		redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent));
 	}
@@ -85,6 +84,7 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	const hasNonGoogleIdentity = identities.some((identity) => identity.provider !== 'google');
 
 	if (identitiesError || !hasGoogleIdentity || !hasNonGoogleIdentity) {
+		console.error('Auth callback identity check failed:', identitiesError);
 		await supabase.auth.signOut();
 		redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_UNAVAILABLE_MESSAGE, intent));
 	}

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -54,17 +54,22 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 		);
 	}
 
-	if (!accountLink) {
-		const { data: identitiesData, error: identitiesError } =
-			await supabase.auth.getUserIdentities();
-		const identities = identitiesData?.identities ?? [];
-		const hasGoogleIdentity = identities.some((identity) => identity.provider === 'google');
-		const hasNonGoogleIdentity = identities.some((identity) => identity.provider !== 'google');
+	// Validate the post-exchange identity for both login and linking callbacks.
+	// `link` is a client-controllable query param, so an unauthenticated user can
+	// initiate a Google OAuth flow with `redirectTo=/auth/callback?link=google`
+	// and, if Google signups are enabled, land here with a fresh Google-only
+	// session. A genuine linkIdentity flow adds Google to an already-authenticated
+	// user, who must therefore have a non-Google identity as well. Reject any
+	// Google-only session regardless of the `link` flag.
+	const { data: identitiesData, error: identitiesError } =
+		await supabase.auth.getUserIdentities();
+	const identities = identitiesData?.identities ?? [];
+	const hasGoogleIdentity = identities.some((identity) => identity.provider === 'google');
+	const hasNonGoogleIdentity = identities.some((identity) => identity.provider !== 'google');
 
-		if (identitiesError || !hasGoogleIdentity || !hasNonGoogleIdentity) {
-			await supabase.auth.signOut();
-			redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_UNAVAILABLE_MESSAGE, intent));
-		}
+	if (identitiesError || !hasGoogleIdentity || !hasNonGoogleIdentity) {
+		await supabase.auth.signOut();
+		redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_UNAVAILABLE_MESSAGE, intent));
 	}
 
 	if (accountLink) {

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -69,12 +69,6 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 		identitiesResult = await supabase.auth.getUserIdentities();
 	} catch (error) {
 		console.error('Auth callback identity lookup error:', error);
-		if (accountLink) {
-			redirect(
-				303,
-				buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
-			);
-		}
 		await supabase.auth.signOut();
 		redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent));
 	}
@@ -86,11 +80,14 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	if (identitiesError || !hasGoogleIdentity || !hasNonGoogleIdentity) {
 		console.error('Auth callback identity check failed:', identitiesError);
 		// Account-link callbacks run for an already-signed-in user. Preserve
-		// their existing password session when the link failed but they have
-		// (or may have, when identities lookup errored) a non-Google identity,
-		// and report the error on the account page. Only confirmed Google-only
-		// sessions (forged link or normal login) need to be cleared.
-		const preserveSession = accountLink && (identitiesError || hasNonGoogleIdentity);
+		// their existing password session only when identities lookup succeeded
+		// and confirms a non-Google identity — the Google link failed but
+		// they're still a verified password user. When identities lookup
+		// errored or returned a Google-only session, sign out: a forged
+		// `link=google` callback can produce a Google-only session, and the
+		// /app guard doesn't re-check identities on subsequent requests, so
+		// retaining it would grant persistent access.
+		const preserveSession = accountLink && !identitiesError && hasNonGoogleIdentity;
 		if (preserveSession) {
 			redirect(
 				303,

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -1,0 +1,61 @@
+import { redirect } from '@sveltejs/kit';
+import {
+	GOOGLE_AUTH_GENERIC_MESSAGE,
+	buildLinkedAccountRedirect,
+	buildLoginErrorRedirect,
+	safeAppRedirectPath,
+	sanitizeGoogleAuthError,
+	type GoogleRedirectIntent
+} from '$lib/auth/google';
+
+import type { RequestHandler } from './$types';
+
+const callbackIntent = (url: URL): GoogleRedirectIntent =>
+	url.searchParams.get('redirect') === 'desktop' ? 'desktop' : 'web';
+
+const isAccountLinkCallback = (url: URL): boolean => url.searchParams.get('link') === 'google';
+
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+	const intent = callbackIntent(url);
+	const nextPath = safeAppRedirectPath(url.searchParams.get('next'));
+	const accountLink = isAccountLinkCallback(url);
+	const providerError =
+		url.searchParams.get('error_description') ?? url.searchParams.get('error');
+
+	if (providerError) {
+		const message = sanitizeGoogleAuthError(providerError);
+		redirect(
+			303,
+			accountLink
+				? buildLinkedAccountRedirect(nextPath, 'error', message)
+				: buildLoginErrorRedirect(message, intent)
+		);
+	}
+
+	const code = url.searchParams.get('code');
+	if (!code) {
+		redirect(
+			303,
+			accountLink
+				? buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
+				: buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent)
+		);
+	}
+
+	const { error } = await supabase.auth.exchangeCodeForSession(code);
+	if (error) {
+		const message = sanitizeGoogleAuthError(error.message);
+		redirect(
+			303,
+			accountLink
+				? buildLinkedAccountRedirect(nextPath, 'error', message)
+				: buildLoginErrorRedirect(message, intent)
+		);
+	}
+
+	if (accountLink) {
+		redirect(303, buildLinkedAccountRedirect(nextPath, 'connected'));
+	}
+
+	redirect(303, intent === 'desktop' ? '/app?redirect=desktop' : '/app');
+};

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -1,6 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import {
 	GOOGLE_AUTH_GENERIC_MESSAGE,
+	GOOGLE_AUTH_UNAVAILABLE_MESSAGE,
 	buildLinkedAccountRedirect,
 	buildLoginErrorRedirect,
 	safeAppRedirectPath,
@@ -51,6 +52,19 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 				? buildLinkedAccountRedirect(nextPath, 'error', message)
 				: buildLoginErrorRedirect(message, intent)
 		);
+	}
+
+	if (!accountLink) {
+		const { data: identitiesData, error: identitiesError } =
+			await supabase.auth.getUserIdentities();
+		const identities = identitiesData?.identities ?? [];
+		const hasGoogleIdentity = identities.some((identity) => identity.provider === 'google');
+		const hasNonGoogleIdentity = identities.some((identity) => identity.provider !== 'google');
+
+		if (identitiesError || !hasGoogleIdentity || !hasNonGoogleIdentity) {
+			await supabase.auth.signOut();
+			redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_UNAVAILABLE_MESSAGE, intent));
+		}
 	}
 
 	if (accountLink) {

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -43,7 +43,18 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 		);
 	}
 
-	const { error } = await supabase.auth.exchangeCodeForSession(code);
+	let exchangeResult;
+	try {
+		exchangeResult = await supabase.auth.exchangeCodeForSession(code);
+	} catch {
+		redirect(
+			303,
+			accountLink
+				? buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
+				: buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent)
+		);
+	}
+	const { error } = exchangeResult;
 	if (error) {
 		const message = sanitizeGoogleAuthError(error.message);
 		redirect(
@@ -61,8 +72,14 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	// session. A genuine linkIdentity flow adds Google to an already-authenticated
 	// user, who must therefore have a non-Google identity as well. Reject any
 	// Google-only session regardless of the `link` flag.
-	const { data: identitiesData, error: identitiesError } =
-		await supabase.auth.getUserIdentities();
+	let identitiesResult;
+	try {
+		identitiesResult = await supabase.auth.getUserIdentities();
+	} catch {
+		await supabase.auth.signOut();
+		redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_GENERIC_MESSAGE, intent));
+	}
+	const { data: identitiesData, error: identitiesError } = identitiesResult;
 	const identities = identitiesData?.identities ?? [];
 	const hasGoogleIdentity = identities.some((identity) => identity.provider === 'google');
 	const hasNonGoogleIdentity = identities.some((identity) => identity.provider !== 'google');

--- a/packages/dtx-web/src/routes/auth/callback/+server.ts
+++ b/packages/dtx-web/src/routes/auth/callback/+server.ts
@@ -85,6 +85,18 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 
 	if (identitiesError || !hasGoogleIdentity || !hasNonGoogleIdentity) {
 		console.error('Auth callback identity check failed:', identitiesError);
+		// Account-link callbacks run for an already-signed-in user. Preserve
+		// their existing password session when the link failed but they have
+		// (or may have, when identities lookup errored) a non-Google identity,
+		// and report the error on the account page. Only confirmed Google-only
+		// sessions (forged link or normal login) need to be cleared.
+		const preserveSession = accountLink && (identitiesError || hasNonGoogleIdentity);
+		if (preserveSession) {
+			redirect(
+				303,
+				buildLinkedAccountRedirect(nextPath, 'error', GOOGLE_AUTH_GENERIC_MESSAGE)
+			);
+		}
 		await supabase.auth.signOut();
 		redirect(303, buildLoginErrorRedirect(GOOGLE_AUTH_UNAVAILABLE_MESSAGE, intent));
 	}

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -36,6 +36,55 @@ const makeEvent = (
 	}
 });
 
+const makeEventWithIdentitiesError = (
+	rawUrl: string,
+	identitiesError: Error,
+	identities = [{ provider: 'email' }, { provider: 'google' }]
+) => ({
+	url: new URL(rawUrl),
+	locals: {
+		supabase: {
+			auth: {
+				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: null }),
+				getUserIdentities: vi.fn().mockResolvedValue({
+					data: { identities },
+					error: identitiesError
+				}),
+				signOut: vi.fn().mockResolvedValue({ error: null })
+			}
+		}
+	}
+});
+
+const makeEventWithThrowingExchange = (rawUrl: string) => ({
+	url: new URL(rawUrl),
+	locals: {
+		supabase: {
+			auth: {
+				exchangeCodeForSession: vi.fn().mockRejectedValue(new Error('network failure')),
+				getUserIdentities: vi.fn().mockResolvedValue({
+					data: { identities: [{ provider: 'email' }, { provider: 'google' }] },
+					error: null
+				}),
+				signOut: vi.fn().mockResolvedValue({ error: null })
+			}
+		}
+	}
+});
+
+const makeEventWithThrowingIdentities = (rawUrl: string) => ({
+	url: new URL(rawUrl),
+	locals: {
+		supabase: {
+			auth: {
+				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: null }),
+				getUserIdentities: vi.fn().mockRejectedValue(new Error('network failure')),
+				signOut: vi.fn().mockResolvedValue({ error: null })
+			}
+		}
+	}
+});
+
 describe('/auth/callback', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -144,5 +193,44 @@ describe('/auth/callback', () => {
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
 		});
+	});
+
+	it('signs out and redirects to login when getUserIdentities returns an error', async () => {
+		const event = makeEventWithIdentitiesError(
+			'http://localhost/auth/callback?code=abc',
+			new Error('identity lookup failed')
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
+	});
+
+	it('redirects to login with generic error when exchangeCodeForSession throws', async () => {
+		const event = makeEventWithThrowingExchange('http://localhost/auth/callback?code=abc');
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+
+	it('redirects account-linking to account page when exchangeCodeForSession throws', async () => {
+		const event = makeEventWithThrowingExchange(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+
+	it('signs out and redirects to login when getUserIdentities throws', async () => {
+		const event = makeEventWithThrowingIdentities('http://localhost/auth/callback?code=abc');
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
 	});
 });

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -16,12 +16,21 @@ vi.mock('@sveltejs/kit', () => ({
 import { GOOGLE_AUTH_GENERIC_MESSAGE, GOOGLE_AUTH_UNAVAILABLE_MESSAGE } from '$lib/auth/google';
 import { GET } from './+server';
 
-const makeEvent = (rawUrl: string, exchangeError: Error | null = null) => ({
+const makeEvent = (
+	rawUrl: string,
+	exchangeError: Error | null = null,
+	identities = [{ provider: 'email' }, { provider: 'google' }]
+) => ({
 	url: new URL(rawUrl),
 	locals: {
 		supabase: {
 			auth: {
-				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: exchangeError })
+				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: exchangeError }),
+				getUserIdentities: vi.fn().mockResolvedValue({
+					data: { identities },
+					error: null
+				}),
+				signOut: vi.fn().mockResolvedValue({ error: null })
 			}
 		}
 	}
@@ -87,6 +96,17 @@ describe('/auth/callback', () => {
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
 		});
+	});
+
+	it('rejects Google-only login sessions created outside the linking flow', async () => {
+		const event = makeEvent('http://localhost/auth/callback?code=abc', null, [
+			{ provider: 'google' }
+		]);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
 	});
 
 	it('redirects successful account linking back to account page', async () => {

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -22,67 +22,33 @@ import { GET } from './+server';
 
 const makeEvent = (
 	rawUrl: string,
-	exchangeError: Error | null = null,
-	identities = [{ provider: 'email' }, { provider: 'google' }]
+	{
+		exchangeError,
+		exchangeThrow,
+		identitiesError,
+		identitiesThrow,
+		identities = [{ provider: 'email' }, { provider: 'google' }]
+	}: {
+		exchangeError?: Error | null;
+		exchangeThrow?: Error;
+		identitiesError?: Error;
+		identitiesThrow?: Error;
+		identities?: Array<{ provider: string }>;
+	} = {}
 ) => ({
 	url: new URL(rawUrl),
 	locals: {
 		supabase: {
 			auth: {
-				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: exchangeError }),
-				getUserIdentities: vi.fn().mockResolvedValue({
-					data: { identities },
-					error: null
-				}),
-				signOut: vi.fn().mockResolvedValue({ error: null })
-			}
-		}
-	}
-});
-
-const makeEventWithIdentitiesError = (
-	rawUrl: string,
-	identitiesError: Error,
-	identities = [{ provider: 'email' }, { provider: 'google' }]
-) => ({
-	url: new URL(rawUrl),
-	locals: {
-		supabase: {
-			auth: {
-				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: null }),
-				getUserIdentities: vi.fn().mockResolvedValue({
-					data: { identities },
-					error: identitiesError
-				}),
-				signOut: vi.fn().mockResolvedValue({ error: null })
-			}
-		}
-	}
-});
-
-const makeEventWithThrowingExchange = (rawUrl: string) => ({
-	url: new URL(rawUrl),
-	locals: {
-		supabase: {
-			auth: {
-				exchangeCodeForSession: vi.fn().mockRejectedValue(new Error('network failure')),
-				getUserIdentities: vi.fn().mockResolvedValue({
-					data: { identities: [{ provider: 'email' }, { provider: 'google' }] },
-					error: null
-				}),
-				signOut: vi.fn().mockResolvedValue({ error: null })
-			}
-		}
-	}
-});
-
-const makeEventWithThrowingIdentities = (rawUrl: string) => ({
-	url: new URL(rawUrl),
-	locals: {
-		supabase: {
-			auth: {
-				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: null }),
-				getUserIdentities: vi.fn().mockRejectedValue(new Error('network failure')),
+				exchangeCodeForSession: exchangeThrow
+					? vi.fn().mockRejectedValue(exchangeThrow)
+					: vi.fn().mockResolvedValue({ error: exchangeError ?? null }),
+				getUserIdentities: identitiesThrow
+					? vi.fn().mockRejectedValue(identitiesThrow)
+					: vi.fn().mockResolvedValue({
+							data: { identities },
+							error: identitiesError ?? null
+						}),
 				signOut: vi.fn().mockResolvedValue({ error: null })
 			}
 		}
@@ -154,10 +120,9 @@ describe('/auth/callback', () => {
 	});
 
 	it('redirects exchange errors to login', async () => {
-		const event = makeEvent(
-			'http://localhost/auth/callback?code=abc',
-			new Error('Signups not allowed')
-		);
+		const event = makeEvent('http://localhost/auth/callback?code=abc', {
+			exchangeError: new Error('Signups not allowed')
+		});
 
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
@@ -165,9 +130,9 @@ describe('/auth/callback', () => {
 	});
 
 	it('rejects Google-only login sessions created outside the linking flow', async () => {
-		const event = makeEvent('http://localhost/auth/callback?code=abc', null, [
-			{ provider: 'google' }
-		]);
+		const event = makeEvent('http://localhost/auth/callback?code=abc', {
+			identities: [{ provider: 'google' }]
+		});
 
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
@@ -182,8 +147,7 @@ describe('/auth/callback', () => {
 		// The post-exchange identity check must reject this regardless of `link`.
 		const event = makeEvent(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
-			null,
-			[{ provider: 'google' }]
+			{ identities: [{ provider: 'google' }] }
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
@@ -213,10 +177,9 @@ describe('/auth/callback', () => {
 	});
 
 	it('signs out and redirects to login when getUserIdentities returns an error', async () => {
-		const event = makeEventWithIdentitiesError(
-			'http://localhost/auth/callback?code=abc',
-			new Error('identity lookup failed')
-		);
+		const event = makeEvent('http://localhost/auth/callback?code=abc', {
+			identitiesError: new Error('identity lookup failed')
+		});
 
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
@@ -225,7 +188,9 @@ describe('/auth/callback', () => {
 	});
 
 	it('redirects to login with generic error when exchangeCodeForSession throws', async () => {
-		const event = makeEventWithThrowingExchange('http://localhost/auth/callback?code=abc');
+		const event = makeEvent('http://localhost/auth/callback?code=abc', {
+			exchangeThrow: new Error('network failure')
+		});
 
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
@@ -233,8 +198,9 @@ describe('/auth/callback', () => {
 	});
 
 	it('redirects account-linking to account page when exchangeCodeForSession throws', async () => {
-		const event = makeEventWithThrowingExchange(
-			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
+			{ exchangeThrow: new Error('network failure') }
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
@@ -243,7 +209,9 @@ describe('/auth/callback', () => {
 	});
 
 	it('signs out and redirects to login when getUserIdentities throws', async () => {
-		const event = makeEventWithThrowingIdentities('http://localhost/auth/callback?code=abc');
+		const event = makeEvent('http://localhost/auth/callback?code=abc', {
+			identitiesThrow: new Error('network failure')
+		});
 
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
@@ -256,8 +224,9 @@ describe('/auth/callback', () => {
 		// and the /app guard doesn't re-check identities on subsequent requests.
 		// When identities lookup throws, we can't verify a non-Google identity,
 		// so the session must be cleared even for account-link callbacks.
-		const event = makeEventWithThrowingIdentities(
-			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
+			{ identitiesThrow: new Error('network failure') }
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
@@ -270,9 +239,9 @@ describe('/auth/callback', () => {
 		// Same rationale as the throw case: an identities-lookup error means
 		// we cannot confirm a non-Google identity, so a forged `link=google`
 		// Google-only session must not be retained.
-		const event = makeEventWithIdentitiesError(
+		const event = makeEvent(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
-			new Error('identity lookup failed')
+			{ identitiesError: new Error('identity lookup failed') }
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
@@ -288,8 +257,7 @@ describe('/auth/callback', () => {
 		// report the error on the account page.
 		const event = makeEvent(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
-			null,
-			[{ provider: 'email' }]
+			{ identities: [{ provider: 'email' }] }
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
@@ -301,7 +269,7 @@ describe('/auth/callback', () => {
 	it('redirects account-linking to account page when exchangeCodeForSession returns an error', async () => {
 		const event = makeEvent(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
-			new Error('identity already linked to another user')
+			{ exchangeError: new Error('identity already linked to another user') }
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -109,6 +109,23 @@ describe('/auth/callback', () => {
 		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
 	});
 
+	it('rejects forged linking callbacks that produce a Google-only session', async () => {
+		// An unauthenticated user can craft `link=google` in the callback URL and
+		// initiate a Google OAuth flow with that redirect. If Google signups are
+		// enabled, exchangeCodeForSession leaves them with a Google-only session.
+		// The post-exchange identity check must reject this regardless of `link`.
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
+			null,
+			[{ provider: 'google' }]
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
+	});
+
 	it('redirects successful account linking back to account page', async () => {
 		const event = makeEvent(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -13,7 +13,11 @@ vi.mock('@sveltejs/kit', () => ({
 	redirect: mockRedirect
 }));
 
-import { GOOGLE_AUTH_GENERIC_MESSAGE, GOOGLE_AUTH_UNAVAILABLE_MESSAGE } from '$lib/auth/google';
+import {
+	GOOGLE_AUTH_GENERIC_MESSAGE,
+	GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE,
+	GOOGLE_AUTH_UNAVAILABLE_MESSAGE
+} from '$lib/auth/google';
 import { GET } from './+server';
 
 const makeEvent = (
@@ -106,6 +110,19 @@ describe('/auth/callback', () => {
 
 		await expect(GET(event as any)).rejects.toMatchObject({
 			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+
+	it('prefers error_description over error when sanitizing provider errors', async () => {
+		// `error=access_denied` alone would sanitize to the generic message, but
+		// `error_description=identity already linked` must win and produce the
+		// provider-conflict message. This locks in the ?? precedence in +server.ts.
+		const event = makeEvent(
+			'http://localhost/auth/callback?error=access_denied&error_description=identity+already+linked'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE.replaceAll(' ', '+')}`
 		});
 	});
 
@@ -232,5 +249,28 @@ describe('/auth/callback', () => {
 			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
 		});
 		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
+	});
+
+	it('preserves session and redirects to account page when getUserIdentities throws during linking', async () => {
+		const event = makeEventWithThrowingIdentities(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
+	});
+
+	it('redirects account-linking to account page when exchangeCodeForSession returns an error', async () => {
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
+			new Error('identity already linked to another user')
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/app/account?auth_error=${GOOGLE_AUTH_PROVIDER_CONFLICT_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
 	});
 });

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -251,31 +251,34 @@ describe('/auth/callback', () => {
 		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
 	});
 
-	it('preserves session and redirects to account page when getUserIdentities throws during linking', async () => {
+	it('signs out and redirects to login when getUserIdentities throws during linking', async () => {
+		// A forged `link=google` callback can produce a Google-only session,
+		// and the /app guard doesn't re-check identities on subsequent requests.
+		// When identities lookup throws, we can't verify a non-Google identity,
+		// so the session must be cleared even for account-link callbacks.
 		const event = makeEventWithThrowingIdentities(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
-			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
 		});
-		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
+		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
 	});
 
-	it('preserves session when getUserIdentities returns an error during linking', async () => {
-		// A signed-in user whose Google link callback hits an identities-lookup
-		// error (return, not throw) must keep their password session and be sent
-		// back to the account page with an error — not signed out and sent to
-		// /login like a Google-only login session.
+	it('signs out and redirects to login when getUserIdentities returns an error during linking', async () => {
+		// Same rationale as the throw case: an identities-lookup error means
+		// we cannot confirm a non-Google identity, so a forged `link=google`
+		// Google-only session must not be retained.
 		const event = makeEventWithIdentitiesError(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
 			new Error('identity lookup failed')
 		);
 
 		await expect(GET(event as any)).rejects.toMatchObject({
-			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
 		});
-		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
+		expect(event.locals.supabase.auth.signOut).toHaveBeenCalled();
 	});
 
 	it('preserves session when a link callback lacks the Google identity', async () => {

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockRedirect = vi.hoisted(() =>
+	vi.fn((status: number, location: string) => {
+		const err = new Error(`Redirect to ${location}`) as any;
+		err.status = status;
+		err.location = location;
+		throw err;
+	})
+);
+
+vi.mock('@sveltejs/kit', () => ({
+	redirect: mockRedirect
+}));
+
+import { GOOGLE_AUTH_GENERIC_MESSAGE, GOOGLE_AUTH_UNAVAILABLE_MESSAGE } from '$lib/auth/google';
+import { GET } from './+server';
+
+const makeEvent = (rawUrl: string, exchangeError: Error | null = null) => ({
+	url: new URL(rawUrl),
+	locals: {
+		supabase: {
+			auth: {
+				exchangeCodeForSession: vi.fn().mockResolvedValue({ error: exchangeError })
+			}
+		}
+	}
+});
+
+describe('/auth/callback', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('redirects missing-code login callbacks to login with sanitized error', async () => {
+		const event = makeEvent('http://localhost/auth/callback');
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.exchangeCodeForSession).not.toHaveBeenCalled();
+	});
+
+	it('redirects provider errors to login with sanitized no-signup message', async () => {
+		const event = makeEvent(
+			'http://localhost/auth/callback?error=access_denied&error_description=Signups+not+allowed'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+
+	it('preserves desktop intent when redirecting login errors', async () => {
+		const event = makeEvent(
+			'http://localhost/auth/callback?redirect=desktop&error=access_denied'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?redirect=desktop&error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+
+	it('exchanges code and redirects standard login to /app', async () => {
+		const event = makeEvent('http://localhost/auth/callback?code=abc');
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: '/app'
+		});
+		expect(event.locals.supabase.auth.exchangeCodeForSession).toHaveBeenCalledWith('abc');
+	});
+
+	it('exchanges code and redirects desktop login to /app?redirect=desktop', async () => {
+		const event = makeEvent('http://localhost/auth/callback?code=abc&redirect=desktop');
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: '/app?redirect=desktop'
+		});
+	});
+
+	it('redirects exchange errors to login', async () => {
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc',
+			new Error('Signups not allowed')
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/login?error=${GOOGLE_AUTH_UNAVAILABLE_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+
+	it('redirects successful account linking back to account page', async () => {
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: '/app/account?linked=google'
+		});
+	});
+
+	it('redirects account-linking errors back to a safe account page', async () => {
+		const event = makeEvent(
+			'http://localhost/auth/callback?link=google&next=https://evil.example&error=denied'
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+	});
+});

--- a/packages/dtx-web/src/routes/auth/callback/server.test.ts
+++ b/packages/dtx-web/src/routes/auth/callback/server.test.ts
@@ -262,6 +262,39 @@ describe('/auth/callback', () => {
 		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
 	});
 
+	it('preserves session when getUserIdentities returns an error during linking', async () => {
+		// A signed-in user whose Google link callback hits an identities-lookup
+		// error (return, not throw) must keep their password session and be sent
+		// back to the account page with an error — not signed out and sent to
+		// /login like a Google-only login session.
+		const event = makeEventWithIdentitiesError(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
+			new Error('identity lookup failed')
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
+	});
+
+	it('preserves session when a link callback lacks the Google identity', async () => {
+		// The Google link did not actually attach the Google identity (e.g. the
+		// provider returned success but the identity is temporarily absent), yet
+		// the user still has their password identity. Preserve the session and
+		// report the error on the account page.
+		const event = makeEvent(
+			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',
+			null,
+			[{ provider: 'email' }]
+		);
+
+		await expect(GET(event as any)).rejects.toMatchObject({
+			location: `/app/account?auth_error=${GOOGLE_AUTH_GENERIC_MESSAGE.replaceAll(' ', '+')}`
+		});
+		expect(event.locals.supabase.auth.signOut).not.toHaveBeenCalled();
+	});
+
 	it('redirects account-linking to account page when exchangeCodeForSession returns an error', async () => {
 		const event = makeEvent(
 			'http://localhost/auth/callback?code=abc&link=google&next=/app/account',


### PR DESCRIPTION
## Summary
- Add Google OAuth helpers and entry point on the login page.
- Add `/auth/callback` endpoint to handle Google auth callbacks and link accounts.
- Add a Google account linking page and wire it from account settings.
- Preserve account linking callback errors and reject google-only sessions outside the linking flow.
- Add tests for helpers, callback server, account page, and login page.

#### Test plan
- [x] `bun run --filter=dtx-web test` passes
- [ ] Verify login with Google on local dev
- [ ] Verify account linking flow from settings

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Google sign-in for existing accounts and a Google “connect” option on the Account page, including web/desktop redirect support.
  - Added Google OAuth callback handling with connected/unavailable outcomes and automatic clearing of temporary URL messages.

- **Bug Fixes**
  - Improved Google error handling with clearer, sanitized messages (including cases like manual linking disabled and provider conflicts) and prevented unsafe redirect destinations.
  - Enhanced callback/session behavior to preserve desktop intent when relevant and to handle linking edge cases safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->