### PR TITLE
fix(desktop): editor cleanup, event listener refs, and sidebar width

### DIFF
--- a/__mocks__/phaser.ts
+++ b/__mocks__/phaser.ts
@@ -169,6 +169,16 @@ const Events = {
 	}
 };
 
+// Mock Phaser.Scenes (lifecycle event name constants used by scene code)
+const Scenes = {
+	Events: {
+		DESTROY: 'destroy',
+		SHUTDOWN: 'shutdown',
+		START: 'start',
+		READY: 'ready'
+	}
+};
+
 // Mock Phaser.Scene
 const Scene = class MockScene {
 	constructor(config = {}) {
@@ -256,10 +266,14 @@ const Scene = class MockScene {
 		pause: vi.fn(),
 		setVisible: vi.fn(),
 		isPaused: vi.fn().mockReturnValue(false),
+		isActive: vi.fn().mockReturnValue(true),
 		resume: vi.fn(),
 		launch: vi.fn(),
 		restart: vi.fn()
 	};
+
+	// Phaser Scene event emitter — used for lifecycle hooks (DESTROY, SHUTDOWN)
+	events = new Events.EventEmitter();
 
 	sound = {
 		add: vi.fn().mockReturnValue(new Sound.WebAudioSound()),
@@ -327,6 +341,7 @@ const Phaser = {
 	Sound,
 	Tweens,
 	Events,
+	Scenes,
 	Scene,
 	Math: {
 		Clamp: (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
@@ -344,5 +359,5 @@ const Phaser = {
 // Make Phaser available globally for tests
 globalThis.Phaser = Phaser;
 
-export { Scene, GameObjects, Sound, Tweens, Events, Geom, Input };
+export { Scene, GameObjects, Sound, Tweens, Events, Geom, Input, Scenes };
 export default Phaser;

--- a/packages/common/src/lib/game/scenes/BaseGame.test.ts
+++ b/packages/common/src/lib/game/scenes/BaseGame.test.ts
@@ -13,6 +13,10 @@ class TestableBaseGame extends BaseGame {
 		super({ key: 'TestableBaseGame' });
 	}
 
+	shutdown(): void {
+		// Test-only no-op implementation
+	}
+
 	drawFooterLane(laneConfig: LaneConfig, currentX: number): void {
 		// Mock implementation for testing
 		const sprite = this.add.rectangle(

--- a/packages/common/src/lib/game/scenes/BaseGame.ts
+++ b/packages/common/src/lib/game/scenes/BaseGame.ts
@@ -10,29 +10,56 @@ export abstract class BaseGame extends Phaser.Scene {
 	/**
 	 * Subclass cleanup for SHUTDOWN (scene.stop()/scene.restart()) and
 	 * DESTROY (game.destroy()). Must be idempotent — it is invoked from both
-	 * lifecycle listeners registered in the constructor, and may also be
-	 * called directly by restart() or tests.
+	 * lifecycle listeners registered in init(), and may also be called
+	 * directly by restart() or tests.
 	 */
 	abstract shutdown(): void;
 
+	/**
+	 * Per-instance guard preventing SHUTDOWN/DESTROY listener accumulation
+	 * across scene.restart() (which re-runs init()/create() on the same
+	 * instance). See init() for details.
+	 */
+	private lifecycleListenersRegistered = false;
+
 	constructor(config?: string | Phaser.Types.Scenes.SettingsConfig) {
 		super(config);
-		// Register lifecycle listeners once per scene instance. scene.restart()
-		// and scene.stop() emit SHUTDOWN (re-running init()/create() on restart,
-		// or leaving the scene dormant on stop) but neither emits DESTROY, so
-		// once-listeners registered in create() would accumulate across
-		// restarts and EventBus handlers would leak across scene.stop() calls
-		// (e.g. difficulty switching via editorScene.scene.stop() in
-		// DesktopEditor). The constructor runs only once per instance, avoiding
-		// both leaks. Phaser's game.destroy() emits DESTROY and calls
-		// removeAllListeners() on the scene's event emitter, but never invokes
-		// scene.shutdown(); the DESTROY listener ensures the module-singleton
-		// EventBus handlers are removed when the game is torn down, otherwise
-		// they leak and reference a destroyed scene whose sys is nulled. Both
-		// listeners call shutdown(), which must be idempotent so it is safe to
-		// invoke from both SHUTDOWN and DESTROY (and any explicit call).
+		// Lifecycle listeners are registered in init(), not here: Phaser only
+		// installs the scene's EventEmitter plugin (this.events) during
+		// sys.init(game), which SceneManager#createSceneFromInstance calls
+		// AFTER the constructor returns. Accessing this.events here throws in
+		// real Phaser (the __mocks__/phaser.ts mock initializes it as a class
+		// field, masking this). init() is the earliest post-injection hook.
+	}
+
+	/**
+	 * Register SHUTDOWN/DESTROY listeners once per scene instance. Phaser
+	 * injects this.events during sys.init() (called by SceneManager after the
+	 * constructor), so this is the earliest safe registration point.
+	 *
+	 * scene.restart() and scene.stop() emit SHUTDOWN (re-running init()/create()
+	 * on restart, or leaving the scene dormant on stop) but neither emits
+	 * DESTROY, so listeners registered without a guard would accumulate across
+	 * restarts and EventBus handlers would leak across scene.stop() calls
+	 * (e.g. difficulty switching via editorScene.scene.stop() in
+	 * DesktopEditor). The lifecycleListenersRegistered guard ensures
+	 * once-per-instance registration. Phaser's game.destroy() emits DESTROY and
+	 * calls removeAllListeners() on the scene's event emitter, but never
+	 * invokes scene.shutdown(); the DESTROY listener ensures the
+	 * module-singleton EventBus handlers are removed when the game is torn
+	 * down, otherwise they leak and reference a destroyed scene whose sys is
+	 * nulled. Both listeners call shutdown(), which must be idempotent so it
+	 * is safe to invoke from both SHUTDOWN and DESTROY (and any explicit call).
+	 *
+	 * Subclasses that override init() MUST call super.init(data) so these
+	 * listeners are registered.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	init(_data?: unknown) {
+		if (this.lifecycleListenersRegistered) return;
 		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.shutdown());
 		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.shutdown());
+		this.lifecycleListenersRegistered = true;
 	}
 
 	protected cellsPerMeasure = 16;

--- a/packages/common/src/lib/game/scenes/BaseGame.ts
+++ b/packages/common/src/lib/game/scenes/BaseGame.ts
@@ -6,6 +6,35 @@ import { calculateHighResolutionPosition } from '../utils/notePositioning';
 
 export abstract class BaseGame extends Phaser.Scene {
 	static measureLengthNoteID = '02';
+
+	/**
+	 * Subclass cleanup for SHUTDOWN (scene.stop()/scene.restart()) and
+	 * DESTROY (game.destroy()). Must be idempotent — it is invoked from both
+	 * lifecycle listeners registered in the constructor, and may also be
+	 * called directly by restart() or tests.
+	 */
+	abstract shutdown(): void;
+
+	constructor(config?: string | Phaser.Types.Scenes.SettingsConfig) {
+		super(config);
+		// Register lifecycle listeners once per scene instance. scene.restart()
+		// and scene.stop() emit SHUTDOWN (re-running init()/create() on restart,
+		// or leaving the scene dormant on stop) but neither emits DESTROY, so
+		// once-listeners registered in create() would accumulate across
+		// restarts and EventBus handlers would leak across scene.stop() calls
+		// (e.g. difficulty switching via editorScene.scene.stop() in
+		// DesktopEditor). The constructor runs only once per instance, avoiding
+		// both leaks. Phaser's game.destroy() emits DESTROY and calls
+		// removeAllListeners() on the scene's event emitter, but never invokes
+		// scene.shutdown(); the DESTROY listener ensures the module-singleton
+		// EventBus handlers are removed when the game is torn down, otherwise
+		// they leak and reference a destroyed scene whose sys is nulled. Both
+		// listeners call shutdown(), which must be idempotent so it is safe to
+		// invoke from both SHUTDOWN and DESTROY (and any explicit call).
+		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.shutdown());
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.shutdown());
+	}
+
 	protected cellsPerMeasure = 16;
 	protected cellWidth = 50;
 	protected cellHeight = 25;

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -226,6 +226,31 @@ describe('Editor Scene', () => {
 		expect(editorScene['autoSaveTimeout']).toBeNull();
 	});
 
+	it('removes its EventBus handlers on shutdown so a destroyed scene cannot redraw later', () => {
+		editorScene.create();
+
+		const eventBusOnMock = EventBus.on as MockedFn;
+		const registeredHandlers = [
+			EventType.MEASURE_UPDATE,
+			EventType.GRID_SPACING_UPDATE,
+			EventType.CELL_HEIGHT_UPDATE,
+			EventType.NOTE_IMPORT,
+			EventType.MEASURE_GOTO,
+			EventType.START_PREVIEW,
+			EventType.STOP_PREVIEW
+		].map((eventName) => {
+			const handler = eventBusOnMock.mock.calls.find((call) => call[0] === eventName)?.[1];
+			expect(handler).toEqual(expect.any(Function));
+			return [eventName, handler] as const;
+		});
+
+		editorScene.shutdown();
+
+		registeredHandlers.forEach(([eventName, handler]) => {
+			expect(EventBus.off).toHaveBeenCalledWith(eventName, handler);
+		});
+	});
+
 	it('should handle missing game container gracefully', () => {
 		// Mock getElementById to return null
 		vi.spyOn(document, 'getElementById').mockReturnValue(null);

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -293,6 +293,46 @@ describe('Editor Scene', () => {
 		});
 	});
 
+	it('removes its EventBus handlers when Phaser emits SHUTDOWN (scene.stop path)', () => {
+		// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
+		// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never
+		// re-runs the constructor. The SHUTDOWN listener registered in the
+		// constructor must remove the EventBus handlers so they do not leak
+		// across stop/start cycles (each create() re-adds them).
+		// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
+		// for on/emit/off, so this test manually invokes the captured SHUTDOWN
+		// callback rather than driving a real emit.
+		editorScene.create();
+
+		const eventBusOnMock = EventBus.on as MockedFn;
+		const registeredHandlers = [
+			EventType.MEASURE_UPDATE,
+			EventType.GRID_SPACING_UPDATE,
+			EventType.CELL_HEIGHT_UPDATE,
+			EventType.NOTE_IMPORT,
+			EventType.MEASURE_GOTO,
+			EventType.START_PREVIEW,
+			EventType.STOP_PREVIEW
+		].map((eventName) => {
+			const handler = eventBusOnMock.mock.calls.find((call) => call[0] === eventName)?.[1];
+			expect(handler).toEqual(expect.any(Function));
+			return [eventName, handler] as const;
+		});
+
+		// Simulate Phaser's Systems.shutdown() firing the SHUTDOWN listener
+		// registered via this.events.on(Phaser.Scenes.Events.SHUTDOWN, ...).
+		const onMock = editorScene.events.on as unknown as MockedFn;
+		const shutdownListener = onMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'shutdown'
+		)?.[1];
+		expect(shutdownListener).toEqual(expect.any(Function));
+		(shutdownListener as (() => void) | undefined)?.();
+
+		registeredHandlers.forEach(([eventName, handler]) => {
+			expect(EventBus.off).toHaveBeenCalledWith(eventName, handler);
+		});
+	});
+
 	it('removes its EventBus handlers on restart so stale handlers are not retained', () => {
 		editorScene.create();
 

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -251,6 +251,31 @@ describe('Editor Scene', () => {
 		});
 	});
 
+	it('removes its EventBus handlers on restart so stale handlers are not retained', () => {
+		editorScene.create();
+
+		const eventBusOnMock = EventBus.on as MockedFn;
+		const registeredHandlers = [
+			EventType.MEASURE_UPDATE,
+			EventType.GRID_SPACING_UPDATE,
+			EventType.CELL_HEIGHT_UPDATE,
+			EventType.NOTE_IMPORT,
+			EventType.MEASURE_GOTO,
+			EventType.START_PREVIEW,
+			EventType.STOP_PREVIEW
+		].map((eventName) => {
+			const handler = eventBusOnMock.mock.calls.find((call) => call[0] === eventName)?.[1];
+			expect(handler).toEqual(expect.any(Function));
+			return [eventName, handler] as const;
+		});
+
+		editorScene.restart();
+
+		registeredHandlers.forEach(([eventName, handler]) => {
+			expect(EventBus.off).toHaveBeenCalledWith(eventName, handler);
+		});
+	});
+
 	it('should handle missing game container gracefully', () => {
 		// Mock getElementById to return null
 		vi.spyOn(document, 'getElementById').mockReturnValue(null);

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -255,6 +255,13 @@ describe('Editor Scene', () => {
 		// Phaser's game.destroy() emits DESTROY on the scene's event emitter
 		// but never calls scene.shutdown(). The DESTROY listener registered in
 		// create() must remove the EventBus handlers so they do not leak.
+		// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
+		// for once/emit/off, so this test manually invokes the captured DESTROY
+		// callback rather than driving a real emit. This verifies the callback
+		// calls removeEventBusListeners(), but cannot verify Phaser actual
+		// emit-vs-removeAllListeners ordering (Systems.destroy emits DESTROY
+		// THEN calls removeAllListeners). Correct for Phaser 3.88 today; if
+		// Phaser reorders, this test would not catch the regression.
 		editorScene.create();
 
 		const eventBusOnMock = EventBus.on as MockedFn;

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -254,7 +254,8 @@ describe('Editor Scene', () => {
 	it('removes its EventBus handlers when Phaser emits DESTROY (game.destroy path)', () => {
 		// Phaser's game.destroy() emits DESTROY on the scene's event emitter
 		// but never calls scene.shutdown(). The DESTROY listener registered in
-		// create() must remove the EventBus handlers so they do not leak.
+		// BaseGame's constructor must remove the EventBus handlers so they do
+		// not leak.
 		// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
 		// for once/emit/off, so this test manually invokes the captured DESTROY
 		// callback rather than driving a real emit. This verifies the callback
@@ -296,9 +297,9 @@ describe('Editor Scene', () => {
 	it('removes its EventBus handlers when Phaser emits SHUTDOWN (scene.stop path)', () => {
 		// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
 		// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never
-		// re-runs the constructor. The SHUTDOWN listener registered in the
-		// constructor must remove the EventBus handlers so they do not leak
-		// across stop/start cycles (each create() re-adds them).
+		// re-runs the constructor. The SHUTDOWN listener registered in
+		// BaseGame's constructor must remove the EventBus handlers so they do
+		// not leak across stop/start cycles (each create() re-adds them).
 		// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
 		// for on/emit/off, so this test manually invokes the captured SHUTDOWN
 		// callback rather than driving a real emit.
@@ -331,6 +332,37 @@ describe('Editor Scene', () => {
 		registeredHandlers.forEach(([eventName, handler]) => {
 			expect(EventBus.off).toHaveBeenCalledWith(eventName, handler);
 		});
+	});
+
+	it('survives SHUTDOWN then DESTROY firing on the same instance (idempotent tearDown)', () => {
+		// Real-world sequence: scene.stop() emits SHUTDOWN (tearDown runs),
+		// then later game.destroy() emits DESTROY (tearDown runs again) on the
+		// same scene instance. tearDown() must be idempotent so the second
+		// call does not throw on already-nulled subscriptions / removed
+		// listeners. This is the load-bearing invariant for the
+		// constructor-registered listeners.
+		editorScene.create();
+
+		const onMock = editorScene.events.on as unknown as MockedFn;
+		const onceMock = editorScene.events.once as unknown as MockedFn;
+		const shutdownListener = onMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'shutdown'
+		)?.[1];
+		const destroyListener = onceMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'destroy'
+		)?.[1];
+		expect(shutdownListener).toEqual(expect.any(Function));
+		expect(destroyListener).toEqual(expect.any(Function));
+
+		expect(() => {
+			(shutdownListener as (() => void) | undefined)?.();
+			(destroyListener as (() => void) | undefined)?.();
+		}).not.toThrow();
+
+		// tearDown ran twice but EventBus.off is called at least once per
+		// handler (idempotent removeEventBusListeners re-off is safe).
+		expect(EventBus.off).toHaveBeenCalledWith(EventType.MEASURE_UPDATE, expect.any(Function));
+		expect(EventBus.off).toHaveBeenCalledWith(EventType.NOTE_IMPORT, expect.any(Function));
 	});
 
 	it('removes its EventBus handlers on restart so stale handlers are not retained', () => {
@@ -2243,6 +2275,31 @@ describe('Editor Scene', () => {
 			expect(restartSpy).toHaveBeenCalledWith({ measureCount: 10 });
 
 			restartSpy.mockRestore();
+		});
+
+		it('emits VALIDATION_ERROR when onNoteImport throws so the UI can surface it', async () => {
+			// autoSaveChart rejection (or any throw inside the try body) must not
+			// be swallowed silently — DesktopEditor listens for VALIDATION_ERROR
+			// and shows it in the UI. Only console.error would leave the user
+			// with a blank editor and no indication of failure.
+			editorScene.create();
+
+			vi.spyOn(editorScene as any, 'restart').mockImplementation(() => {});
+			vi.spyOn(editorScene as any, 'syncNotesToStore').mockImplementation(() => {});
+			vi.spyOn(editorScene, 'autoSaveChart').mockRejectedValue(new Error('disk full'));
+
+			const eventBusOnMock = EventBus.on as MockedFn;
+			const noteImportCallback = eventBusOnMock.mock.calls.find(
+				(call) => call[0] === EventType.NOTE_IMPORT
+			)?.[1];
+			expect(noteImportCallback).toBeDefined();
+
+			await noteImportCallback?.([], {});
+
+			expect(EventBus.emit).toHaveBeenCalledWith(
+				EventType.VALIDATION_ERROR,
+				expect.stringContaining('Failed to import notes')
+			);
 		});
 	});
 

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -251,6 +251,41 @@ describe('Editor Scene', () => {
 		});
 	});
 
+	it('removes its EventBus handlers when Phaser emits DESTROY (game.destroy path)', () => {
+		// Phaser's game.destroy() emits DESTROY on the scene's event emitter
+		// but never calls scene.shutdown(). The DESTROY listener registered in
+		// create() must remove the EventBus handlers so they do not leak.
+		editorScene.create();
+
+		const eventBusOnMock = EventBus.on as MockedFn;
+		const registeredHandlers = [
+			EventType.MEASURE_UPDATE,
+			EventType.GRID_SPACING_UPDATE,
+			EventType.CELL_HEIGHT_UPDATE,
+			EventType.NOTE_IMPORT,
+			EventType.MEASURE_GOTO,
+			EventType.START_PREVIEW,
+			EventType.STOP_PREVIEW
+		].map((eventName) => {
+			const handler = eventBusOnMock.mock.calls.find((call) => call[0] === eventName)?.[1];
+			expect(handler).toEqual(expect.any(Function));
+			return [eventName, handler] as const;
+		});
+
+		// Simulate Phaser's Systems.destroy() firing the DESTROY listener
+		// registered via this.events.once(Phaser.Scenes.Events.DESTROY, ...).
+		const onceMock = editorScene.events.once as unknown as MockedFn;
+		const destroyListener = onceMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'destroy'
+		)?.[1];
+		expect(destroyListener).toEqual(expect.any(Function));
+		(destroyListener as (() => void) | undefined)?.();
+
+		registeredHandlers.forEach(([eventName, handler]) => {
+			expect(EventBus.off).toHaveBeenCalledWith(eventName, handler);
+		});
+	});
+
 	it('removes its EventBus handlers on restart so stale handlers are not retained', () => {
 		editorScene.create();
 

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -254,8 +254,8 @@ describe('Editor Scene', () => {
 	it('removes its EventBus handlers when Phaser emits DESTROY (game.destroy path)', () => {
 		// Phaser's game.destroy() emits DESTROY on the scene's event emitter
 		// but never calls scene.shutdown(). The DESTROY listener registered in
-		// BaseGame's constructor must remove the EventBus handlers so they do
-		// not leak.
+		// BaseGame.init() must remove the EventBus handlers so they do not
+		// leak.
 		// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
 		// for once/emit/off, so this test manually invokes the captured DESTROY
 		// callback rather than driving a real emit. This verifies the callback
@@ -263,6 +263,10 @@ describe('Editor Scene', () => {
 		// emit-vs-removeAllListeners ordering (Systems.destroy emits DESTROY
 		// THEN calls removeAllListeners). Correct for Phaser 3.88 today; if
 		// Phaser reorders, this test would not catch the regression.
+		// init() is called before create() to mirror Phaser's lifecycle (init
+		// runs first, registering the SHUTDOWN/DESTROY listeners) and to
+		// exercise the post-injection registration path in BaseGame.init().
+		editorScene.init({});
 		editorScene.create();
 
 		const eventBusOnMock = EventBus.on as MockedFn;
@@ -298,11 +302,14 @@ describe('Editor Scene', () => {
 		// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
 		// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never
 		// re-runs the constructor. The SHUTDOWN listener registered in
-		// BaseGame's constructor must remove the EventBus handlers so they do
-		// not leak across stop/start cycles (each create() re-adds them).
+		// BaseGame.init() must remove the EventBus handlers so they do not
+		// leak across stop/start cycles (each create() re-adds them).
 		// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
 		// for on/emit/off, so this test manually invokes the captured SHUTDOWN
 		// callback rather than driving a real emit.
+		// init() is called before create() to mirror Phaser's lifecycle (init
+		// runs first, registering the SHUTDOWN/DESTROY listeners).
+		editorScene.init({});
 		editorScene.create();
 
 		const eventBusOnMock = EventBus.on as MockedFn;
@@ -340,7 +347,10 @@ describe('Editor Scene', () => {
 		// same scene instance. tearDown() must be idempotent so the second
 		// call does not throw on already-nulled subscriptions / removed
 		// listeners. This is the load-bearing invariant for the
-		// constructor-registered listeners.
+		// init()-registered listeners.
+		// init() is called before create() to mirror Phaser's lifecycle (init
+		// runs first, registering the SHUTDOWN/DESTROY listeners).
+		editorScene.init({});
 		editorScene.create();
 
 		const onMock = editorScene.events.on as unknown as MockedFn;

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -418,6 +418,83 @@ describe('Editor Scene', () => {
 		expect(EventBus.off).toHaveBeenCalledWith(EventType.NOTE_IMPORT, expect.any(Function));
 	});
 
+	it('unregisters input and keyboard handlers on shutdown', () => {
+		editorScene.create();
+
+		const inputOffMock = editorScene.input.off as MockedFn;
+		const keyboardOffMock = editorScene.input.keyboard?.off as MockedFn;
+
+		editorScene.shutdown();
+
+		// Verify scene input handlers are unregistered
+		expect(inputOffMock).toHaveBeenCalledWith('pointerdown');
+		expect(inputOffMock).toHaveBeenCalledWith('pointermove');
+		expect(inputOffMock).toHaveBeenCalledWith('pointerup');
+		expect(inputOffMock).toHaveBeenCalledWith('wheel');
+
+		// Verify keyboard handlers are unregistered
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-Q');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-BACKSPACE');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-DELETE');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-Z');
+	});
+
+	it('unregisters input and keyboard handlers when Phaser emits DESTROY', () => {
+		editorScene.init({});
+		editorScene.create();
+
+		const inputOffMock = editorScene.input.off as MockedFn;
+		const keyboardOffMock = editorScene.input.keyboard?.off as MockedFn;
+
+		// Simulate Phaser's Systems.destroy() firing the DESTROY listener
+		const onceMock = editorScene.events.once as unknown as MockedFn;
+		const destroyListener = onceMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'destroy'
+		)?.[1];
+		expect(destroyListener).toEqual(expect.any(Function));
+		(destroyListener as (() => void) | undefined)?.();
+
+		// Verify scene input handlers are unregistered
+		expect(inputOffMock).toHaveBeenCalledWith('pointerdown');
+		expect(inputOffMock).toHaveBeenCalledWith('pointermove');
+		expect(inputOffMock).toHaveBeenCalledWith('pointerup');
+		expect(inputOffMock).toHaveBeenCalledWith('wheel');
+
+		// Verify keyboard handlers are unregistered
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-Q');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-BACKSPACE');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-DELETE');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-Z');
+	});
+
+	it('unregisters input and keyboard handlers when Phaser emits SHUTDOWN', () => {
+		editorScene.init({});
+		editorScene.create();
+
+		const inputOffMock = editorScene.input.off as MockedFn;
+		const keyboardOffMock = editorScene.input.keyboard?.off as MockedFn;
+
+		// Simulate Phaser's Systems.shutdown() firing the SHUTDOWN listener
+		const onMock = editorScene.events.on as unknown as MockedFn;
+		const shutdownListener = onMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'shutdown'
+		)?.[1];
+		expect(shutdownListener).toEqual(expect.any(Function));
+		(shutdownListener as (() => void) | undefined)?.();
+
+		// Verify scene input handlers are unregistered
+		expect(inputOffMock).toHaveBeenCalledWith('pointerdown');
+		expect(inputOffMock).toHaveBeenCalledWith('pointermove');
+		expect(inputOffMock).toHaveBeenCalledWith('pointerup');
+		expect(inputOffMock).toHaveBeenCalledWith('wheel');
+
+		// Verify keyboard handlers are unregistered
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-Q');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-BACKSPACE');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-DELETE');
+		expect(keyboardOffMock).toHaveBeenCalledWith('keydown-Z');
+	});
+
 	it('removes its EventBus handlers on restart so stale handlers are not retained', () => {
 		editorScene.create();
 
@@ -2330,7 +2407,7 @@ describe('Editor Scene', () => {
 			restartSpy.mockRestore();
 		});
 
-		it('emits VALIDATION_ERROR when onNoteImport throws so the UI can surface it', async () => {
+		it('emits VALIDATION_ERROR when handleNoteImport throws so the UI can surface it', async () => {
 			// autoSaveChart rejection (or any throw inside the try body) must not
 			// be swallowed silently — DesktopEditor listens for VALIDATION_ERROR
 			// and shows it in the UI. Only console.error would leave the user
@@ -2353,6 +2430,34 @@ describe('Editor Scene', () => {
 				EventType.VALIDATION_ERROR,
 				expect.stringContaining('Failed to import notes')
 			);
+		});
+
+		it('skips restart when scene is torn down during handleNoteImport await', async () => {
+			// Liveness guard: if SHUTDOWN/DESTROY fires tearDown() while
+			// autoSaveChart() is awaited, isSceneActive becomes false and the
+			// post-import restart must be skipped to avoid operating on a
+			// torn-down scene.
+			editorScene.create();
+
+			const restartSpy = vi.spyOn(editorScene as any, 'restart').mockImplementation(() => {});
+			vi.spyOn(editorScene as any, 'syncNotesToStore').mockImplementation(() => {});
+
+			// Simulate tearDown() firing during the await by making autoSaveChart
+			// call shutdown() before resolving.
+			vi.spyOn(editorScene, 'autoSaveChart').mockImplementation(async () => {
+				editorScene.shutdown(); // sets isSceneActive = false via tearDown()
+			});
+
+			const eventBusOnMock = EventBus.on as MockedFn;
+			const noteImportCallback = eventBusOnMock.mock.calls.find(
+				(call) => call[0] === EventType.NOTE_IMPORT
+			)?.[1];
+
+			await noteImportCallback?.([], {});
+
+			expect(restartSpy).not.toHaveBeenCalled();
+
+			restartSpy.mockRestore();
 		});
 	});
 
@@ -2440,28 +2545,28 @@ describe('Editor Scene', () => {
 		});
 	});
 
-	describe('onGridSpacingUpdate and onCellHeightUpdate callbacks', () => {
-		it('should call updateGridSpacing when onGridSpacingUpdate is invoked', () => {
+	describe('handleGridSpacingUpdate and handleCellHeightUpdate callbacks', () => {
+		it('should call updateGridSpacing when handleGridSpacingUpdate is invoked', () => {
 			editorScene.create();
 
 			const updateGridSpacingSpy = vi
 				.spyOn(editorScene as any, 'updateGridSpacing')
 				.mockImplementation(() => {});
 
-			editorScene['onGridSpacingUpdate']?.(16);
+			editorScene['handleGridSpacingUpdate']?.(16);
 
 			expect(updateGridSpacingSpy).toHaveBeenCalledWith(16);
 			updateGridSpacingSpy.mockRestore();
 		});
 
-		it('should call updateCellHeight when onCellHeightUpdate is invoked', () => {
+		it('should call updateCellHeight when handleCellHeightUpdate is invoked', () => {
 			editorScene.create();
 
 			const updateCellHeightSpy = vi
 				.spyOn(editorScene as any, 'updateCellHeight')
 				.mockImplementation(() => {});
 
-			editorScene['onCellHeightUpdate']?.(30);
+			editorScene['handleCellHeightUpdate']?.(30);
 
 			expect(updateCellHeightSpy).toHaveBeenCalledWith(30);
 			updateCellHeightSpy.mockRestore();

--- a/packages/common/src/lib/game/scenes/Editor.test.ts
+++ b/packages/common/src/lib/game/scenes/Editor.test.ts
@@ -298,6 +298,49 @@ describe('Editor Scene', () => {
 		});
 	});
 
+	it('does not throw on DESTROY when InputPlugin.destroy() has nulled input.manager first', () => {
+		// Real Phaser DESTROY ordering (game.destroy() path):
+		// InputPlugin registers its DESTROY handler during BOOT (InputPlugin.boot,
+		// which runs on Systems.init's BOOT emit during scene *add*), BEFORE
+		// BaseGame.init() registers its DESTROY handler (during scene *start*).
+		// Systems.destroy emits DESTROY and EventEmitter fires handlers in
+		// registration order, so InputPlugin.destroy() runs first and nulls
+		// this.input.manager. Then BaseGame's DESTROY listener fires tearDown(),
+		// which calls this.input.setDefaultCursor('default') -> delegates to
+		// this.manager.setDefaultCursor -> TypeError on null. The throw aborts
+		// Systems.destroy() before removeAllListeners()/prop-nulling and can
+		// abort the SceneManager.destroy() loop, hanging remount.
+		// This test simulates that ordering by nulling input.manager (mimicking
+		// InputPlugin.destroy() having run) before invoking the DESTROY listener.
+		editorScene.init({});
+		editorScene.create();
+
+		// Mimic real InputPlugin.setDefaultCursor: delegates to manager, throws
+		// if manager was nulled by InputPlugin.destroy().
+		(editorScene.input as any).manager = { setDefaultCursor: vi.fn() };
+		(editorScene.input as any).setDefaultCursor = function (cursor: string) {
+			this.manager.setDefaultCursor(cursor);
+		};
+
+		// Simulate InputPlugin.destroy() having run before our DESTROY listener.
+		(editorScene.input as any).manager = null;
+
+		const onceMock = editorScene.events.once as unknown as MockedFn;
+		const destroyListener = onceMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'destroy'
+		)?.[1];
+		expect(destroyListener).toEqual(expect.any(Function));
+
+		// tearDown() must guard the plugin-dependent setDefaultCursor call so
+		// the DESTROY listener does not throw and abort Phaser teardown.
+		expect(() => {
+			(destroyListener as (() => void) | undefined)?.();
+		}).not.toThrow();
+
+		// EventBus handlers must still be removed on DESTROY despite the guard.
+		expect(EventBus.off).toHaveBeenCalledWith(EventType.MEASURE_UPDATE, expect.any(Function));
+	});
+
 	it('removes its EventBus handlers when Phaser emits SHUTDOWN (scene.stop path)', () => {
 		// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
 		// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -36,17 +36,124 @@ export class Editor extends BaseGame {
 	private isInitializing = false; // Flag to prevent auto-save during initialization
 	private isLoaded = false; // Flag to track if scene has finished loading and drawing
 	private soundFileHashCache: Map<File, string> = new Map(); // Cache file hashes to avoid recomputing
-	private onGridSpacingUpdate?: (cellsPerMeasure: number) => void;
-	private onCellHeightUpdate?: (height: number) => void;
-	private onMeasureUpdate?: (measureCount: number) => void;
-	private onNoteImport?: (
+	private readonly clampY = (newY: number) =>
+		Phaser.Math.Clamp(
+			newY,
+			0,
+			this.laneHeight - this.cameras.main.height + this.bottomMargin + this.cellMargin
+		);
+	private onGridSpacingUpdate = (cellsPerMeasure: number) => {
+		this.updateGridSpacing(cellsPerMeasure);
+	};
+	private onCellHeightUpdate = (height: number) => {
+		this.updateCellHeight(height);
+	};
+	private onMeasureUpdate = (measureCount: number) => {
+		this.measureCount = get(store.measureCount);
+		this.restart({ measureCount });
+	};
+	private onNoteImport = async (
 		notes: LaneMeasureNote[],
 		bpmNotes: Record<string, number>,
 		draftMeasureCount?: number
-	) => Promise<void>;
-	private onMeasureGoto?: (measure: number) => void;
-	private onStartPreview?: (bpm: number) => void;
-	private onStopPreview?: () => void;
+	) => {
+		// Mark as not loaded at the start of import process
+		this.isLoaded = false;
+		this.notes = {};
+		this.sound.removeAll();
+		notes.forEach((note) => {
+			if (!(note.laneID in this.notes)) {
+				this.notes[note.laneID] = [];
+			}
+			this.notes[note.laneID].push(note);
+		});
+		this.parseMesaureLength();
+		if (notes.length > 0) {
+			const maxMeasure = notes.reduce((max, note) => Math.max(max, note.measure), 0);
+			const baseMeasureCount = maxMeasure + 1;
+			this.measureCount = Math.max(baseMeasureCount, draftMeasureCount || 0);
+		} else {
+			// draftMeasureCount of 0 is invalid — treat as "not provided"
+			this.measureCount = draftMeasureCount || this.measureCount;
+		}
+		store.measureCount.set(this.measureCount);
+		this.bpmNotes = bpmNotes;
+		this.syncNotesToStore();
+		await this.autoSaveChart(); // Save immediately instead of debounced
+		this.setDirty(false); // Clear dirty state after importing notes
+		this.restart({ measureCount: this.measureCount });
+	};
+	private onMeasureGoto = (measure: number) => {
+		this.panelContainer.y = this.clampY(this.getTotalMesaureOffest(measure));
+	};
+	private onStartPreview = (bpm: number) => {
+		const currentMeasure = Math.floor(
+			this.panelContainer.y / (this.cellHeight * this.cellsPerMeasure)
+		);
+		this.scene.pause();
+		this.scene.setVisible(false);
+
+		// If preview scene doesn't exist, create it
+		if (!this.scene.isActive(Preview.key) && !this.scene.isPaused(Preview.key)) {
+			// Launch new preview
+			this.scene.launch(Preview.key, {
+				bpm: bpm,
+				bpmNotes: this.bpmNotes,
+				notes: this.notes,
+				measureCount: this.measureCount,
+				startMeasure: currentMeasure
+			});
+
+			// Clear dirty state after successful preview creation
+			this.setDirty(false);
+		} else if (this.isDirty) {
+			// Update existing scene data without recreating
+			const previewScene = this.scene.get(Preview.key) as Preview;
+			if (previewScene) {
+				// Update scene data
+				previewScene.updateData({
+					bpm: bpm,
+					bpmNotes: this.bpmNotes,
+					notes: this.notes,
+					measureCount: this.measureCount,
+					startMeasure: currentMeasure
+				});
+				this.scene.setVisible(true, Preview.key);
+				this.scene.resume(Preview.key);
+
+				// Clear dirty state after successful preview update
+				this.setDirty(false);
+			} else {
+				// Fallback to recreation if scene not found
+				this.scene.launch(Preview.key, {
+					bpm: bpm,
+					bpmNotes: this.bpmNotes,
+					notes: this.notes,
+					measureCount: this.measureCount,
+					startMeasure: currentMeasure
+				});
+
+				// Clear dirty state after successful preview creation
+				this.setDirty(false);
+			}
+		} else {
+			// Resume existing preview if no changes
+			this.scene.setVisible(true, Preview.key);
+			this.scene.resume(Preview.key);
+			EventBus.emit(EventType.RESUME_PREVIEW, {
+				startMeasure: currentMeasure
+			});
+		}
+	};
+	private onStopPreview = () => {
+		// Pause the preview scene to keep it alive for resume
+		if (this.scene.isActive(Preview.key)) {
+			this.scene.pause(Preview.key);
+			this.scene.setVisible(false, Preview.key);
+		}
+		this.scene.resume();
+		this.scene.setVisible(true);
+	};
 
 	// Store references to grid line graphics for direct access
 	private cellLinesGraphics: Phaser.GameObjects.Graphics | null = null;
@@ -87,15 +194,6 @@ export class Editor extends BaseGame {
 
 		this.drawPanel();
 		this.drawNotes();
-
-		// Helper function for clamping Y position (still needed for wheel scrolling)
-		const clampY = (newY: number) => {
-			return Phaser.Math.Clamp(
-				newY,
-				0,
-				this.laneHeight - this.cameras.main.height + this.bottomMargin + this.cellMargin
-			);
-		};
 
 		// Enable input events
 		this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
@@ -299,7 +397,7 @@ export class Editor extends BaseGame {
 			) => {
 				if (pointer.y < this.scale.height - this.bottomMargin) {
 					const newY = this.panelContainer.y - deltaY * 0.5;
-					this.panelContainer.y = clampY(newY);
+					this.panelContainer.y = this.clampY(newY);
 				}
 			}
 		);
@@ -333,127 +431,12 @@ export class Editor extends BaseGame {
 		this.setupKeyBindingListener();
 
 		EventBus.emit(EventType.SCENE_READY, this);
-		this.onMeasureUpdate = (measureCount: number) => {
-			this.measureCount = get(store.measureCount);
-			this.restart({ measureCount });
-		};
 		EventBus.on(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
-		this.onGridSpacingUpdate = (cellsPerMeasure: number) => {
-			this.updateGridSpacing(cellsPerMeasure);
-		};
-		this.onCellHeightUpdate = (height: number) => {
-			this.updateCellHeight(height);
-		};
 		EventBus.on(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
 		EventBus.on(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
-		this.onNoteImport = async (
-			notes: LaneMeasureNote[],
-			bpmNotes: Record<string, number>,
-			draftMeasureCount?: number
-		) => {
-			// Mark as not loaded at the start of import process
-			this.isLoaded = false;
-			this.notes = {};
-			this.sound.removeAll();
-			notes.forEach((note) => {
-				if (!(note.laneID in this.notes)) {
-					this.notes[note.laneID] = [];
-				}
-				this.notes[note.laneID].push(note);
-			});
-			this.parseMesaureLength();
-			if (notes.length > 0) {
-				const maxMeasure = notes.reduce((max, note) => Math.max(max, note.measure), 0);
-				const baseMeasureCount = maxMeasure + 1;
-				this.measureCount = Math.max(baseMeasureCount, draftMeasureCount || 0);
-			} else {
-				// draftMeasureCount of 0 is invalid — treat as "not provided"
-				this.measureCount = draftMeasureCount || this.measureCount;
-			}
-			store.measureCount.set(this.measureCount);
-			this.bpmNotes = bpmNotes;
-			this.syncNotesToStore();
-			await this.autoSaveChart(); // Save immediately instead of debounced
-			this.setDirty(false); // Clear dirty state after importing notes
-			this.restart({ measureCount: this.measureCount });
-		};
 		EventBus.on(EventType.NOTE_IMPORT, this.onNoteImport);
-
-		this.onMeasureGoto = (measure: number) => {
-			this.panelContainer.y = clampY(this.getTotalMesaureOffest(measure));
-		};
 		EventBus.on(EventType.MEASURE_GOTO, this.onMeasureGoto);
-
-		this.onStartPreview = (bpm: number) => {
-			const currentMeasure = Math.floor(
-				this.panelContainer.y / (this.cellHeight * this.cellsPerMeasure)
-			);
-			this.scene.pause();
-			this.scene.setVisible(false);
-
-			// If preview scene doesn't exist, create it
-			if (!this.scene.isActive(Preview.key) && !this.scene.isPaused(Preview.key)) {
-				// Launch new preview
-				this.scene.launch(Preview.key, {
-					bpm: bpm,
-					bpmNotes: this.bpmNotes,
-					notes: this.notes,
-					measureCount: this.measureCount,
-					startMeasure: currentMeasure
-				});
-
-				// Clear dirty state after successful preview creation
-				this.setDirty(false);
-			} else if (this.isDirty) {
-				// Update existing scene data without recreating
-				const previewScene = this.scene.get(Preview.key) as Preview;
-				if (previewScene) {
-					// Update scene data
-					previewScene.updateData({
-						bpm: bpm,
-						bpmNotes: this.bpmNotes,
-						notes: this.notes,
-						measureCount: this.measureCount,
-						startMeasure: currentMeasure
-					});
-					this.scene.setVisible(true, Preview.key);
-					this.scene.resume(Preview.key);
-
-					// Clear dirty state after successful preview update
-					this.setDirty(false);
-				} else {
-					// Fallback to recreation if scene not found
-					this.scene.launch(Preview.key, {
-						bpm: bpm,
-						bpmNotes: this.bpmNotes,
-						notes: this.notes,
-						measureCount: this.measureCount,
-						startMeasure: currentMeasure
-					});
-
-					// Clear dirty state after successful preview creation
-					this.setDirty(false);
-				}
-			} else {
-				// Resume existing preview if no changes
-				this.scene.setVisible(true, Preview.key);
-				this.scene.resume(Preview.key);
-				EventBus.emit(EventType.RESUME_PREVIEW, {
-					startMeasure: currentMeasure
-				});
-			}
-		};
 		EventBus.on(EventType.START_PREVIEW, this.onStartPreview);
-
-		this.onStopPreview = () => {
-			// Pause the preview scene to keep it alive for resume
-			if (this.scene.isActive(Preview.key)) {
-				this.scene.pause(Preview.key);
-				this.scene.setVisible(false, Preview.key);
-			}
-			this.scene.resume();
-			this.scene.setVisible(true);
-		};
 		EventBus.on(EventType.STOP_PREVIEW, this.onStopPreview);
 
 		// Listen for active note changes to update cursor
@@ -894,34 +877,13 @@ export class Editor extends BaseGame {
 	}
 
 	private removeEventBusListeners(): void {
-		if (this.onMeasureUpdate) {
-			EventBus.off(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
-			this.onMeasureUpdate = undefined;
-		}
-		if (this.onGridSpacingUpdate) {
-			EventBus.off(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
-			this.onGridSpacingUpdate = undefined;
-		}
-		if (this.onCellHeightUpdate) {
-			EventBus.off(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
-			this.onCellHeightUpdate = undefined;
-		}
-		if (this.onNoteImport) {
-			EventBus.off(EventType.NOTE_IMPORT, this.onNoteImport);
-			this.onNoteImport = undefined;
-		}
-		if (this.onMeasureGoto) {
-			EventBus.off(EventType.MEASURE_GOTO, this.onMeasureGoto);
-			this.onMeasureGoto = undefined;
-		}
-		if (this.onStartPreview) {
-			EventBus.off(EventType.START_PREVIEW, this.onStartPreview);
-			this.onStartPreview = undefined;
-		}
-		if (this.onStopPreview) {
-			EventBus.off(EventType.STOP_PREVIEW, this.onStopPreview);
-			this.onStopPreview = undefined;
-		}
+		EventBus.off(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
+		EventBus.off(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
+		EventBus.off(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
+		EventBus.off(EventType.NOTE_IMPORT, this.onNoteImport);
+		EventBus.off(EventType.MEASURE_GOTO, this.onMeasureGoto);
+		EventBus.off(EventType.START_PREVIEW, this.onStartPreview);
+		EventBus.off(EventType.STOP_PREVIEW, this.onStopPreview);
 	}
 
 	drawFooterLane(laneConfig: LaneConfig, currentX: number) {

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -173,6 +173,16 @@ export class Editor extends BaseGame {
 			this.setDirty(true);
 			this.debouncedAutoSave();
 		});
+		// Register the DESTROY listener once per scene instance. scene.restart()
+		// emits SHUTDOWN and re-runs init()/create(), but does NOT emit DESTROY,
+		// so a once-listener registered in create() would accumulate across
+		// restarts. The constructor runs only once per instance, avoiding the
+		// leak. Phaser's game.destroy() emits DESTROY and calls
+		// removeAllListeners() on the scene's event emitter, but never invokes
+		// scene.shutdown(); this listener ensures the module-singleton EventBus
+		// handlers are removed when the game is torn down, otherwise they leak
+		// and reference a destroyed scene whose sys is nulled.
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
 	}
 
 	init(data: Data) {
@@ -439,12 +449,8 @@ export class Editor extends BaseGame {
 		EventBus.on(EventType.START_PREVIEW, this.onStartPreview);
 		EventBus.on(EventType.STOP_PREVIEW, this.onStopPreview);
 
-		// Phaser's game.destroy() emits DESTROY and calls removeAllListeners() on
-		// the scene's event emitter, but never invokes scene.shutdown(). Register a
-		// DESTROY listener so the module-singleton EventBus handlers are removed
-		// when the game is torn down, otherwise they leak and reference a destroyed
-		// scene whose sys is nulled.
-		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
+		// DESTROY listener is registered in the constructor to avoid
+		// accumulation across scene.restart() (see constructor comment).
 
 		// Listen for active note changes to update cursor
 		this.activeNoteSubscription = store.activeNote.subscribe(() => {

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -186,15 +186,18 @@ export class Editor extends BaseGame {
 		// EventBus handlers are removed when the game is torn down, otherwise
 		// they leak and reference a destroyed scene whose sys is nulled. The
 		// SHUTDOWN listener runs the full tearDown() (cursor, context menu, key
-		// binding, autoSave, EventBus) to cover scene.stop()/scene.restart()
-		// paths where DESTROY never fires. tearDown() is idempotent, so it is
-		// safe to call from both the SHUTDOWN listener and restart(). The
-		// DESTROY listener only calls removeEventBusListeners() because
-		// this.input may be nulled by the time DESTROY fires during
-		// game.destroy(), and the other tearDown() steps are not needed when
-		// the entire game is going away.
+		// binding, autoSave, Svelte store subscriptions, EventBus) to cover
+		// scene.stop()/scene.restart() paths where DESTROY never fires. The
+		// DESTROY listener also calls tearDown() so the document-level keydown
+		// listener and Svelte store subscriptions are cleaned up on
+		// game.destroy(). tearDown() is idempotent, so it is safe to call from
+		// both the SHUTDOWN listener, the DESTROY listener, and restart(). At
+		// DESTROY emit time this.input is still valid: Phaser's Systems.destroy
+		// emits DESTROY before nulling its props list (which does not include
+		// 'input'), and the Editor's constructor-registered DESTROY listener
+		// fires before InputPlugin.destroy (registered at scene boot).
 		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.tearDown());
-		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.tearDown());
 	}
 
 	init(data: Data) {
@@ -832,10 +835,11 @@ export class Editor extends BaseGame {
 	}
 
 	/**
-	 * Shared cleanup between shutdown() and restart(). Idempotent: safe to call
-	 * from the SHUTDOWN listener and restart()/shutdown(), since
-	 * removeEventBusListeners(), enableBrowserContextMenu(), and
-	 * removeKeyBindingListener() are no-ops when already cleaned up, and
+	 * Shared cleanup between shutdown(), DESTROY, and restart(). Idempotent:
+	 * safe to call from the SHUTDOWN listener, the DESTROY listener, and
+	 * restart()/shutdown(), since removeEventBusListeners(),
+	 * enableBrowserContextMenu(), removeKeyBindingListener(), and the Svelte
+	 * store unsubscribe calls are no-ops when already cleaned up, and
 	 * autoSaveTimeout is null-guarded.
 	 */
 	private tearDown(): void {
@@ -850,6 +854,24 @@ export class Editor extends BaseGame {
 		if (this.autoSaveTimeout !== null) {
 			this.autoSaveTimeout.destroy();
 			this.autoSaveTimeout = null;
+		}
+		// Clean up Svelte store subscriptions to prevent leaks across
+		// scene.stop()/scene.restart() (SHUTDOWN) and game.destroy() (DESTROY)
+		if (this.activeNoteSubscription) {
+			this.activeNoteSubscription();
+			this.activeNoteSubscription = null;
+		}
+		if (this.keyBindingsSubscription) {
+			this.keyBindingsSubscription();
+			this.keyBindingsSubscription = null;
+		}
+		if (this.dtxFileSubscription) {
+			this.dtxFileSubscription();
+			this.dtxFileSubscription = null;
+		}
+		if (this.soundChipSubscription) {
+			this.soundChipSubscription();
+			this.soundChipSubscription = null;
 		}
 	}
 
@@ -867,30 +889,6 @@ export class Editor extends BaseGame {
 		this.input.keyboard?.off('keydown-BACKSPACE');
 		this.input.keyboard?.off('keydown-DELETE');
 		this.input.keyboard?.off('keydown-Z');
-
-		// Clean up active note subscription
-		if (this.activeNoteSubscription) {
-			this.activeNoteSubscription();
-			this.activeNoteSubscription = null;
-		}
-
-		// Clean up key bindings subscription
-		if (this.keyBindingsSubscription) {
-			this.keyBindingsSubscription();
-			this.keyBindingsSubscription = null;
-		}
-
-		// Clean up DTX file subscription
-		if (this.dtxFileSubscription) {
-			this.dtxFileSubscription();
-			this.dtxFileSubscription = null;
-		}
-
-		// Clean up sound chip subscription
-		if (this.soundChipSubscription) {
-			this.soundChipSubscription();
-			this.soundChipSubscription = null;
-		}
 
 		// Clean up drag state
 		this.noteManager.destroy();

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -184,14 +184,16 @@ export class Editor extends BaseGame {
 			this.setDirty(true);
 			this.debouncedAutoSave();
 		});
-		// SHUTDOWN/DESTROY listeners are registered by BaseGame's constructor.
-		// At DESTROY emit time this.input is still valid: Phaser's Systems.destroy
-		// emits DESTROY before nulling its props list (which does not include
-		// 'input'), and the DESTROY listener fires before InputPlugin.destroy
-		// (registered at scene boot).
+		// SHUTDOWN/DESTROY listeners are registered by BaseGame.init(), which
+		// runs before create() on every scene start/restart. At DESTROY emit
+		// time this.input is still valid: Phaser's Systems.destroy emits DESTROY
+		// before nulling its props list (which does not include 'input'), and
+		// the DESTROY listener fires before InputPlugin.destroy (registered at
+		// scene boot).
 	}
 
 	init(data: Data) {
+		super.init(data);
 		this.measureCount = data.measureCount || this.measureCount;
 	}
 
@@ -820,7 +822,7 @@ export class Editor extends BaseGame {
 
 	/**
 	 * Public teardown entry point. Auto-invoked by the SHUTDOWN and DESTROY
-	 * listeners registered in BaseGame's constructor. Delegates to tearDown()
+	 * listeners registered in BaseGame.init(). Delegates to tearDown()
 	 * which is idempotent, so repeated calls (SHUTDOWN then DESTROY, or
 	 * explicit restart() + listener) are safe.
 	 */

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -88,6 +88,10 @@ export class Editor extends BaseGame {
 			this.restart({ measureCount: this.measureCount });
 		} catch (error) {
 			console.error('[Editor] onNoteImport failed:', error);
+			EventBus.emit(
+				EventType.VALIDATION_ERROR,
+				`Failed to import notes: ${error instanceof Error ? error.message : String(error)}`
+			);
 		}
 	};
 	private readonly onMeasureGoto = (measure: number) => {
@@ -180,31 +184,11 @@ export class Editor extends BaseGame {
 			this.setDirty(true);
 			this.debouncedAutoSave();
 		});
-		// Register lifecycle listeners once per scene instance. scene.restart()
-		// and scene.stop() emit SHUTDOWN (re-running init()/create() on restart,
-		// or leaving the scene dormant on stop) but neither emits DESTROY, so
-		// once-listeners registered in create() would accumulate across
-		// restarts and EventBus handlers would leak across scene.stop() calls
-		// (e.g. difficulty switching via editorScene.scene.stop() in
-		// DesktopEditor). The constructor runs only once per instance, avoiding
-		// both leaks. Phaser's game.destroy() emits DESTROY and calls
-		// removeAllListeners() on the scene's event emitter, but never invokes
-		// scene.shutdown(); the DESTROY listener ensures the module-singleton
-		// EventBus handlers are removed when the game is torn down, otherwise
-		// they leak and reference a destroyed scene whose sys is nulled. The
-		// SHUTDOWN listener runs the full tearDown() (cursor, context menu, key
-		// binding, autoSave, Svelte store subscriptions, EventBus) to cover
-		// scene.stop()/scene.restart() paths where DESTROY never fires. The
-		// DESTROY listener also calls tearDown() so the document-level keydown
-		// listener and Svelte store subscriptions are cleaned up on
-		// game.destroy(). tearDown() is idempotent, so it is safe to call from
-		// both the SHUTDOWN listener, the DESTROY listener, and restart(). At
-		// DESTROY emit time this.input is still valid: Phaser's Systems.destroy
+		// SHUTDOWN/DESTROY listeners are registered by BaseGame's constructor.
+		// At DESTROY emit time this.input is still valid: Phaser's Systems.destroy
 		// emits DESTROY before nulling its props list (which does not include
-		// 'input'), and the Editor's constructor-registered DESTROY listener
-		// fires before InputPlugin.destroy (registered at scene boot).
-		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.tearDown());
-		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.tearDown());
+		// 'input'), and the DESTROY listener fires before InputPlugin.destroy
+		// (registered at scene boot).
 	}
 
 	init(data: Data) {
@@ -470,9 +454,6 @@ export class Editor extends BaseGame {
 		EventBus.on(EventType.MEASURE_GOTO, this.onMeasureGoto);
 		EventBus.on(EventType.START_PREVIEW, this.onStartPreview);
 		EventBus.on(EventType.STOP_PREVIEW, this.onStopPreview);
-
-		// DESTROY listener is registered in the constructor to avoid
-		// accumulation across scene.restart() (see constructor comment).
 
 		// Listen for active note changes to update cursor
 		this.activeNoteSubscription = store.activeNote.subscribe(() => {
@@ -838,11 +819,10 @@ export class Editor extends BaseGame {
 	}
 
 	/**
-	 * Public teardown entry point. Auto-invoked by the SHUTDOWN listener
-	 * registered in the constructor (scene.stop()/scene.restart() paths) and
-	 * the DESTROY listener (game.destroy() path), both of which call
-	 * tearDown() directly. Kept public for explicit callers and tests; the
-	 * underlying tearDown() is idempotent so repeated calls are safe.
+	 * Public teardown entry point. Auto-invoked by the SHUTDOWN and DESTROY
+	 * listeners registered in BaseGame's constructor. Delegates to tearDown()
+	 * which is idempotent, so repeated calls (SHUTDOWN then DESTROY, or
+	 * explicit restart() + listener) are safe.
 	 */
 	shutdown() {
 		this.tearDown();

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -38,6 +38,15 @@ export class Editor extends BaseGame {
 	private soundFileHashCache: Map<File, string> = new Map(); // Cache file hashes to avoid recomputing
 	private onGridSpacingUpdate?: (cellsPerMeasure: number) => void;
 	private onCellHeightUpdate?: (height: number) => void;
+	private onMeasureUpdate?: (measureCount: number) => void;
+	private onNoteImport?: (
+		notes: LaneMeasureNote[],
+		bpmNotes: Record<string, number>,
+		draftMeasureCount?: number
+	) => Promise<void>;
+	private onMeasureGoto?: (measure: number) => void;
+	private onStartPreview?: (bpm: number) => void;
+	private onStopPreview?: () => void;
 
 	// Store references to grid line graphics for direct access
 	private cellLinesGraphics: Phaser.GameObjects.Graphics | null = null;
@@ -324,10 +333,11 @@ export class Editor extends BaseGame {
 		this.setupKeyBindingListener();
 
 		EventBus.emit(EventType.SCENE_READY, this);
-		EventBus.on(EventType.MEASURE_UPDATE, (measureCount: number) => {
+		this.onMeasureUpdate = (measureCount: number) => {
 			this.measureCount = get(store.measureCount);
 			this.restart({ measureCount });
-		});
+		};
+		EventBus.on(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
 		this.onGridSpacingUpdate = (cellsPerMeasure: number) => {
 			this.updateGridSpacing(cellsPerMeasure);
 		};
@@ -336,46 +346,45 @@ export class Editor extends BaseGame {
 		};
 		EventBus.on(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
 		EventBus.on(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
-		EventBus.on(
-			EventType.NOTE_IMPORT,
-			async (
-				notes: LaneMeasureNote[],
-				bpmNotes: Record<string, number>,
-				draftMeasureCount?: number
-			) => {
-				// Mark as not loaded at the start of import process
-				this.isLoaded = false;
-				this.notes = {};
-				this.sound.removeAll();
-				notes.forEach((note) => {
-					if (!(note.laneID in this.notes)) {
-						this.notes[note.laneID] = [];
-					}
-					this.notes[note.laneID].push(note);
-				});
-				this.parseMesaureLength();
-				if (notes.length > 0) {
-					const maxMeasure = notes.reduce((max, note) => Math.max(max, note.measure), 0);
-					const baseMeasureCount = maxMeasure + 1;
-					this.measureCount = Math.max(baseMeasureCount, draftMeasureCount || 0);
-				} else {
-					// draftMeasureCount of 0 is invalid — treat as "not provided"
-					this.measureCount = draftMeasureCount || this.measureCount;
+		this.onNoteImport = async (
+			notes: LaneMeasureNote[],
+			bpmNotes: Record<string, number>,
+			draftMeasureCount?: number
+		) => {
+			// Mark as not loaded at the start of import process
+			this.isLoaded = false;
+			this.notes = {};
+			this.sound.removeAll();
+			notes.forEach((note) => {
+				if (!(note.laneID in this.notes)) {
+					this.notes[note.laneID] = [];
 				}
-				store.measureCount.set(this.measureCount);
-				this.bpmNotes = bpmNotes;
-				this.syncNotesToStore();
-				await this.autoSaveChart(); // Save immediately instead of debounced
-				this.setDirty(false); // Clear dirty state after importing notes
-				this.restart({ measureCount: this.measureCount });
+				this.notes[note.laneID].push(note);
+			});
+			this.parseMesaureLength();
+			if (notes.length > 0) {
+				const maxMeasure = notes.reduce((max, note) => Math.max(max, note.measure), 0);
+				const baseMeasureCount = maxMeasure + 1;
+				this.measureCount = Math.max(baseMeasureCount, draftMeasureCount || 0);
+			} else {
+				// draftMeasureCount of 0 is invalid — treat as "not provided"
+				this.measureCount = draftMeasureCount || this.measureCount;
 			}
-		);
+			store.measureCount.set(this.measureCount);
+			this.bpmNotes = bpmNotes;
+			this.syncNotesToStore();
+			await this.autoSaveChart(); // Save immediately instead of debounced
+			this.setDirty(false); // Clear dirty state after importing notes
+			this.restart({ measureCount: this.measureCount });
+		};
+		EventBus.on(EventType.NOTE_IMPORT, this.onNoteImport);
 
-		EventBus.on(EventType.MEASURE_GOTO, (measure: number) => {
+		this.onMeasureGoto = (measure: number) => {
 			this.panelContainer.y = clampY(this.getTotalMesaureOffest(measure));
-		});
+		};
+		EventBus.on(EventType.MEASURE_GOTO, this.onMeasureGoto);
 
-		EventBus.on(EventType.START_PREVIEW, (bpm: number) => {
+		this.onStartPreview = (bpm: number) => {
 			const currentMeasure = Math.floor(
 				this.panelContainer.y / (this.cellHeight * this.cellsPerMeasure)
 			);
@@ -433,9 +442,10 @@ export class Editor extends BaseGame {
 					startMeasure: currentMeasure
 				});
 			}
-		});
+		};
+		EventBus.on(EventType.START_PREVIEW, this.onStartPreview);
 
-		EventBus.on(EventType.STOP_PREVIEW, () => {
+		this.onStopPreview = () => {
 			// Pause the preview scene to keep it alive for resume
 			if (this.scene.isActive(Preview.key)) {
 				this.scene.pause(Preview.key);
@@ -443,7 +453,8 @@ export class Editor extends BaseGame {
 			}
 			this.scene.resume();
 			this.scene.setVisible(true);
-		});
+		};
+		EventBus.on(EventType.STOP_PREVIEW, this.onStopPreview);
 
 		// Listen for active note changes to update cursor
 		this.activeNoteSubscription = store.activeNote.subscribe(() => {
@@ -811,6 +822,7 @@ export class Editor extends BaseGame {
 	shutdown() {
 		// Reset cursor to default when shutting down
 		this.input.setDefaultCursor('default');
+		this.removeEventBusListeners();
 		// Clean up context menu event listener when scene shuts down
 		this.enableBrowserContextMenu();
 		// Clean up key binding listener to prevent memory leaks
@@ -827,13 +839,7 @@ export class Editor extends BaseGame {
 		this.isLoaded = false;
 		// Clear hash cache to avoid stale File references
 		this.soundFileHashCache.clear();
-		EventBus.off(EventType.MEASURE_UPDATE);
-		EventBus.off(EventType.GRID_SPACING_UPDATE);
-		EventBus.off(EventType.CELL_HEIGHT_UPDATE);
-		EventBus.off(EventType.NOTE_IMPORT);
-		EventBus.off(EventType.MEASURE_GOTO);
-		EventBus.off(EventType.START_PREVIEW);
-		EventBus.off(EventType.STOP_PREVIEW);
+		this.removeEventBusListeners();
 		this.input.off('pointerdown');
 		this.input.off('pointermove');
 		this.input.off('pointerup');
@@ -847,14 +853,6 @@ export class Editor extends BaseGame {
 		if (this.activeNoteSubscription) {
 			this.activeNoteSubscription();
 			this.activeNoteSubscription = null;
-		}
-
-		// Clean up EventBus listeners
-		if (this.onGridSpacingUpdate) {
-			EventBus.off(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
-		}
-		if (this.onCellHeightUpdate) {
-			EventBus.off(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
 		}
 
 		// Clean up key bindings subscription
@@ -893,6 +891,37 @@ export class Editor extends BaseGame {
 			this.autoSaveTimeout = null;
 		}
 		this.scene.restart(data);
+	}
+
+	private removeEventBusListeners(): void {
+		if (this.onMeasureUpdate) {
+			EventBus.off(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
+			this.onMeasureUpdate = undefined;
+		}
+		if (this.onGridSpacingUpdate) {
+			EventBus.off(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
+			this.onGridSpacingUpdate = undefined;
+		}
+		if (this.onCellHeightUpdate) {
+			EventBus.off(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
+			this.onCellHeightUpdate = undefined;
+		}
+		if (this.onNoteImport) {
+			EventBus.off(EventType.NOTE_IMPORT, this.onNoteImport);
+			this.onNoteImport = undefined;
+		}
+		if (this.onMeasureGoto) {
+			EventBus.off(EventType.MEASURE_GOTO, this.onMeasureGoto);
+			this.onMeasureGoto = undefined;
+		}
+		if (this.onStartPreview) {
+			EventBus.off(EventType.START_PREVIEW, this.onStartPreview);
+			this.onStartPreview = undefined;
+		}
+		if (this.onStopPreview) {
+			EventBus.off(EventType.STOP_PREVIEW, this.onStopPreview);
+			this.onStopPreview = undefined;
+		}
 	}
 
 	drawFooterLane(laneConfig: LaneConfig, currentX: number) {

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -42,51 +42,58 @@ export class Editor extends BaseGame {
 			0,
 			this.laneHeight - this.cameras.main.height + this.bottomMargin + this.cellMargin
 		);
-	private onGridSpacingUpdate = (cellsPerMeasure: number) => {
+	private readonly onGridSpacingUpdate = (cellsPerMeasure: number) => {
 		this.updateGridSpacing(cellsPerMeasure);
 	};
-	private onCellHeightUpdate = (height: number) => {
+	private readonly onCellHeightUpdate = (height: number) => {
 		this.updateCellHeight(height);
 	};
-	private onMeasureUpdate = (measureCount: number) => {
+	private readonly onMeasureUpdate = (measureCount: number) => {
 		this.measureCount = get(store.measureCount);
 		this.restart({ measureCount });
 	};
-	private onNoteImport = async (
+	private readonly onNoteImport = async (
 		notes: LaneMeasureNote[],
 		bpmNotes: Record<string, number>,
 		draftMeasureCount?: number
 	) => {
-		// Mark as not loaded at the start of import process
-		this.isLoaded = false;
-		this.notes = {};
-		this.sound.removeAll();
-		notes.forEach((note) => {
-			if (!(note.laneID in this.notes)) {
-				this.notes[note.laneID] = [];
+		// EventBus.emit is synchronous and does not await the returned promise,
+		// so a throw here would surface as an unhandled rejection. Wrap the
+		// body so failures are logged instead of swallowed silently.
+		try {
+			// Mark as not loaded at the start of import process
+			this.isLoaded = false;
+			this.notes = {};
+			this.sound.removeAll();
+			notes.forEach((note) => {
+				if (!(note.laneID in this.notes)) {
+					this.notes[note.laneID] = [];
+				}
+				this.notes[note.laneID].push(note);
+			});
+			this.parseMesaureLength();
+			if (notes.length > 0) {
+				const maxMeasure = notes.reduce((max, note) => Math.max(max, note.measure), 0);
+				const baseMeasureCount = maxMeasure + 1;
+				this.measureCount = Math.max(baseMeasureCount, draftMeasureCount || 0);
+			} else {
+				// draftMeasureCount of 0 is invalid — treat as "not provided"
+				this.measureCount = draftMeasureCount || this.measureCount;
 			}
-			this.notes[note.laneID].push(note);
-		});
-		this.parseMesaureLength();
-		if (notes.length > 0) {
-			const maxMeasure = notes.reduce((max, note) => Math.max(max, note.measure), 0);
-			const baseMeasureCount = maxMeasure + 1;
-			this.measureCount = Math.max(baseMeasureCount, draftMeasureCount || 0);
-		} else {
-			// draftMeasureCount of 0 is invalid — treat as "not provided"
-			this.measureCount = draftMeasureCount || this.measureCount;
+			store.measureCount.set(this.measureCount);
+			this.bpmNotes = bpmNotes;
+			this.syncNotesToStore();
+			await this.autoSaveChart(); // Save immediately instead of debounced
+			this.setDirty(false); // Clear dirty state after importing notes
+			this.restart({ measureCount: this.measureCount });
+		} catch (error) {
+			console.error('[Editor] onNoteImport failed:', error);
 		}
-		store.measureCount.set(this.measureCount);
-		this.bpmNotes = bpmNotes;
-		this.syncNotesToStore();
-		await this.autoSaveChart(); // Save immediately instead of debounced
-		this.setDirty(false); // Clear dirty state after importing notes
-		this.restart({ measureCount: this.measureCount });
 	};
-	private onMeasureGoto = (measure: number) => {
+	private readonly onMeasureGoto = (measure: number) => {
 		this.panelContainer.y = this.clampY(this.getTotalMesaureOffest(measure));
 	};
-	private onStartPreview = (bpm: number) => {
+	private readonly onStartPreview = (bpm: number) => {
 		const currentMeasure = Math.floor(
 			this.panelContainer.y / (this.cellHeight * this.cellsPerMeasure)
 		);
@@ -145,7 +152,7 @@ export class Editor extends BaseGame {
 			});
 		}
 	};
-	private onStopPreview = () => {
+	private readonly onStopPreview = () => {
 		// Pause the preview scene to keep it alive for resume
 		if (this.scene.isActive(Preview.key)) {
 			this.scene.pause(Preview.key);
@@ -830,6 +837,13 @@ export class Editor extends BaseGame {
 		return true;
 	}
 
+	/**
+	 * Public teardown entry point. Auto-invoked by the SHUTDOWN listener
+	 * registered in the constructor (scene.stop()/scene.restart() paths) and
+	 * the DESTROY listener (game.destroy() path), both of which call
+	 * tearDown() directly. Kept public for explicit callers and tests; the
+	 * underlying tearDown() is idempotent so repeated calls are safe.
+	 */
 	shutdown() {
 		this.tearDown();
 	}

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -840,8 +840,17 @@ export class Editor extends BaseGame {
 	 */
 	private tearDown(): void {
 		this.removeEventBusListeners();
-		// Reset cursor to default
-		this.input.setDefaultCursor('default');
+		// Reset cursor to default. Guard: on the DESTROY path (game.destroy()),
+		// InputPlugin registers its DESTROY handler during BOOT (before
+		// BaseGame.init() registers this listener), so InputPlugin.destroy()
+		// runs first and nulls this.input.manager. Calling setDefaultCursor
+		// then throws TypeError, aborting Systems.destroy() before it nulls
+		// props/removeAllListeners and potentially hanging SceneManager.destroy
+		// (and remount). On SHUTDOWN the input plugin is still alive, so the
+		// cursor reset still runs.
+		if (this.input?.manager) {
+			this.input.setDefaultCursor('default');
+		}
 		// Clean up context menu event listener
 		this.enableBrowserContextMenu();
 		// Clean up key binding listener to prevent memory leaks

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -35,6 +35,7 @@ export class Editor extends BaseGame {
 	private keyBindings: Record<string, string> = {}; // key -> noteId mapping
 	private isInitializing = false; // Flag to prevent auto-save during initialization
 	private isLoaded = false; // Flag to track if scene has finished loading and drawing
+	private isSceneActive = false; // Liveness guard: false after tearDown(), true after create()
 	private soundFileHashCache: Map<File, string> = new Map(); // Cache file hashes to avoid recomputing
 	private readonly clampY = (newY: number) =>
 		Phaser.Math.Clamp(
@@ -42,17 +43,17 @@ export class Editor extends BaseGame {
 			0,
 			this.laneHeight - this.cameras.main.height + this.bottomMargin + this.cellMargin
 		);
-	private readonly onGridSpacingUpdate = (cellsPerMeasure: number) => {
+	private readonly handleGridSpacingUpdate = (cellsPerMeasure: number) => {
 		this.updateGridSpacing(cellsPerMeasure);
 	};
-	private readonly onCellHeightUpdate = (height: number) => {
+	private readonly handleCellHeightUpdate = (height: number) => {
 		this.updateCellHeight(height);
 	};
-	private readonly onMeasureUpdate = (measureCount: number) => {
+	private readonly handleMeasureUpdate = (measureCount: number) => {
 		this.measureCount = get(store.measureCount);
 		this.restart({ measureCount });
 	};
-	private readonly onNoteImport = async (
+	private readonly handleNoteImport = async (
 		notes: LaneMeasureNote[],
 		bpmNotes: Record<string, number>,
 		draftMeasureCount?: number
@@ -84,20 +85,24 @@ export class Editor extends BaseGame {
 			this.bpmNotes = bpmNotes;
 			this.syncNotesToStore();
 			await this.autoSaveChart(); // Save immediately instead of debounced
+			// Liveness guard: the await above can allow SHUTDOWN/DESTROY to
+			// fire tearDown() mid-import. Skip the restart path if the scene
+			// is no longer active so we don't operate on a torn-down scene.
+			if (!this.isSceneActive) return;
 			this.setDirty(false); // Clear dirty state after importing notes
 			this.restart({ measureCount: this.measureCount });
 		} catch (error) {
-			console.error('[Editor] onNoteImport failed:', error);
+			console.error('[Editor] handleNoteImport failed:', error);
 			EventBus.emit(
 				EventType.VALIDATION_ERROR,
 				`Failed to import notes: ${error instanceof Error ? error.message : String(error)}`
 			);
 		}
 	};
-	private readonly onMeasureGoto = (measure: number) => {
+	private readonly handleMeasureGoto = (measure: number) => {
 		this.panelContainer.y = this.clampY(this.getTotalMesaureOffest(measure));
 	};
-	private readonly onStartPreview = (bpm: number) => {
+	private readonly handleStartPreview = (bpm: number) => {
 		const currentMeasure = Math.floor(
 			this.panelContainer.y / (this.cellHeight * this.cellsPerMeasure)
 		);
@@ -156,7 +161,7 @@ export class Editor extends BaseGame {
 			});
 		}
 	};
-	private readonly onStopPreview = () => {
+	private readonly handleStopPreview = () => {
 		// Pause the preview scene to keep it alive for resume
 		if (this.scene.isActive(Preview.key)) {
 			this.scene.pause(Preview.key);
@@ -449,13 +454,13 @@ export class Editor extends BaseGame {
 		this.setupKeyBindingListener();
 
 		EventBus.emit(EventType.SCENE_READY, this);
-		EventBus.on(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
-		EventBus.on(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
-		EventBus.on(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
-		EventBus.on(EventType.NOTE_IMPORT, this.onNoteImport);
-		EventBus.on(EventType.MEASURE_GOTO, this.onMeasureGoto);
-		EventBus.on(EventType.START_PREVIEW, this.onStartPreview);
-		EventBus.on(EventType.STOP_PREVIEW, this.onStopPreview);
+		EventBus.on(EventType.MEASURE_UPDATE, this.handleMeasureUpdate);
+		EventBus.on(EventType.GRID_SPACING_UPDATE, this.handleGridSpacingUpdate);
+		EventBus.on(EventType.CELL_HEIGHT_UPDATE, this.handleCellHeightUpdate);
+		EventBus.on(EventType.NOTE_IMPORT, this.handleNoteImport);
+		EventBus.on(EventType.MEASURE_GOTO, this.handleMeasureGoto);
+		EventBus.on(EventType.START_PREVIEW, this.handleStartPreview);
+		EventBus.on(EventType.STOP_PREVIEW, this.handleStopPreview);
 
 		// Listen for active note changes to update cursor
 		this.activeNoteSubscription = store.activeNote.subscribe(() => {
@@ -498,6 +503,7 @@ export class Editor extends BaseGame {
 
 		// All drawing operations are synchronous, so scene is loaded when create() completes
 		this.markAsLoaded();
+		this.isSceneActive = true;
 	}
 
 	update() {
@@ -836,9 +842,12 @@ export class Editor extends BaseGame {
 	 * restart()/shutdown(), since removeEventBusListeners(),
 	 * enableBrowserContextMenu(), removeKeyBindingListener(), and the Svelte
 	 * store unsubscribe calls are no-ops when already cleaned up, and
-	 * autoSaveTimeout is null-guarded.
+	 * autoSaveTimeout is null-guarded. NoteManager.destroy() is also
+	 * idempotent (Phaser GameObject.destroy guards on !this.scene, and all
+	 * DOM listener removals are null-guarded).
 	 */
 	private tearDown(): void {
+		this.isSceneActive = false;
 		this.removeEventBusListeners();
 		// Reset cursor to default. Guard: on the DESTROY path (game.destroy()),
 		// InputPlugin registers its DESTROY handler during BOOT (before
@@ -851,10 +860,26 @@ export class Editor extends BaseGame {
 		if (this.input?.manager) {
 			this.input.setDefaultCursor('default');
 		}
+		// Unregister scene input/keyboard handlers so they do not leak across
+		// non-restart shutdown/start cycles (scene.stop() then scene.start()).
+		// Phaser's InputPlugin.shutdown/destroy also clears these, but
+		// centralizing here ensures cleanup on every teardown path.
+		this.input?.off('pointerdown');
+		this.input?.off('pointermove');
+		this.input?.off('pointerup');
+		this.input?.off('wheel');
+		this.input?.keyboard?.off('keydown-Q');
+		this.input?.keyboard?.off('keydown-BACKSPACE');
+		this.input?.keyboard?.off('keydown-DELETE');
+		this.input?.keyboard?.off('keydown-Z');
 		// Clean up context menu event listener
 		this.enableBrowserContextMenu();
 		// Clean up key binding listener to prevent memory leaks
 		this.removeKeyBindingListener();
+		// Clean up NoteManager: removes global DOM listeners (keydown/mousemove
+		// on document) that Phaser's scene shutdown does NOT handle, plus
+		// selection overlays and drag state.
+		this.noteManager.destroy();
 		// Clean up auto-save timeout
 		if (this.autoSaveTimeout !== null) {
 			this.autoSaveTimeout.destroy();
@@ -886,32 +911,17 @@ export class Editor extends BaseGame {
 		// Clear hash cache to avoid stale File references
 		this.soundFileHashCache.clear();
 		this.tearDown();
-		this.input.off('pointerdown');
-		this.input.off('pointermove');
-		this.input.off('pointerup');
-		this.input.off('wheel');
-		this.input.keyboard?.off('keydown-Q');
-		this.input.keyboard?.off('keydown-BACKSPACE');
-		this.input.keyboard?.off('keydown-DELETE');
-		this.input.keyboard?.off('keydown-Z');
-
-		// Clean up drag state
-		this.noteManager.destroy();
-
-		// Clear undo history when restarting
-		this.noteManager.clearUndoHistory();
-
 		this.scene.restart(data);
 	}
 
 	private removeEventBusListeners(): void {
-		EventBus.off(EventType.MEASURE_UPDATE, this.onMeasureUpdate);
-		EventBus.off(EventType.GRID_SPACING_UPDATE, this.onGridSpacingUpdate);
-		EventBus.off(EventType.CELL_HEIGHT_UPDATE, this.onCellHeightUpdate);
-		EventBus.off(EventType.NOTE_IMPORT, this.onNoteImport);
-		EventBus.off(EventType.MEASURE_GOTO, this.onMeasureGoto);
-		EventBus.off(EventType.START_PREVIEW, this.onStartPreview);
-		EventBus.off(EventType.STOP_PREVIEW, this.onStopPreview);
+		EventBus.off(EventType.MEASURE_UPDATE, this.handleMeasureUpdate);
+		EventBus.off(EventType.GRID_SPACING_UPDATE, this.handleGridSpacingUpdate);
+		EventBus.off(EventType.CELL_HEIGHT_UPDATE, this.handleCellHeightUpdate);
+		EventBus.off(EventType.NOTE_IMPORT, this.handleNoteImport);
+		EventBus.off(EventType.MEASURE_GOTO, this.handleMeasureGoto);
+		EventBus.off(EventType.START_PREVIEW, this.handleStartPreview);
+		EventBus.off(EventType.STOP_PREVIEW, this.handleStopPreview);
 	}
 
 	drawFooterLane(laneConfig: LaneConfig, currentX: number) {

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -173,15 +173,27 @@ export class Editor extends BaseGame {
 			this.setDirty(true);
 			this.debouncedAutoSave();
 		});
-		// Register the DESTROY listener once per scene instance. scene.restart()
-		// emits SHUTDOWN and re-runs init()/create(), but does NOT emit DESTROY,
-		// so a once-listener registered in create() would accumulate across
-		// restarts. The constructor runs only once per instance, avoiding the
-		// leak. Phaser's game.destroy() emits DESTROY and calls
+		// Register lifecycle listeners once per scene instance. scene.restart()
+		// and scene.stop() emit SHUTDOWN (re-running init()/create() on restart,
+		// or leaving the scene dormant on stop) but neither emits DESTROY, so
+		// once-listeners registered in create() would accumulate across
+		// restarts and EventBus handlers would leak across scene.stop() calls
+		// (e.g. difficulty switching via editorScene.scene.stop() in
+		// DesktopEditor). The constructor runs only once per instance, avoiding
+		// both leaks. Phaser's game.destroy() emits DESTROY and calls
 		// removeAllListeners() on the scene's event emitter, but never invokes
-		// scene.shutdown(); this listener ensures the module-singleton EventBus
-		// handlers are removed when the game is torn down, otherwise they leak
-		// and reference a destroyed scene whose sys is nulled.
+		// scene.shutdown(); the DESTROY listener ensures the module-singleton
+		// EventBus handlers are removed when the game is torn down, otherwise
+		// they leak and reference a destroyed scene whose sys is nulled. The
+		// SHUTDOWN listener runs the full tearDown() (cursor, context menu, key
+		// binding, autoSave, EventBus) to cover scene.stop()/scene.restart()
+		// paths where DESTROY never fires. tearDown() is idempotent, so it is
+		// safe to call from both the SHUTDOWN listener and restart(). The
+		// DESTROY listener only calls removeEventBusListeners() because
+		// this.input may be nulled by the time DESTROY fires during
+		// game.destroy(), and the other tearDown() steps are not needed when
+		// the entire game is going away.
+		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.tearDown());
 		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
 	}
 
@@ -816,10 +828,21 @@ export class Editor extends BaseGame {
 	}
 
 	shutdown() {
-		// Reset cursor to default when shutting down
-		this.input.setDefaultCursor('default');
+		this.tearDown();
+	}
+
+	/**
+	 * Shared cleanup between shutdown() and restart(). Idempotent: safe to call
+	 * from the SHUTDOWN listener and restart()/shutdown(), since
+	 * removeEventBusListeners(), enableBrowserContextMenu(), and
+	 * removeKeyBindingListener() are no-ops when already cleaned up, and
+	 * autoSaveTimeout is null-guarded.
+	 */
+	private tearDown(): void {
 		this.removeEventBusListeners();
-		// Clean up context menu event listener when scene shuts down
+		// Reset cursor to default
+		this.input.setDefaultCursor('default');
+		// Clean up context menu event listener
 		this.enableBrowserContextMenu();
 		// Clean up key binding listener to prevent memory leaks
 		this.removeKeyBindingListener();
@@ -835,7 +858,7 @@ export class Editor extends BaseGame {
 		this.isLoaded = false;
 		// Clear hash cache to avoid stale File references
 		this.soundFileHashCache.clear();
-		this.removeEventBusListeners();
+		this.tearDown();
 		this.input.off('pointerdown');
 		this.input.off('pointermove');
 		this.input.off('pointerup');
@@ -875,17 +898,6 @@ export class Editor extends BaseGame {
 		// Clear undo history when restarting
 		this.noteManager.clearUndoHistory();
 
-		// Reset cursor to default when restarting
-		this.input.setDefaultCursor('default');
-		// Re-enable browser context menu when restarting
-		this.enableBrowserContextMenu();
-		// Clean up key binding listener to prevent memory leaks
-		this.removeKeyBindingListener();
-		// Clean up auto-save timeout
-		if (this.autoSaveTimeout !== null) {
-			this.autoSaveTimeout.destroy();
-			this.autoSaveTimeout = null;
-		}
 		this.scene.restart(data);
 	}
 

--- a/packages/common/src/lib/game/scenes/Editor.ts
+++ b/packages/common/src/lib/game/scenes/Editor.ts
@@ -439,6 +439,13 @@ export class Editor extends BaseGame {
 		EventBus.on(EventType.START_PREVIEW, this.onStartPreview);
 		EventBus.on(EventType.STOP_PREVIEW, this.onStopPreview);
 
+		// Phaser's game.destroy() emits DESTROY and calls removeAllListeners() on
+		// the scene's event emitter, but never invokes scene.shutdown(). Register a
+		// DESTROY listener so the module-singleton EventBus handlers are removed
+		// when the game is torn down, otherwise they leak and reference a destroyed
+		// scene whose sys is nulled.
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
+
 		// Listen for active note changes to update cursor
 		this.activeNoteSubscription = store.activeNote.subscribe(() => {
 			if (this.isEditing) {

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -830,6 +830,13 @@ describe('Preview Scene', () => {
 			// Phaser's game.destroy() emits DESTROY on the scene's event emitter
 			// but never calls scene.shutdown(). The DESTROY listener registered in
 			// create() must remove the EventBus handlers so they do not leak.
+			// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
+			// for once/emit/off, so this test manually invokes the captured DESTROY
+			// callback rather than driving a real emit. This verifies the callback
+			// calls removeEventBusListeners(), but cannot verify Phaser actual
+			// emit-vs-removeAllListeners ordering (Systems.destroy emits DESTROY
+			// THEN calls removeAllListeners). Correct for Phaser 3.88 today; if
+			// Phaser reorders, this test would not catch the regression.
 			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
 			(Preview as any).animationsCreated = true;
 
@@ -848,6 +855,41 @@ describe('Preview Scene', () => {
 			)?.[1];
 			expect(destroyListener).toEqual(expect.any(Function));
 			(destroyListener as (() => void) | undefined)?.();
+
+			expect(EventBus.off).toHaveBeenCalledWith(
+				EventType.STOP_PREVIEW,
+				previewScene['boundStopPreview']
+			);
+			expect(EventBus.off).toHaveBeenCalledWith(
+				EventType.RESUME_PREVIEW,
+				previewScene['boundResumePreview']
+			);
+		});
+
+		it('removes EventBus handlers when Phaser emits SHUTDOWN (scene.stop path)', async () => {
+			// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
+			// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never
+			// re-runs the constructor. The SHUTDOWN listener registered in the
+			// constructor must remove the EventBus handlers so they do not leak
+			// across stop/start cycles (each create() re-adds them).
+			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
+			(Preview as any).animationsCreated = true;
+
+			vi.spyOn(previewScene as any, 'drawPanel').mockImplementation(() => {});
+			vi.spyOn(previewScene as any, 'drawNotes').mockImplementation(() => {});
+			vi.spyOn(previewScene as any, 'setupSoundsAsync').mockResolvedValue(undefined);
+			vi.spyOn(previewScene as any, 'startPreview').mockImplementation(() => {});
+
+			await previewScene.create();
+
+			// Simulate Phaser's Systems.shutdown() firing the SHUTDOWN listener
+			// registered via this.events.on(Phaser.Scenes.Events.SHUTDOWN, ...).
+			const onMock = previewScene.events.on as unknown as MockedFn;
+			const shutdownListener = onMock.mock.calls.find(
+				(call: unknown[]) => call[0] === 'shutdown'
+			)?.[1];
+			expect(shutdownListener).toEqual(expect.any(Function));
+			(shutdownListener as (() => void) | undefined)?.();
 
 			expect(EventBus.off).toHaveBeenCalledWith(
 				EventType.STOP_PREVIEW,

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -828,8 +828,9 @@ describe('Preview Scene', () => {
 
 		it('removes EventBus handlers when Phaser emits DESTROY (game.destroy path)', async () => {
 			// Phaser's game.destroy() emits DESTROY on the scene's event emitter
-			// but never calls scene.shutdown(). The DESTROY listener registered in
-			// create() must remove the EventBus handlers so they do not leak.
+			// but never calls scene.shutdown(). The DESTROY listener registered
+			// in BaseGame's constructor must remove the EventBus handlers so
+			// they do not leak.
 			// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
 			// for once/emit/off, so this test manually invokes the captured DESTROY
 			// callback rather than driving a real emit. This verifies the callback
@@ -869,9 +870,9 @@ describe('Preview Scene', () => {
 		it('removes EventBus handlers when Phaser emits SHUTDOWN (scene.stop path)', async () => {
 			// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
 			// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never
-			// re-runs the constructor. The SHUTDOWN listener registered in the
-			// constructor must remove the EventBus handlers so they do not leak
-			// across stop/start cycles (each create() re-adds them).
+			// re-runs the constructor. The SHUTDOWN listener registered in
+			// BaseGame's constructor must remove the EventBus handlers so they
+			// do not leak across stop/start cycles (each create() re-adds them).
 			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
 			(Preview as any).animationsCreated = true;
 
@@ -890,6 +891,49 @@ describe('Preview Scene', () => {
 			)?.[1];
 			expect(shutdownListener).toEqual(expect.any(Function));
 			(shutdownListener as (() => void) | undefined)?.();
+
+			expect(EventBus.off).toHaveBeenCalledWith(
+				EventType.STOP_PREVIEW,
+				previewScene['boundStopPreview']
+			);
+			expect(EventBus.off).toHaveBeenCalledWith(
+				EventType.RESUME_PREVIEW,
+				previewScene['boundResumePreview']
+			);
+		});
+
+		it('survives SHUTDOWN then DESTROY firing on the same instance (idempotent shutdown)', async () => {
+			// Real-world sequence: scene.stop() emits SHUTDOWN (shutdown runs),
+			// then later game.destroy() emits DESTROY (shutdown runs again) on
+			// the same scene instance. shutdown() must be idempotent so the
+			// second call does not throw on already-nulled storeUnsubscribe /
+			// stopped tweens / cleared audio. This is the load-bearing
+			// invariant for the constructor-registered listeners.
+			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
+			(Preview as any).animationsCreated = true;
+
+			vi.spyOn(previewScene as any, 'drawPanel').mockImplementation(() => {});
+			vi.spyOn(previewScene as any, 'drawNotes').mockImplementation(() => {});
+			vi.spyOn(previewScene as any, 'setupSoundsAsync').mockResolvedValue(undefined);
+			vi.spyOn(previewScene as any, 'startPreview').mockImplementation(() => {});
+
+			await previewScene.create();
+
+			const onMock = previewScene.events.on as unknown as MockedFn;
+			const onceMock = previewScene.events.once as unknown as MockedFn;
+			const shutdownListener = onMock.mock.calls.find(
+				(call: unknown[]) => call[0] === 'shutdown'
+			)?.[1];
+			const destroyListener = onceMock.mock.calls.find(
+				(call: unknown[]) => call[0] === 'destroy'
+			)?.[1];
+			expect(shutdownListener).toEqual(expect.any(Function));
+			expect(destroyListener).toEqual(expect.any(Function));
+
+			expect(() => {
+				(shutdownListener as (() => void) | undefined)?.();
+				(destroyListener as (() => void) | undefined)?.();
+			}).not.toThrow();
 
 			expect(EventBus.off).toHaveBeenCalledWith(
 				EventType.STOP_PREVIEW,

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -829,8 +829,8 @@ describe('Preview Scene', () => {
 		it('removes EventBus handlers when Phaser emits DESTROY (game.destroy path)', async () => {
 			// Phaser's game.destroy() emits DESTROY on the scene's event emitter
 			// but never calls scene.shutdown(). The DESTROY listener registered
-			// in BaseGame's constructor must remove the EventBus handlers so
-			// they do not leak.
+			// in BaseGame.init() must remove the EventBus handlers so they do
+			// not leak.
 			// Mock limitation: __mocks__/phaser.ts EventEmitter uses no-op vi.fn()s
 			// for once/emit/off, so this test manually invokes the captured DESTROY
 			// callback rather than driving a real emit. This verifies the callback
@@ -838,6 +838,8 @@ describe('Preview Scene', () => {
 			// emit-vs-removeAllListeners ordering (Systems.destroy emits DESTROY
 			// THEN calls removeAllListeners). Correct for Phaser 3.88 today; if
 			// Phaser reorders, this test would not catch the regression.
+			// init() is called before create() to mirror Phaser's lifecycle (init
+			// runs first, registering the SHUTDOWN/DESTROY listeners).
 			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
 			(Preview as any).animationsCreated = true;
 
@@ -846,6 +848,13 @@ describe('Preview Scene', () => {
 			vi.spyOn(previewScene as any, 'setupSoundsAsync').mockResolvedValue(undefined);
 			vi.spyOn(previewScene as any, 'startPreview').mockImplementation(() => {});
 
+			previewScene.init({
+				measureCount: 10,
+				notes: {},
+				bpm: 120,
+				bpmNotes: {},
+				startMeasure: 0
+			});
 			await previewScene.create();
 
 			// Simulate Phaser's Systems.destroy() firing the DESTROY listener
@@ -871,8 +880,10 @@ describe('Preview Scene', () => {
 			// scene.stop() (e.g. difficulty switching in DesktopEditor) calls
 			// sys.shutdown() which emits SHUTDOWN but never emits DESTROY and never
 			// re-runs the constructor. The SHUTDOWN listener registered in
-			// BaseGame's constructor must remove the EventBus handlers so they
-			// do not leak across stop/start cycles (each create() re-adds them).
+			// BaseGame.init() must remove the EventBus handlers so they do
+			// not leak across stop/start cycles (each create() re-adds them).
+			// init() is called before create() to mirror Phaser's lifecycle (init
+			// runs first, registering the SHUTDOWN/DESTROY listeners).
 			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
 			(Preview as any).animationsCreated = true;
 
@@ -881,6 +892,13 @@ describe('Preview Scene', () => {
 			vi.spyOn(previewScene as any, 'setupSoundsAsync').mockResolvedValue(undefined);
 			vi.spyOn(previewScene as any, 'startPreview').mockImplementation(() => {});
 
+			previewScene.init({
+				measureCount: 10,
+				notes: {},
+				bpm: 120,
+				bpmNotes: {},
+				startMeasure: 0
+			});
 			await previewScene.create();
 
 			// Simulate Phaser's Systems.shutdown() firing the SHUTDOWN listener
@@ -908,7 +926,9 @@ describe('Preview Scene', () => {
 			// the same scene instance. shutdown() must be idempotent so the
 			// second call does not throw on already-nulled storeUnsubscribe /
 			// stopped tweens / cleared audio. This is the load-bearing
-			// invariant for the constructor-registered listeners.
+			// invariant for the init()-registered listeners.
+			// init() is called before create() to mirror Phaser's lifecycle (init
+			// runs first, registering the SHUTDOWN/DESTROY listeners).
 			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
 			(Preview as any).animationsCreated = true;
 
@@ -917,6 +937,13 @@ describe('Preview Scene', () => {
 			vi.spyOn(previewScene as any, 'setupSoundsAsync').mockResolvedValue(undefined);
 			vi.spyOn(previewScene as any, 'startPreview').mockImplementation(() => {});
 
+			previewScene.init({
+				measureCount: 10,
+				notes: {},
+				bpm: 120,
+				bpmNotes: {},
+				startMeasure: 0
+			});
 			await previewScene.create();
 
 			const onMock = previewScene.events.on as unknown as MockedFn;

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -825,6 +825,39 @@ describe('Preview Scene', () => {
 			setupSoundsSpy.mockRestore();
 			startPreviewSpy.mockRestore();
 		});
+
+		it('removes EventBus handlers when Phaser emits DESTROY (game.destroy path)', async () => {
+			// Phaser's game.destroy() emits DESTROY on the scene's event emitter
+			// but never calls scene.shutdown(). The DESTROY listener registered in
+			// create() must remove the EventBus handlers so they do not leak.
+			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
+			(Preview as any).animationsCreated = true;
+
+			vi.spyOn(previewScene as any, 'drawPanel').mockImplementation(() => {});
+			vi.spyOn(previewScene as any, 'drawNotes').mockImplementation(() => {});
+			vi.spyOn(previewScene as any, 'setupSoundsAsync').mockResolvedValue(undefined);
+			vi.spyOn(previewScene as any, 'startPreview').mockImplementation(() => {});
+
+			await previewScene.create();
+
+			// Simulate Phaser's Systems.destroy() firing the DESTROY listener
+			// registered via this.events.once(Phaser.Scenes.Events.DESTROY, ...).
+			const onceMock = previewScene.events.once as unknown as MockedFn;
+			const destroyListener = onceMock.mock.calls.find(
+				(call: unknown[]) => call[0] === 'destroy'
+			)?.[1];
+			expect(destroyListener).toEqual(expect.any(Function));
+			(destroyListener as (() => void) | undefined)?.();
+
+			expect(EventBus.off).toHaveBeenCalledWith(
+				EventType.STOP_PREVIEW,
+				previewScene['boundStopPreview']
+			);
+			expect(EventBus.off).toHaveBeenCalledWith(
+				EventType.RESUME_PREVIEW,
+				previewScene['boundResumePreview']
+			);
+		});
 	});
 
 	describe('updateData()', () => {

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -64,15 +64,23 @@ export class Preview extends BaseGame {
 	constructor() {
 		super({ key: Preview.key });
 		this.laneConfigs = this.laneConfigs.filter((lane) => lane.playable);
-		// Register the DESTROY listener once per scene instance. scene.restart()
-		// emits SHUTDOWN and re-runs init()/create(), but does NOT emit DESTROY,
-		// so a once-listener registered in create() would accumulate across
-		// restarts. The constructor runs only once per instance, avoiding the
-		// leak. Phaser's game.destroy() emits DESTROY and calls
+		// Register lifecycle listeners once per scene instance. scene.restart()
+		// and scene.stop() emit SHUTDOWN (re-running init()/create() on restart,
+		// or leaving the scene dormant on stop) but neither emits DESTROY, so
+		// once-listeners registered in create() would accumulate across
+		// restarts and EventBus handlers would leak across scene.stop() calls
+		// (e.g. difficulty switching via previewScene.scene.stop() in
+		// DesktopEditor). The constructor runs only once per instance, avoiding
+		// both leaks. Phaser's game.destroy() emits DESTROY and calls
 		// removeAllListeners() on the scene's event emitter, but never invokes
-		// scene.shutdown(); this listener ensures the module-singleton EventBus
-		// handlers are removed when the game is torn down, otherwise they leak
-		// and reference a destroyed scene whose sys is nulled.
+		// scene.shutdown(); the DESTROY listener ensures the module-singleton
+		// EventBus handlers are removed when the game is torn down, otherwise
+		// they leak and reference a destroyed scene whose sys is nulled. The
+		// SHUTDOWN listener covers scene.stop()/scene.restart() paths where
+		// DESTROY never fires. removeEventBusListeners() is idempotent
+		// (EventBus.off is a no-op for unregistered handlers), so calling it on
+		// both SHUTDOWN and DESTROY is safe.
+		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.removeEventBusListeners());
 		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
 	}
 

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -64,13 +64,15 @@ export class Preview extends BaseGame {
 	constructor() {
 		super({ key: Preview.key });
 		this.laneConfigs = this.laneConfigs.filter((lane) => lane.playable);
-		// SHUTDOWN/DESTROY listeners are registered by BaseGame's constructor.
-		// shutdown() cleans up the Svelte store subscription (storeUnsubscribe),
-		// preview tween, playing audio, scheduled time events, and EventBus
-		// handlers, and is idempotent so both listeners firing is safe.
+		// SHUTDOWN/DESTROY listeners are registered by BaseGame.init(), which
+		// runs before create() on every scene start/restart. shutdown() cleans
+		// up the Svelte store subscription (storeUnsubscribe), preview tween,
+		// playing audio, scheduled time events, and EventBus handlers, and is
+		// idempotent so both listeners firing is safe.
 	}
 
 	init(data: Data) {
+		super.init(data);
 		this.measureCount = data.measureCount;
 		this.notes = data.notes;
 		this.bpm = data.bpm;

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -64,26 +64,10 @@ export class Preview extends BaseGame {
 	constructor() {
 		super({ key: Preview.key });
 		this.laneConfigs = this.laneConfigs.filter((lane) => lane.playable);
-		// Register lifecycle listeners once per scene instance. scene.restart()
-		// and scene.stop() emit SHUTDOWN (re-running init()/create() on restart,
-		// or leaving the scene dormant on stop) but neither emits DESTROY, so
-		// once-listeners registered in create() would accumulate across
-		// restarts and EventBus handlers would leak across scene.stop() calls
-		// (e.g. difficulty switching via previewScene.scene.stop() in
-		// DesktopEditor). The constructor runs only once per instance, avoiding
-		// both leaks. Phaser's game.destroy() emits DESTROY and calls
-		// removeAllListeners() on the scene's event emitter, but never invokes
-		// scene.shutdown(); the DESTROY listener ensures the module-singleton
-		// EventBus handlers are removed when the game is torn down, otherwise
-		// they leak and reference a destroyed scene whose sys is nulled. The
-		// SHUTDOWN listener covers scene.stop()/scene.restart() paths where
-		// DESTROY never fires. Both listeners call the full shutdown() method,
-		// which cleans up the Svelte store subscription (storeUnsubscribe),
+		// SHUTDOWN/DESTROY listeners are registered by BaseGame's constructor.
+		// shutdown() cleans up the Svelte store subscription (storeUnsubscribe),
 		// preview tween, playing audio, scheduled time events, and EventBus
-		// handlers. shutdown() is idempotent, so calling it from both SHUTDOWN
-		// and DESTROY (and any explicit call) is safe.
-		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.shutdown());
-		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.shutdown());
+		// handlers, and is idempotent so both listeners firing is safe.
 	}
 
 	init(data: Data) {
@@ -163,9 +147,6 @@ export class Preview extends BaseGame {
 		EventBus.emit(EventType.SCENE_READY, this);
 		EventBus.on(EventType.STOP_PREVIEW, this.boundStopPreview);
 		EventBus.on(EventType.RESUME_PREVIEW, this.boundResumePreview);
-
-		// DESTROY listener is registered in the constructor to avoid
-		// accumulation across scene.restart() (see constructor comment).
 	}
 
 	private removeEventBusListeners(): void {

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -64,6 +64,16 @@ export class Preview extends BaseGame {
 	constructor() {
 		super({ key: Preview.key });
 		this.laneConfigs = this.laneConfigs.filter((lane) => lane.playable);
+		// Register the DESTROY listener once per scene instance. scene.restart()
+		// emits SHUTDOWN and re-runs init()/create(), but does NOT emit DESTROY,
+		// so a once-listener registered in create() would accumulate across
+		// restarts. The constructor runs only once per instance, avoiding the
+		// leak. Phaser's game.destroy() emits DESTROY and calls
+		// removeAllListeners() on the scene's event emitter, but never invokes
+		// scene.shutdown(); this listener ensures the module-singleton EventBus
+		// handlers are removed when the game is torn down, otherwise they leak
+		// and reference a destroyed scene whose sys is nulled.
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
 	}
 
 	init(data: Data) {
@@ -144,12 +154,8 @@ export class Preview extends BaseGame {
 		EventBus.on(EventType.STOP_PREVIEW, this.boundStopPreview);
 		EventBus.on(EventType.RESUME_PREVIEW, this.boundResumePreview);
 
-		// Phaser's game.destroy() emits DESTROY and calls removeAllListeners() on
-		// the scene's event emitter, but never invokes scene.shutdown(). Register a
-		// DESTROY listener so the module-singleton EventBus handlers are removed
-		// when the game is torn down, otherwise they leak and reference a destroyed
-		// scene whose sys is nulled.
-		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
+		// DESTROY listener is registered in the constructor to avoid
+		// accumulation across scene.restart() (see constructor comment).
 	}
 
 	private removeEventBusListeners(): void {

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -77,11 +77,13 @@ export class Preview extends BaseGame {
 		// EventBus handlers are removed when the game is torn down, otherwise
 		// they leak and reference a destroyed scene whose sys is nulled. The
 		// SHUTDOWN listener covers scene.stop()/scene.restart() paths where
-		// DESTROY never fires. removeEventBusListeners() is idempotent
-		// (EventBus.off is a no-op for unregistered handlers), so calling it on
-		// both SHUTDOWN and DESTROY is safe.
-		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.removeEventBusListeners());
-		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
+		// DESTROY never fires. Both listeners call the full shutdown() method,
+		// which cleans up the Svelte store subscription (storeUnsubscribe),
+		// preview tween, playing audio, scheduled time events, and EventBus
+		// handlers. shutdown() is idempotent, so calling it from both SHUTDOWN
+		// and DESTROY (and any explicit call) is safe.
+		this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.shutdown());
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.shutdown());
 	}
 
 	init(data: Data) {

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -143,6 +143,18 @@ export class Preview extends BaseGame {
 		EventBus.emit(EventType.SCENE_READY, this);
 		EventBus.on(EventType.STOP_PREVIEW, this.boundStopPreview);
 		EventBus.on(EventType.RESUME_PREVIEW, this.boundResumePreview);
+
+		// Phaser's game.destroy() emits DESTROY and calls removeAllListeners() on
+		// the scene's event emitter, but never invokes scene.shutdown(). Register a
+		// DESTROY listener so the module-singleton EventBus handlers are removed
+		// when the game is torn down, otherwise they leak and reference a destroyed
+		// scene whose sys is nulled.
+		this.events.once(Phaser.Scenes.Events.DESTROY, () => this.removeEventBusListeners());
+	}
+
+	private removeEventBusListeners(): void {
+		EventBus.off(EventType.STOP_PREVIEW, this.boundStopPreview);
+		EventBus.off(EventType.RESUME_PREVIEW, this.boundResumePreview);
 	}
 
 	/**
@@ -1152,8 +1164,7 @@ export class Preview extends BaseGame {
 		}
 
 		// Remove event listeners to prevent leaks
-		EventBus.off(EventType.STOP_PREVIEW, this.boundStopPreview);
-		EventBus.off(EventType.RESUME_PREVIEW, this.boundResumePreview);
+		this.removeEventBusListeners();
 
 		// Reset all container scales
 		if (this.gridContainer) this.gridContainer.setScale(1);

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -45,8 +45,8 @@ export class Preview extends BaseGame {
 	private isInitialized = false;
 
 	// Bound event handlers to prevent listener leaks
-	private boundStopPreview = () => this.pausePreview();
-	private boundResumePreview = (data: { startMeasure: number }) => {
+	private readonly boundStopPreview = () => this.pausePreview();
+	private readonly boundResumePreview = (data: { startMeasure: number }) => {
 		this.startMeasure = data.startMeasure;
 		this.resumePreview();
 	};

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -79,9 +79,8 @@
 	let currentChart = $state<ChartState | null>(null); // Track current chart with DTX files
 	const SIDEBAR_WIDTH_STORAGE_KEY = 'desktop_editor_sidebar_width';
 	const SIDEBAR_WIDTH_DEFAULT = 320;
-	let sidebarWidth = $state(
-		Number(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)) || SIDEBAR_WIDTH_DEFAULT
-	);
+	const storedSidebarWidth = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+	let sidebarWidth = $state(Number(storedSidebarWidth) || SIDEBAR_WIDTH_DEFAULT);
 	let isDragging = $state(false);
 	let minSidebarWidth = 120;
 	let maxSidebarWidth = 600;
@@ -94,11 +93,18 @@
 	// Persist sidebar width to localStorage so it survives remounts/reloads.
 	// Skip writing during drag (handleMouseMove fires every pointermove) to
 	// avoid a synchronous localStorage write per frame; the final width is
-	// persisted when isDragging flips back to false on mouseup.
+	// persisted when isDragging flips back to false on mouseup. The
+	// last-persisted guard is seeded from the same localStorage read that
+	// initializes sidebarWidth, so a mount with an unchanged value writes
+	// nothing; a missing or invalid stored value persists the resolved default.
+	let lastPersistedSidebarWidth: string | null = storedSidebarWidth;
 	$effect(() => {
 		if (isDragging) return;
+		const serialized = String(sidebarWidth);
+		if (serialized === lastPersistedSidebarWidth) return;
 		try {
-			localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
+			localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, serialized);
+			lastPersistedSidebarWidth = serialized;
 		} catch {
 			// localStorage can throw (quota exceeded, disabled in private mode);
 			// sidebar width persistence is non-critical, ignore.

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -377,7 +377,16 @@
 						clearTimeout(timeout);
 						resolve();
 					});
-					gameToDestroy.destroy(true);
+					// If destroy throws synchronously (e.g. scene error during
+					// shutdown), resolve like the missing-'destroy' event path so
+					// pendingPhaserTeardown never rejects and hangs later mounts.
+					try {
+						gameToDestroy.destroy(true);
+					} catch (err) {
+						console.error('[DesktopEditor] Phaser destroy threw synchronously:', err);
+						clearTimeout(timeout);
+						resolve();
+					}
 				});
 				pendingPhaserTeardown = pendingPhaserTeardown.then(
 					() => teardownPromise,

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -316,9 +316,15 @@
 				game = null;
 				// Register the destroy listener before calling destroy so we
 				// never miss the event, then resolve pendingPhaserTeardown only
-				// when Phaser signals full teardown completion.
+				// when Phaser signals full teardown completion. Race with a
+				// timeout so a missing 'destroy' event (scene throw during
+				// shutdown, WebGL context loss) cannot hang every later mount.
 				const teardownPromise = new Promise<void>((resolve) => {
-					gameToDestroy.events.once('destroy', () => resolve());
+					const timeout = setTimeout(() => resolve(), 5000);
+					gameToDestroy.events.once('destroy', () => {
+						clearTimeout(timeout);
+						resolve();
+					});
 					gameToDestroy.destroy(true);
 				});
 				pendingPhaserTeardown = pendingPhaserTeardown.then(

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -1,5 +1,4 @@
 <script module lang="ts">
-	const waitForNextTask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 	let pendingPhaserTeardown: Promise<void> = Promise.resolve();
 </script>
 
@@ -259,6 +258,9 @@
 				}
 
 				// Initialize the Phaser game for the editor
+				// Re-check mounted here because loadFromSimFileId / loadChartFromPath
+				// above may still have been in flight when teardown began.
+				if (!mounted) return;
 				if (gameContainer) {
 					// Set the active scene to Editor for desktop
 					store.activeScene.set(Editor.key);
@@ -312,10 +314,16 @@
 			if (game) {
 				const gameToDestroy = game;
 				game = null;
-				gameToDestroy.destroy(true);
+				// Register the destroy listener before calling destroy so we
+				// never miss the event, then resolve pendingPhaserTeardown only
+				// when Phaser signals full teardown completion.
+				const teardownPromise = new Promise<void>((resolve) => {
+					gameToDestroy.events.once('destroy', () => resolve());
+					gameToDestroy.destroy(true);
+				});
 				pendingPhaserTeardown = pendingPhaserTeardown.then(
-					waitForNextTask,
-					waitForNextTask
+					() => teardownPromise,
+					() => teardownPromise
 				);
 			}
 		};

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -4,11 +4,11 @@
 	// Test-only hook: resets the module-scoped teardown promise so test suites
 	// are not order-coupled by leftover chain state. Guarded by DEV so it is
 	// stripped from production builds.
-	export function __resetPendingTeardownForTests(): void {
+	export const __resetPendingTeardownForTests = (): void => {
 		if (import.meta.env.DEV) {
 			pendingPhaserTeardown = Promise.resolve();
 		}
-	}
+	};
 </script>
 
 <script lang="ts">

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -1,6 +1,11 @@
+<script module lang="ts">
+	const waitForNextTask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+	let pendingPhaserTeardown: Promise<void> = Promise.resolve();
+</script>
+
 <script lang="ts">
 	// Desktop Editor component that uses common package components directly
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import Phaser from 'phaser';
 	import EditorContextBar from './editor/EditorContextBar.svelte';
 	import EditorDock from './editor/EditorDock.svelte';
@@ -66,7 +71,7 @@
 	let currentChart = $state<ChartState | null>(null); // Track current chart with DTX files
 	let sidebarWidth = $state(320); // Sidebar width in pixels (default 80 * 0.25rem = 320px)
 	let isDragging = $state(false);
-	let minSidebarWidth = 200;
+	let minSidebarWidth = 120;
 	let maxSidebarWidth = 600;
 	let collapseThreshold = 50; // Width below which sidebar collapses
 	const keyboardResizeStep = 20;
@@ -198,11 +203,16 @@
 	};
 
 	onMount(() => {
+		let mounted = true;
 		// Set up validation error event listener
 		EventBus.on(EventType.VALIDATION_ERROR, handleValidationError);
 
 		const initializeEditor = async () => {
 			try {
+				await pendingPhaserTeardown;
+				await tick();
+				if (!mounted) return;
+
 				// Initialize file provider
 				let workspacePath = localStorage.getItem('workspace_path') || '';
 				// Remove extra quotes if present
@@ -280,11 +290,15 @@
 					});
 
 					isGameInitialized = true;
+				} else {
+					throw new Error('Desktop editor game container was not available');
 				}
 			} catch (error) {
 				console.error('Failed to initialize desktop editor:', error);
 				// Set initialized to true even on error so we don't show loading forever
-				isGameInitialized = true;
+				if (mounted) {
+					isGameInitialized = true;
+				}
 			}
 		};
 
@@ -293,9 +307,16 @@
 
 		// Return cleanup function
 		return () => {
+			mounted = false;
 			EventBus.off(EventType.VALIDATION_ERROR, handleValidationError);
 			if (game) {
-				game.destroy(true);
+				const gameToDestroy = game;
+				game = null;
+				gameToDestroy.destroy(true);
+				pendingPhaserTeardown = pendingPhaserTeardown.then(
+					waitForNextTask,
+					waitForNextTask
+				);
 			}
 		};
 	});

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -2,8 +2,12 @@
 	let pendingPhaserTeardown: Promise<void> = Promise.resolve();
 
 	// Test-only hook: resets the module-scoped teardown promise so test suites
-	// are not order-coupled by leftover chain state. Guarded by DEV so it is
-	// stripped from production builds.
+	// are not order-coupled by leftover chain state. Guarded by DEV so the
+	// body is a no-op in production. The export itself is only imported by
+	// DesktopEditor.test.ts; in production builds tree-shaking drops it since
+	// no production code references it. Co-located with the state it resets
+	// rather than split into a separate module to keep the teardown chain
+	// logic in one place.
 	export const __resetPendingTeardownForTests = (): void => {
 		if (import.meta.env.DEV) {
 			pendingPhaserTeardown = Promise.resolve();

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -2,9 +2,12 @@
 	let pendingPhaserTeardown: Promise<void> = Promise.resolve();
 
 	// Test-only hook: resets the module-scoped teardown promise so test suites
-	// are not order-coupled by leftover chain state. Not for production use.
+	// are not order-coupled by leftover chain state. Guarded by DEV so it is
+	// stripped from production builds.
 	export function __resetPendingTeardownForTests(): void {
-		pendingPhaserTeardown = Promise.resolve();
+		if (import.meta.env.DEV) {
+			pendingPhaserTeardown = Promise.resolve();
+		}
 	}
 </script>
 
@@ -90,7 +93,12 @@
 
 	// Persist sidebar width to localStorage so it survives remounts/reloads.
 	$effect(() => {
-		localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
+		try {
+			localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
+		} catch {
+			// localStorage can throw (quota exceeded, disabled in private mode);
+			// sidebar width persistence is non-critical, ignore.
+		}
 	});
 
 	const toArrayBuffer = (content: ArrayBuffer | Uint8Array): ArrayBuffer => {
@@ -344,7 +352,13 @@
 				// timeout so a missing 'destroy' event (scene throw during
 				// shutdown, WebGL context loss) cannot hang every later mount.
 				const teardownPromise = new Promise<void>((resolve) => {
-					const timeout = setTimeout(() => resolve(), 5000);
+					const timeout = setTimeout(() => {
+						console.warn(
+							'[DesktopEditor] Phaser destroy event did not fire within 5s; ' +
+								'resolving teardown to avoid hanging subsequent mounts.'
+						);
+						resolve();
+					}, 5000);
 					gameToDestroy.events.once('destroy', () => {
 						clearTimeout(timeout);
 						resolve();

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -1,5 +1,11 @@
 <script module lang="ts">
 	let pendingPhaserTeardown: Promise<void> = Promise.resolve();
+
+	// Test-only hook: resets the module-scoped teardown promise so test suites
+	// are not order-coupled by leftover chain state. Not for production use.
+	export function __resetPendingTeardownForTests(): void {
+		pendingPhaserTeardown = Promise.resolve();
+	}
 </script>
 
 <script lang="ts">
@@ -68,7 +74,11 @@
 	let isSidebarCollapsed = $state(false); // Track sidebar collapse state
 	let currentSongName = $state<string | null>(null); // Track current song name
 	let currentChart = $state<ChartState | null>(null); // Track current chart with DTX files
-	let sidebarWidth = $state(320); // Sidebar width in pixels (default 80 * 0.25rem = 320px)
+	const SIDEBAR_WIDTH_STORAGE_KEY = 'desktop_editor_sidebar_width';
+	const SIDEBAR_WIDTH_DEFAULT = 320;
+	let sidebarWidth = $state(
+		Number(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)) || SIDEBAR_WIDTH_DEFAULT
+	);
 	let isDragging = $state(false);
 	let minSidebarWidth = 120;
 	let maxSidebarWidth = 600;
@@ -76,6 +86,12 @@
 	const keyboardResizeStep = 20;
 	let validationError = $state<string | null>(null); // Track validation errors
 	let chartLoadError = $state<string | null>(null); // Track chart-folder load errors
+	let validationErrorTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	// Persist sidebar width to localStorage so it survives remounts/reloads.
+	$effect(() => {
+		localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
+	});
 
 	const toArrayBuffer = (content: ArrayBuffer | Uint8Array): ArrayBuffer => {
 		if (content instanceof ArrayBuffer) {
@@ -196,8 +212,12 @@
 	const handleValidationError = (message: string) => {
 		validationError = message;
 		// Auto-hide error after 5 seconds
-		setTimeout(() => {
+		if (validationErrorTimeout !== null) {
+			clearTimeout(validationErrorTimeout);
+		}
+		validationErrorTimeout = setTimeout(() => {
 			validationError = null;
+			validationErrorTimeout = null;
 		}, 5000);
 	};
 
@@ -311,6 +331,10 @@
 		return () => {
 			mounted = false;
 			EventBus.off(EventType.VALIDATION_ERROR, handleValidationError);
+			if (validationErrorTimeout !== null) {
+				clearTimeout(validationErrorTimeout);
+				validationErrorTimeout = null;
+			}
 			if (game) {
 				const gameToDestroy = game;
 				game = null;

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.svelte
@@ -92,7 +92,11 @@
 	let validationErrorTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	// Persist sidebar width to localStorage so it survives remounts/reloads.
+	// Skip writing during drag (handleMouseMove fires every pointermove) to
+	// avoid a synchronous localStorage write per frame; the final width is
+	// persisted when isDragging flips back to false on mouseup.
 	$effect(() => {
+		if (isDragging) return;
 		try {
 			localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
 		} catch {

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
@@ -45,19 +45,29 @@ vi.mock('@dtx/common/components', () => ({
 	PreviewTab: vi.fn()
 }));
 
-const mockPhaserGame = vi.hoisted(() => ({
-	events: {
-		once: vi.fn((event: string, cb: () => void) => {
-			if (event === 'ready') {
-				setTimeout(cb, 0);
-			}
-		})
-	},
-	destroy: vi.fn(),
-	scene: {
-		getScene: vi.fn(() => null)
-	}
-}));
+const mockPhaserGame = vi.hoisted(() => {
+	let destroyCallback: (() => void) | null = null;
+	return {
+		events: {
+			once: vi.fn((event: string, cb: () => void) => {
+				if (event === 'ready') {
+					setTimeout(cb, 0);
+				} else if (event === 'destroy') {
+					destroyCallback = cb;
+				}
+			})
+		},
+		destroy: vi.fn(),
+		scene: {
+			getScene: vi.fn(() => null)
+		},
+		_takeDestroyCallback: () => {
+			const cb = destroyCallback;
+			destroyCallback = null;
+			return cb;
+		}
+	};
+});
 
 const mockPhaserState = vi.hoisted(() => ({
 	isDestroying: false,
@@ -196,6 +206,9 @@ describe('DesktopEditor', () => {
 			mockPhaserState.isDestroying = true;
 			setTimeout(() => {
 				mockPhaserState.isDestroying = false;
+				// Simulate Phaser's DESTROY event firing after async teardown.
+				const cb = mockPhaserGame._takeDestroyCallback();
+				if (cb) cb();
 			}, 0);
 		});
 		mockDesktopHost.readFile.mockResolvedValue({ error: 'not found', content: '' });

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
@@ -381,8 +381,10 @@ describe('DesktopEditor', () => {
 	});
 
 	it('persists sidebar width to localStorage and restores it on remount', async () => {
-		vi.spyOn(localStorage, 'getItem').mockReturnValue('240');
-		const { unmount } = render(DesktopEditor);
+		vi.spyOn(localStorage, 'getItem').mockImplementation((key) =>
+			key === 'desktop_editor_sidebar_width' ? '240' : null
+		);
+		const first = render(DesktopEditor);
 		const sidebar = screen.getByLabelText('Resize sidebar');
 		expect(sidebar.parentElement?.style.width).toBe('240px');
 
@@ -392,7 +394,16 @@ describe('DesktopEditor', () => {
 		await fireEvent.mouseUp(document);
 		expect(localStorage.setItem).toHaveBeenCalledWith('desktop_editor_sidebar_width', '200');
 
-		unmount();
+		first.unmount();
+
+		// Remount and confirm the persisted width is restored from localStorage.
+		vi.spyOn(localStorage, 'getItem').mockImplementation((key) =>
+			key === 'desktop_editor_sidebar_width' ? '200' : null
+		);
+		const second = render(DesktopEditor);
+		const restoredSidebar = screen.getByLabelText('Resize sidebar');
+		expect(restoredSidebar.parentElement?.style.width).toBe('200px');
+		second.unmount();
 	});
 
 	it('collapses and expands the sidebar via keyboard', async () => {

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
@@ -352,6 +352,33 @@ describe('DesktopEditor', () => {
 		vi.useRealTimers();
 	});
 
+	it('resolves pendingPhaserTeardown when destroy throws synchronously', async () => {
+		// If Phaser's destroy() throws synchronously (scene error during
+		// shutdown), the teardown promise must still resolve so a later
+		// remount boots instead of awaiting a rejected promise forever.
+		mockPhaserGame.destroy.mockImplementation(() => {
+			mockPhaserState.isDestroying = true;
+			throw new Error('boom during destroy');
+		});
+
+		const firstRender = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserState.successfulGames).toBe(1);
+		});
+
+		firstRender.unmount();
+		// Synchronous throw resolves teardown immediately; no timeout needed.
+		mockPhaserState.isDestroying = false;
+
+		const secondRender = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserState.successfulGames).toBe(2);
+		});
+		expect(screen.queryByText(/Initializing editor/)).toBeNull();
+
+		secondRender.unmount();
+	});
+
 	it('clears the validation error auto-hide timeout on unmount', async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		const { unmount } = render(DesktopEditor);

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
@@ -59,12 +59,29 @@ const mockPhaserGame = vi.hoisted(() => ({
 	}
 }));
 
+const mockPhaserState = vi.hoisted(() => ({
+	isDestroying: false,
+	successfulGames: 0
+}));
+
 vi.mock('phaser', () => ({
 	default: {
-		Game: vi.fn(() => mockPhaserGame),
+		Game: vi.fn(() => {
+			if (mockPhaserState.isDestroying) {
+				throw new Error('Previous Phaser game is still destroying');
+			}
+			mockPhaserState.successfulGames += 1;
+			return mockPhaserGame;
+		}),
 		AUTO: 0
 	},
-	Game: vi.fn(() => mockPhaserGame),
+	Game: vi.fn(() => {
+		if (mockPhaserState.isDestroying) {
+			throw new Error('Previous Phaser game is still destroying');
+		}
+		mockPhaserState.successfulGames += 1;
+		return mockPhaserGame;
+	}),
 	AUTO: 0
 }));
 
@@ -158,11 +175,29 @@ vi.mock('../stores/editorMappingStore', () => ({
 
 import DesktopEditor from './DesktopEditor.svelte';
 import { editorMappingStore } from '../stores/editorMappingStore';
+import Phaser from 'phaser';
+
+const createDeferred = <T>() => {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+
+	return { promise, resolve };
+};
 
 describe('DesktopEditor', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockEventBus._reset();
+		mockPhaserState.isDestroying = false;
+		mockPhaserState.successfulGames = 0;
+		mockPhaserGame.destroy.mockImplementation(() => {
+			mockPhaserState.isDestroying = true;
+			setTimeout(() => {
+				mockPhaserState.isDestroying = false;
+			}, 0);
+		});
 		mockDesktopHost.readFile.mockResolvedValue({ error: 'not found', content: '' });
 		mockDesktopHost.listFiles.mockResolvedValue({ files: [], error: null });
 		vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
@@ -231,6 +266,44 @@ describe('DesktopEditor', () => {
 		expect(mockPhaserGame.destroy).toHaveBeenCalledWith(true);
 	});
 
+	it('does not finish a stale editor initialization after unmount', async () => {
+		vi.spyOn(localStorage, 'getItem').mockReturnValue('/test/workspace');
+		const pendingWorkspaceLoad = createDeferred<{ files: []; error: null }>();
+		mockDesktopHost.listFiles.mockReturnValueOnce(pendingWorkspaceLoad.promise);
+
+		const { unmount } = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockDesktopHost.listFiles).toHaveBeenCalledWith(
+				'/test/workspace',
+				'/test/workspace'
+			);
+		});
+
+		unmount();
+		pendingWorkspaceLoad.resolve({ files: [], error: null });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(Phaser.Game).not.toHaveBeenCalled();
+		expect(console.error).not.toHaveBeenCalled();
+	});
+
+	it('waits for a previous Phaser game teardown before booting a remounted editor', async () => {
+		const firstRender = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserState.successfulGames).toBe(1);
+		});
+
+		firstRender.unmount();
+		const secondRender = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserState.successfulGames).toBe(2);
+		});
+		expect(screen.queryByText(/Initializing editor/)).toBeNull();
+
+		secondRender.unmount();
+	});
+
 	it('collapses and expands the sidebar via keyboard', async () => {
 		render(DesktopEditor);
 		const resizeHandle = screen.getByLabelText('Resize sidebar');
@@ -243,6 +316,18 @@ describe('DesktopEditor', () => {
 		// Click on collapsed sidebar to expand
 		const collapsedHandle = screen.getByTitle('Expand dock');
 		await fireEvent.click(collapsedHandle);
+		expect(screen.getByRole('button', { name: /Chart Info/i })).toBeInTheDocument();
+	});
+
+	it('lets the editor sidebar be dragged to a compact width before collapsing', async () => {
+		render(DesktopEditor);
+		const resizeHandle = screen.getByLabelText('Resize sidebar');
+
+		await fireEvent.mouseDown(resizeHandle, { clientX: 320 });
+		await fireEvent.mouseMove(document, { clientX: 120 });
+		await fireEvent.mouseUp(document);
+
+		expect(resizeHandle.parentElement?.style.width).toBe('120px');
 		expect(screen.getByRole('button', { name: /Chart Info/i })).toBeInTheDocument();
 	});
 

--- a/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/DesktopEditor.test.ts
@@ -184,6 +184,7 @@ vi.mock('../stores/editorMappingStore', () => ({
 }));
 
 import DesktopEditor from './DesktopEditor.svelte';
+import { __resetPendingTeardownForTests } from './DesktopEditor.svelte';
 import { editorMappingStore } from '../stores/editorMappingStore';
 import Phaser from 'phaser';
 
@@ -202,6 +203,7 @@ describe('DesktopEditor', () => {
 		mockEventBus._reset();
 		mockPhaserState.isDestroying = false;
 		mockPhaserState.successfulGames = 0;
+		__resetPendingTeardownForTests();
 		mockPhaserGame.destroy.mockImplementation(() => {
 			mockPhaserState.isDestroying = true;
 			setTimeout(() => {
@@ -315,6 +317,82 @@ describe('DesktopEditor', () => {
 		expect(screen.queryByText(/Initializing editor/)).toBeNull();
 
 		secondRender.unmount();
+	});
+
+	it('resolves pendingPhaserTeardown via the 5s safety timeout when destroy never fires', async () => {
+		// Cover the safety timeout added in dac8f7d1: if Phaser's 'destroy'
+		// event never emits (scene throw during shutdown, WebGL context loss),
+		// the teardown promise must still resolve so a later remount boots.
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+
+		// Override destroy to NOT fire the destroy callback, simulating a
+		// hung teardown.
+		mockPhaserGame.destroy.mockImplementation(() => {
+			mockPhaserState.isDestroying = true;
+		});
+
+		const firstRender = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserState.successfulGames).toBe(1);
+		});
+
+		firstRender.unmount();
+		// At this point pendingPhaserTeardown is chained to a promise that only
+		// resolves via the 5s timeout. Advance past it, then mark the game as
+		// fully torn down (the real Phaser would be gone by now).
+		vi.advanceTimersByTime(5000);
+		mockPhaserState.isDestroying = false;
+
+		const secondRender = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserState.successfulGames).toBe(2);
+		});
+
+		secondRender.unmount();
+		vi.useRealTimers();
+	});
+
+	it('clears the validation error auto-hide timeout on unmount', async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		const { unmount } = render(DesktopEditor);
+
+		mockEventBus.emit('validation-error', 'Bad note');
+		await waitFor(() => {
+			expect(screen.getByText('Bad note')).toBeInTheDocument();
+		});
+
+		// Unmount before the 5s auto-hide fires; the timeout must be cleared
+		// so it does not run on a destroyed component.
+		unmount();
+		vi.advanceTimersByTime(5000);
+		vi.useRealTimers();
+		// No throw / no console error means the timeout was cleared.
+	});
+
+	it('handles a double unmount without throwing or double-destroying the game', async () => {
+		const { unmount } = render(DesktopEditor);
+		await waitFor(() => {
+			expect(mockPhaserGame.events.once).toHaveBeenCalled();
+		});
+		unmount();
+		// Second unmount must be a no-op (game already nulled).
+		expect(() => unmount()).not.toThrow();
+		expect(mockPhaserGame.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('persists sidebar width to localStorage and restores it on remount', async () => {
+		vi.spyOn(localStorage, 'getItem').mockReturnValue('240');
+		const { unmount } = render(DesktopEditor);
+		const sidebar = screen.getByLabelText('Resize sidebar');
+		expect(sidebar.parentElement?.style.width).toBe('240px');
+
+		// Drag to a new width and confirm it is written to localStorage.
+		await fireEvent.mouseDown(sidebar, { clientX: 240 });
+		await fireEvent.mouseMove(document, { clientX: 200 });
+		await fireEvent.mouseUp(document);
+		expect(localStorage.setItem).toHaveBeenCalledWith('desktop_editor_sidebar_width', '200');
+
+		unmount();
 	});
 
 	it('collapses and expands the sidebar via keyboard', async () => {

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.test.ts
@@ -166,6 +166,36 @@ describe('DesktopFileProvider', () => {
 			expect(file).toBeUndefined();
 		});
 
+		it('rejects parent-directory traversal without calling the host', async () => {
+			// Defense-in-depth: the renderer must not send `..` segments to the
+			// Rust IPC layer, even though read_file_path_inner canonicalizes
+			// and enforces workspace containment authoritatively.
+			provider.setWorkspaceRoot('/workspace');
+			host.readFile.mockResolvedValue({ error: null, content: 'secret' });
+
+			const file = await provider.getFile('sim1', '../escape.dtx');
+			expect(file).toBeUndefined();
+			expect(host.readFile).not.toHaveBeenCalled();
+		});
+
+		it('rejects backslash-encoded parent-directory traversal', async () => {
+			provider.setWorkspaceRoot('/workspace');
+			host.readFile.mockResolvedValue({ error: null, content: 'secret' });
+
+			const file = await provider.getFile(null, '..\\..\\etc\\passwd');
+			expect(file).toBeUndefined();
+			expect(host.readFile).not.toHaveBeenCalled();
+		});
+
+		it('rejects nested parent-directory traversal segments', async () => {
+			provider.setWorkspaceRoot('/workspace');
+			host.readFile.mockResolvedValue({ error: null, content: 'secret' });
+
+			const file = await provider.getFile('sim1', 'songs/../etc/passwd');
+			expect(file).toBeUndefined();
+			expect(host.readFile).not.toHaveBeenCalled();
+		});
+
 		it('returns File for audio files with binary content', async () => {
 			provider.setWorkspaceRoot('/workspace');
 			host.readFile.mockResolvedValue({

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.test.ts
@@ -95,6 +95,18 @@ describe('DesktopFileProvider', () => {
 			expect(host.readFile).toHaveBeenCalledWith('/workspace/test.dtx', '/workspace');
 		});
 
+		it('normalizes DTX backslash sample paths before reading from the local filesystem', async () => {
+			provider.setWorkspaceRoot('/workspace');
+			host.readFile.mockResolvedValue({
+				error: null,
+				content: new Uint8Array([1, 2, 3])
+			});
+
+			await provider.getFile(null, 'sound\\kick.wav');
+
+			expect(host.readFile).toHaveBeenCalledWith('/workspace/sound/kick.wav', '/workspace');
+		});
+
 		it('returns undefined when host returns error', async () => {
 			provider.setWorkspaceRoot('/workspace');
 			host.readFile.mockResolvedValue({

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.test.ts
@@ -143,6 +143,21 @@ describe('DesktopFileProvider', () => {
 			expect(host.readFile).toHaveBeenCalledTimes(1);
 		});
 
+		it('dedupes cache entries for backslash and forward-slash variants of the same file', async () => {
+			// generateKey must normalize fileName so that 'foo\\bar.wav' and
+			// 'foo/bar.wav' share a single cache entry instead of duplicating.
+			provider.setWorkspaceRoot('/workspace');
+			host.readFile.mockResolvedValue({
+				error: null,
+				content: 'audio content'
+			});
+
+			await provider.getFile('sim1', 'sound\\kick.wav');
+			await provider.getFile('sim1', 'sound/kick.wav');
+
+			expect(host.readFile).toHaveBeenCalledTimes(1);
+		});
+
 		it('returns undefined when host throws an error', async () => {
 			provider.setWorkspaceRoot('/workspace');
 			host.readFile.mockRejectedValue(new Error('IPC error'));

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
@@ -138,7 +138,7 @@ export class DesktopFileProvider implements IFileProvider {
 	}
 
 	private generateKey(simfileId: string | null, fileName: string): string {
-		return `${simfileId || 'local'}:${fileName}`;
+		return `${simfileId || 'local'}:${this.normalizeFileName(fileName)}`;
 	}
 
 	private normalizeFileName(fileName: string): string {

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
@@ -32,6 +32,17 @@ export class DesktopFileProvider implements IFileProvider {
 	async getFile(simfileId: string | null, fileName: string): Promise<File | undefined> {
 		try {
 			const normalizedFileName = this.normalizeFileName(fileName);
+
+			// Defense-in-depth: reject parent-directory traversal segments
+			// before building the IPC path. The authoritative containment
+			// check lives in the Rust read_file_path_inner (canonicalize +
+			// starts_with(workspace_root)), which defeats `..`, symlinks, and
+			// absolute paths; this renderer guard avoids sending the IPC call
+			// at all and guards against any future code path that bypasses it.
+			if (this.containsParentTraversal(normalizedFileName)) {
+				return undefined;
+			}
+
 			const key = this.generateKey(simfileId, normalizedFileName);
 
 			// Check cache first
@@ -142,6 +153,14 @@ export class DesktopFileProvider implements IFileProvider {
 
 	private normalizeFileName(fileName: string): string {
 		return fileName.replaceAll('\\', '/');
+	}
+
+	/**
+	 * Returns true if any path segment is a parent-directory reference (`..`).
+	 * Used as defense-in-depth alongside the Rust-layer containment check.
+	 */
+	private containsParentTraversal(normalizedFileName: string): boolean {
+		return normalizedFileName.split('/').some((segment) => segment === '..');
 	}
 
 	private copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
@@ -31,7 +31,8 @@ export class DesktopFileProvider implements IFileProvider {
 
 	async getFile(simfileId: string | null, fileName: string): Promise<File | undefined> {
 		try {
-			const key = this.generateKey(simfileId, fileName);
+			const normalizedFileName = this.normalizeFileName(fileName);
+			const key = this.generateKey(simfileId, normalizedFileName);
 
 			// Check cache first
 			if (this.fileCache.has(key)) {
@@ -42,8 +43,6 @@ export class DesktopFileProvider implements IFileProvider {
 			if (!this._workspaceRoot) {
 				return undefined;
 			}
-
-			const normalizedFileName = this.normalizeFileName(fileName);
 
 			// For simfile-specific files, look in the simfile directory
 			// For local files (simfileId is null), look in the workspace root
@@ -81,7 +80,7 @@ export class DesktopFileProvider implements IFileProvider {
 
 	async setFile(simfileId: string | null, fileName: string, file: File): Promise<boolean> {
 		try {
-			const key = this.generateKey(simfileId, fileName);
+			const key = this.generateKey(simfileId, this.normalizeFileName(fileName));
 
 			// For desktop app, we just cache the file in memory
 			// Actual file writing to disk would require additional IPC handlers
@@ -96,7 +95,7 @@ export class DesktopFileProvider implements IFileProvider {
 
 	async removeFile(simfileId: string | null, fileName: string): Promise<boolean> {
 		try {
-			const key = this.generateKey(simfileId, fileName);
+			const key = this.generateKey(simfileId, this.normalizeFileName(fileName));
 			return this.fileCache.delete(key);
 		} catch (error) {
 			console.error('Failed to remove file:', error);
@@ -137,8 +136,8 @@ export class DesktopFileProvider implements IFileProvider {
 			.map((key) => key.substring(prefix.length)); // Return just the filename part
 	}
 
-	private generateKey(simfileId: string | null, fileName: string): string {
-		return `${simfileId || 'local'}:${this.normalizeFileName(fileName)}`;
+	private generateKey(simfileId: string | null, normalizedFileName: string): string {
+		return `${simfileId || 'local'}:${normalizedFileName}`;
 	}
 
 	private normalizeFileName(fileName: string): string {

--- a/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/desktopFileProvider.ts
@@ -43,13 +43,15 @@ export class DesktopFileProvider implements IFileProvider {
 				return undefined;
 			}
 
+			const normalizedFileName = this.normalizeFileName(fileName);
+
 			// For simfile-specific files, look in the simfile directory
 			// For local files (simfileId is null), look in the workspace root
 			let filePath: string;
 			if (simfileId) {
-				filePath = `${this._workspaceRoot}/${simfileId}/${fileName}`;
+				filePath = `${this._workspaceRoot}/${simfileId}/${normalizedFileName}`;
 			} else {
-				filePath = `${this._workspaceRoot}/${fileName}`;
+				filePath = `${this._workspaceRoot}/${normalizedFileName}`;
 			}
 
 			// Ask host process to read the local file
@@ -137,6 +139,10 @@ export class DesktopFileProvider implements IFileProvider {
 
 	private generateKey(simfileId: string | null, fileName: string): string {
 		return `${simfileId || 'local'}:${fileName}`;
+	}
+
+	private normalizeFileName(fileName: string): string {
+		return fileName.replaceAll('\\', '/');
 	}
 
 	private copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {


### PR DESCRIPTION
## Summary
- Store EventBus handler references in `Editor` scene so listeners can be removed with the correct callback and references are cleared, preventing stale/duplicate callbacks after scene restart.
- Add `shutdown` cleanup for EventBus listeners and a test asserting all handlers are unregistered.
- Fix `DesktopEditor` Svelte lifecycle: wait for the previous Phaser game teardown before booting a new game, and guard `onMount` async initialization against a stale unmounted component.
- Reduce desktop editor sidebar minimum width from 200 px to 120 px so it can be dragged to a compact width before collapsing.
- Normalize backslash sample paths in `DesktopFileProvider` before reading from the local filesystem.

#### Test plan
- [x] `bun run --filter=@dtx/common build` passes
- [x] `bun run --filter=@dtx/common test -- Editor.test.ts` passes (142 tests)
- [x] `bun run --filter=dtx-desktop test -- DesktopEditor.test.ts desktopFileProvider.test.ts` passes (57 tests)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor and preview scene lifecycle cleanup to reliably unregister event handlers across shutdown, restart, and destroy (including idempotent teardown).
  * Desktop editor now coordinates Phaser teardown to prevent late UI updates and safely resolves even if destroy events misfire or throw.
  * Added better error emission when note import fails.
  * Hardened file fetching by normalizing backslashes, de-duplicating cache keys, and blocking parent-directory traversal attempts.
* **UI Improvements**
  * Reduced minimum sidebar width to 120 and reliably persists/restores it (with drag-based resizing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->