### PR TITLE
Harden security checks and filename sanitization

### DIFF
--- a/.github/workflows/desktop-build-deploy.yml
+++ b/.github/workflows/desktop-build-deploy.yml
@@ -476,12 +476,28 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
+      # Publish the fully-staged asset directory (build artifacts + latest.json)
+      # as a workflow artifact so the tag-only release job can attach exactly
+      # what was published to R2 — including the updater manifest, which the
+      # release job cannot reconstruct on its own. Gated to tags because the
+      # release job only runs on tag pushes; main-push continuous releases do
+      # not need a GitHub release.
+      - name: Upload Release Assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-assets
+          path: dist/artifacts/all/
+          retention-days: 5
+
   # GitHub release creation is split into its own tag-only job so the
   # `contents: write` permission is scoped to the single step that needs it
   # (softprops/action-gh-release). The R2 deploy job above runs with only
   # `contents: read`, limiting supply-chain exposure across checkout, artifact
   # processing, and the dynamically installed wrangler package. The release
-  # job runs only on tag pushes and re-downloads the build artifacts directly.
+  # job runs only on tag pushes and consumes the staged release-assets
+  # artifact (build artifacts + latest.json) produced by the deploy job, so it
+  # does not duplicate manifest generation or re-stage platform artifacts.
   release:
     permissions:
       contents: write
@@ -496,17 +512,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download Windows Artifacts
+      - name: Download Release Assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tauri-app-win
-          path: dist/artifacts/win
-
-      - name: Download macOS Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: tauri-app-mac
-          path: dist/artifacts/mac
+          name: release-assets
+          path: dist/artifacts/all
 
       - name: Set Release Version
         env:
@@ -526,15 +536,6 @@ jobs:
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
         shell: bash
-
-      - name: Stage Release Assets
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p dist/artifacts/all
-          cp dist/artifacts/win/* dist/artifacts/all/ 2>/dev/null || true
-          cp dist/artifacts/mac/* dist/artifacts/all/ 2>/dev/null || true
-          ls -la dist/artifacts/all/
 
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/desktop-build-deploy.yml
+++ b/.github/workflows/desktop-build-deploy.yml
@@ -43,6 +43,8 @@ on:
 
 jobs:
   build-windows:
+    permissions:
+      contents: read
     name: Windows Tauri Build
     if: github.event_name != 'pull_request' || github.head_ref != 'preview'
     runs-on: windows-latest
@@ -190,6 +192,8 @@ jobs:
           retention-days: 5
 
   build-mac:
+    permissions:
+      contents: read
     name: macOS Tauri Build
     if: github.event_name != 'pull_request' || github.head_ref != 'preview'
     runs-on: macos-latest
@@ -310,6 +314,8 @@ jobs:
           retention-days: 5
 
   deploy:
+    permissions:
+      contents: write
     name: Deploy to Cloudflare R2
     needs: [build-windows, build-mac]
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-build-deploy.yml
+++ b/.github/workflows/desktop-build-deploy.yml
@@ -315,7 +315,7 @@ jobs:
 
   deploy:
     permissions:
-      contents: write
+      contents: read
     name: Deploy to Cloudflare R2
     needs: [build-windows, build-mac]
     runs-on: ubuntu-latest
@@ -331,6 +331,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # No git operations are needed here (R2 upload only), so do not
+          # persist the GITHUB_TOKEN credential beyond checkout.
+          persist-credentials: false
 
       - name: Download Windows Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -472,8 +476,67 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Create Release (for tags only)
-        if: startsWith(github.ref, 'refs/tags/')
+  # GitHub release creation is split into its own tag-only job so the
+  # `contents: write` permission is scoped to the single step that needs it
+  # (softprops/action-gh-release). The R2 deploy job above runs with only
+  # `contents: read`, limiting supply-chain exposure across checkout, artifact
+  # processing, and the dynamically installed wrangler package. The release
+  # job runs only on tag pushes and re-downloads the build artifacts directly.
+  release:
+    permissions:
+      contents: write
+    name: Create GitHub Release (tags only)
+    needs: deploy
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tauri-app-win
+          path: dist/artifacts/win
+
+      - name: Download macOS Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tauri-app-mac
+          path: dist/artifacts/mac
+
+      - name: Set Release Version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
+            VERSION="${INPUT_VERSION}"
+          else
+            VERSION="$(jq -r '.version' packages/dtx-desktop/src-tauri/tauri.conf.json)"
+          fi
+          VERSION="${VERSION#v}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Release version '$VERSION' is not valid SemVer (expected MAJOR.MINOR.PATCH, e.g. 1.0.1)."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Stage Release Assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/artifacts/all
+          cp dist/artifacts/win/* dist/artifacts/all/ 2>/dev/null || true
+          cp dist/artifacts/mac/* dist/artifacts/all/ 2>/dev/null || true
+          ls -la dist/artifacts/all/
+
+      - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/packages/common/src/lib/components/UploadedAssetFiles.download-url.test.ts
+++ b/packages/common/src/lib/components/UploadedAssetFiles.download-url.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@testing-library/svelte', async () => await vi.importActual('@testing-library/svelte'));
+
+vi.mock('@skeletonlabs/skeleton-svelte', async () => {
+	const { default: AccordionStub } = await import('../../tests/stubs/AccordionStub.svelte');
+	const { default: AccordionItemStub } =
+		await import('../../tests/stubs/AccordionItemStub.svelte');
+	(AccordionStub as unknown as Record<string, unknown>).Item = AccordionItemStub;
+	return { Accordion: AccordionStub };
+});
+
+vi.mock('@lucide/svelte', () => ({
+	DownloadCloud: vi.fn()
+}));
+
+import { render, screen, waitFor } from '@testing-library/svelte';
+import UploadedAssetFiles from './UploadedAssetFiles.svelte';
+
+const cloudFile = {
+	fileName: 'snare#1.wav',
+	size: 100,
+	lastModified: '2024-01-01T00:00:00Z',
+	key: 'songs/1/snare#1.wav'
+};
+
+describe('UploadedAssetFiles download URL validation', () => {
+	it('uses an encoded root-relative URL when the desktop bucket origin is empty', async () => {
+		render(UploadedAssetFiles, {
+			props: {
+				simfileId: 'sim-1',
+				simfileBucketUrl: '',
+				loadAssetFiles: vi.fn().mockResolvedValue([cloudFile])
+			}
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTitle('Download file')).toHaveAttribute(
+				'href',
+				'/songs/1/snare%231.wav'
+			);
+		});
+	});
+
+	it('does not render a download link for an executable bucket URL scheme', async () => {
+		render(UploadedAssetFiles, {
+			props: {
+				simfileId: 'sim-1',
+				simfileBucketUrl: 'javascript:alert(1)',
+				loadAssetFiles: vi.fn().mockResolvedValue([cloudFile])
+			}
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('snare#1.wav')).toBeInTheDocument();
+			expect(screen.queryByTitle('Download file')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/packages/common/src/lib/components/UploadedAssetFiles.download-url.test.ts
+++ b/packages/common/src/lib/components/UploadedAssetFiles.download-url.test.ts
@@ -56,4 +56,23 @@ describe('UploadedAssetFiles download URL validation', () => {
 			expect(screen.queryByTitle('Download file')).not.toBeInTheDocument();
 		});
 	});
+
+	it.each([
+		['non-empty placeholder from .env.example', 'my_awesome_simfile_bucket_url'],
+		['protocol-only string', 'https://'],
+		['whitespace-only string', '   ']
+	])('hides the download link for a malformed bucket URL (%s)', async (_label, bucketUrl) => {
+		render(UploadedAssetFiles, {
+			props: {
+				simfileId: 'sim-1',
+				simfileBucketUrl: bucketUrl,
+				loadAssetFiles: vi.fn().mockResolvedValue([cloudFile])
+			}
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('snare#1.wav')).toBeInTheDocument();
+			expect(screen.queryByTitle('Download file')).not.toBeInTheDocument();
+		});
+	});
 });

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -488,6 +488,7 @@
 													<a
 														href={downloadUrl}
 														target="_blank"
+														rel="noopener noreferrer"
 														download={file.name}
 														class="inline-flex items-center rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/60"
 														title="Download file"

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -121,16 +121,21 @@
 	}
 
 	function getDownloadUrl(key: string): string {
-		// Parse the configured origin before appending untrusted key data. This
-		// avoids treating the URL as a string-based sanitization problem and keeps
-		// the host, credentials, query, and fragment outside the key-controlled path.
-		const url = new URL(simfileBucketUrl);
-		const baseSegments = url.pathname.split('/').filter(Boolean);
 		const keySegments = key
 			.split('/')
 			.filter((segment) => segment !== '' && segment !== '.' && segment !== '..')
 			.map(encodeURIComponent);
 
+		// Desktop intentionally omits a public bucket origin. Preserve its
+		// existing root-relative download path while still encoding each segment.
+		if (!simfileBucketUrl) {
+			return `/${keySegments.join('/')}`;
+		}
+
+		// Parse the configured web origin before appending untrusted key data so
+		// host, credentials, query, and fragment cannot be affected by the key.
+		const url = new URL(simfileBucketUrl);
+		const baseSegments = url.pathname.split('/').filter(Boolean);
 		url.pathname = `/${[...baseSegments, ...keySegments].join('/')}`;
 		return url.toString();
 	}
@@ -155,7 +160,7 @@
 		selectedFiles = new Set(selectedFiles);
 
 		if (checked) {
-			// Select all files that have userFile property (new or replacing)
+			// Select all files that have a userFile property (new or replacing)
 			for (const file of mergedFiles) {
 				if (file.userFile) {
 					selectedFiles.add(file.name);
@@ -306,7 +311,6 @@
 					status: 'new' as const,
 					userFile
 				});
-			});
 		}
 
 		return merged;
@@ -482,7 +486,7 @@
 												<span class="text-gray-400 dark:text-slate-500"
 													>-</span
 												>
-											{/if}
+												{/if}
 										</td>
 									</tr>
 								{/each}

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -121,7 +121,17 @@
 	}
 
 	function getDownloadUrl(key: string): string {
-		return `${simfileBucketUrl}/${key}`;
+		// Encode each path segment at the URL-construction boundary. The key
+		// originates from the API (which stores the sanitizeFilename() output
+		// beneath the simfile prefix), and sanitizeFilename does NOT decode
+		// percent-encoding — so a key like `%2e%2e/secret.txt` passes through
+		// unchanged. Interpolating it raw lets browser URL canonicalization
+		// decode `%2e` to `.` and resolve `..` out of the simfile prefix.
+		// encodeURIComponent encodes the `%` to `%25`, so the browser treats
+		// `%2e%2e` as a literal segment rather than a traversal. Matches the
+		// API's R2 URL construction (toPublicUrl / cache-purge encoding).
+		const base = simfileBucketUrl.replace(/\/+$/, '');
+		return `${base}/${key.split('/').map(encodeURIComponent).join('/')}`;
 	}
 
 	// Toggle selection of a file

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -120,7 +120,7 @@
 		return dayjs(dateString).format('YYYY-MM-DD HH:mm');
 	}
 
-	function getDownloadUrl(key: string): string {
+	function getDownloadUrl(key: string): string | null {
 		const keySegments = key
 			.split('/')
 			.filter((segment) => segment !== '' && segment !== '.' && segment !== '..')
@@ -132,9 +132,13 @@
 			return `/${keySegments.join('/')}`;
 		}
 
-		// Parse the configured web origin before appending untrusted key data so
-		// host, credentials, query, and fragment cannot be affected by the key.
+		// Only HTTP(S) bucket origins may reach an anchor href. Parsing first and
+		// positively allowlisting the protocol prevents executable URL schemes.
 		const url = new URL(simfileBucketUrl);
+		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+			return null;
+		}
+
 		const baseSegments = url.pathname.split('/').filter(Boolean);
 		url.pathname = `/${[...baseSegments, ...keySegments].join('/')}`;
 		return url.toString();
@@ -474,15 +478,22 @@
 										{/if}
 										<td class="px-4 py-2 text-center">
 											{#if file.source === 'cloud' && file.key}
-												<a
-													href={getDownloadUrl(file.key)}
-													target="_blank"
-													download={file.name}
-													class="inline-flex items-center rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/60"
-													title="Download file"
-												>
-													<DownloadCloud />
-												</a>
+												{@const downloadUrl = getDownloadUrl(file.key)}
+												{#if downloadUrl}
+													<a
+														href={downloadUrl}
+														target="_blank"
+														download={file.name}
+														class="inline-flex items-center rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/60"
+														title="Download file"
+													>
+														<DownloadCloud />
+													</a>
+												{:else}
+													<span class="text-gray-400 dark:text-slate-500"
+														>-</span
+													>
+												{/if}
 											{:else}
 												<span class="text-gray-400 dark:text-slate-500"
 													>-</span

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -134,7 +134,12 @@
 
 		// Only HTTP(S) bucket origins may reach an anchor href. Parsing first and
 		// positively allowlisting the protocol prevents executable URL schemes.
-		const url = new URL(simfileBucketUrl);
+		let url: URL;
+		try {
+			url = new URL(simfileBucketUrl);
+		} catch {
+			return null;
+		}
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 			return null;
 		}

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -121,17 +121,18 @@
 	}
 
 	function getDownloadUrl(key: string): string {
-		// Encode each path segment at the URL-construction boundary. The key
-		// originates from the API (which stores the sanitizeFilename() output
-		// beneath the simfile prefix), and sanitizeFilename does NOT decode
-		// percent-encoding — so a key like `%2e%2e/secret.txt` passes through
-		// unchanged. Interpolating it raw lets browser URL canonicalization
-		// decode `%2e` to `.` and resolve `..` out of the simfile prefix.
-		// encodeURIComponent encodes the `%` to `%25`, so the browser treats
-		// `%2e%2e` as a literal segment rather than a traversal. Matches the
-		// API's R2 URL construction (toPublicUrl / cache-purge encoding).
-		const base = simfileBucketUrl.replace(/\/+$/, '');
-		return `${base}/${key.split('/').map(encodeURIComponent).join('/')}`;
+		// Parse the configured origin before appending untrusted key data. This
+		// avoids treating the URL as a string-based sanitization problem and keeps
+		// the host, credentials, query, and fragment outside the key-controlled path.
+		const url = new URL(simfileBucketUrl);
+		const baseSegments = url.pathname.split('/').filter(Boolean);
+		const keySegments = key
+			.split('/')
+			.filter((segment) => segment !== '' && segment !== '.' && segment !== '..')
+			.map(encodeURIComponent);
+
+		url.pathname = `/${[...baseSegments, ...keySegments].join('/')}`;
+		return url.toString();
 	}
 
 	// Toggle selection of a file
@@ -154,7 +155,7 @@
 		selectedFiles = new Set(selectedFiles);
 
 		if (checked) {
-			// Select all files that have a userFile property (new or replacing)
+			// Select all files that have userFile property (new or replacing)
 			for (const file of mergedFiles) {
 				if (file.userFile) {
 					selectedFiles.add(file.name);

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -487,7 +487,7 @@
 												<span class="text-gray-400 dark:text-slate-500"
 													>-</span
 												>
-												{/if}
+											{/if}
 										</td>
 									</tr>
 								{/each}

--- a/packages/common/src/lib/components/UploadedAssetFiles.svelte
+++ b/packages/common/src/lib/components/UploadedAssetFiles.svelte
@@ -311,6 +311,7 @@
 					status: 'new' as const,
 					userFile
 				});
+			});
 		}
 
 		return merged;

--- a/packages/common/src/lib/components/UploadedAssetFiles.test.ts
+++ b/packages/common/src/lib/components/UploadedAssetFiles.test.ts
@@ -122,6 +122,54 @@ describe('UploadedAssetFiles', () => {
 		});
 	});
 
+	it('encodes each key segment in download URLs (special chars, spaces, non-ASCII)', async () => {
+		const loadAssetFiles = vi.fn().mockResolvedValue([
+			{
+				fileName: 'snare#1.wav',
+				size: 100,
+				lastModified: '2024-01-01T00:00:00Z',
+				key: 'songs/1/snare#1.wav'
+			}
+		]);
+		render(UploadedAssetFiles, { props: makeProps({ simfileId: 'sim-1', loadAssetFiles }) });
+		await waitFor(() => {
+			const link = screen.getByTitle('Download file');
+			// `#` must be encoded to %23, else the browser treats it as a URL fragment.
+			expect(link).toHaveAttribute('href', 'https://cdn.example.com/songs/1/snare%231.wav');
+		});
+	});
+
+	it('defeats percent-encoded path-traversal keys in download URLs', async () => {
+		// sanitizeFilename does not decode percent-encoding, so a stored key of
+		// `%2e%2e/secret.dtx` reaches the UI unchanged. The download URL must
+		// encode the `%` to `%25` so the browser treats `%2e%2e` as a literal
+		// segment instead of decoding it to `..` and escaping the simfile prefix.
+		const cases = [
+			{ key: '%2e%2e/secret.dtx', expected: '%252e%252e' },
+			{ key: '.%2e/secret.dtx', expected: '.%252e' },
+			{ key: '%2E%2E/secret.dtx', expected: '%252E%252E' } // mixed-case encoding
+		];
+		for (const { key, expected } of cases) {
+			const loadAssetFiles = vi
+				.fn()
+				.mockResolvedValue([
+					{ fileName: 'secret.dtx', size: 100, lastModified: '2024-01-01T00:00:00Z', key }
+				]);
+			const { unmount } = render(UploadedAssetFiles, {
+				props: makeProps({ simfileId: 'sim-1', loadAssetFiles })
+			});
+			await waitFor(() => {
+				const link = screen.getByTitle('Download file');
+				const href = link.getAttribute('href') ?? '';
+				// The traversal sequence is double-encoded (the `%` becomes `%25`),
+				// so the browser never decodes it back to `..`.
+				expect(href).toContain(expected);
+				expect(href).not.toMatch(/(?<!%25)\.\.(?=\/|$)/);
+			});
+			unmount();
+		}
+	});
+
 	it('shows error state when loadAssetFiles throws', async () => {
 		const loadAssetFiles = vi.fn().mockRejectedValue(new Error('Network failed'));
 		render(UploadedAssetFiles, {

--- a/packages/dtx-api/src/lib/sanitizeFilename.test.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.test.ts
@@ -71,6 +71,13 @@ describe('sanitizeFilename', () => {
 		expect(sanitizeFilename('audio/.\x01./song.wav')).toBe('audio/song.wav');
 	});
 
+	it('removes Windows-style backslash traversal sequences exposed by control-character removal', () => {
+		// ".\x00.\" collapses to "..\" after control-char stripping, which the iterative loop removes.
+		expect(sanitizeFilename('.\x00.\\secret.txt')).toBe('secret.txt');
+		expect(sanitizeFilename('audio\\.\x01.\\song.wav')).toBe('audio/song.wav');
+		expect(sanitizeFilename('..\\.\x00.\\secret.txt')).toBe('secret.txt');
+	});
+
 	it('removes DEL character (0x7f)', () => {
 		expect(sanitizeFilename('file\x7fname.wav')).toBe('filename.wav');
 	});

--- a/packages/dtx-api/src/lib/sanitizeFilename.test.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.test.ts
@@ -96,6 +96,42 @@ describe('sanitizeFilename', () => {
 		expect(result.endsWith('.wav')).toBe(true);
 	});
 
+	it('re-normalizes traversal after truncation exposes a trailing ".." segment', () => {
+		// Length 1045 > 1024. "..x/" is not a traversal segment before truncation
+		// (the dots are followed by "x", not a slash), so the pre-truncation loop
+		// leaves it intact. Slicing to 1024 cuts at "aaa/.." and would return a
+		// trailing "/.." segment without a final normalization pass.
+		const input = 'a'.repeat(1021) + '/..x/' + 'b'.repeat(20);
+		const result = sanitizeFilename(input);
+		expect(result.length).toBeLessThanOrEqual(1024);
+		// No path segment may resolve to parent-directory traversal.
+		const segments = result.split('/');
+		expect(segments).not.toContain('..');
+		expect(segments).not.toContain('.');
+		// The trailing "/.." must have been stripped, leaving the leading dir.
+		expect(result).toBe('a'.repeat(1021));
+	});
+
+	it('drops a trailing "." segment exposed by truncation', () => {
+		// Slicing to 1024 cuts at "aaa/." producing a trailing "/." segment.
+		const input = 'a'.repeat(1023) + '/.x' + 'b'.repeat(20);
+		const result = sanitizeFilename(input);
+		expect(result.length).toBeLessThanOrEqual(1024);
+		const segments = result.split('/');
+		expect(segments).not.toContain('.');
+		expect(segments).not.toContain('..');
+		expect(result).toBe('a'.repeat(1023));
+	});
+
+	it('drops single-dot segments the traversal regex loop does not match', () => {
+		// The regex loop only matches ".." (two dots). A single "." segment such as
+		// "foo/./bar" passes through it unchanged; the final segment guard must drop it
+		// so URL canonicalization does not collapse "/./" against the public bucket.
+		expect(sanitizeFilename('foo/./bar')).toBe('foo/bar');
+		expect(sanitizeFilename('./foo')).toBe('foo');
+		expect(sanitizeFilename('foo/.')).toBe('foo');
+	});
+
 	it('preserves complex directory structures with DTX-style paths', () => {
 		expect(sanitizeFilename('graphics/jacket.png')).toBe('graphics/jacket.png');
 		expect(sanitizeFilename('sound/snare.wav')).toBe('sound/snare.wav');

--- a/packages/dtx-api/src/lib/sanitizeFilename.test.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.test.ts
@@ -66,6 +66,11 @@ describe('sanitizeFilename', () => {
 		expect(sanitizeFilename('file\x01\x02name.wav')).toBe('filename.wav');
 	});
 
+	it('removes traversal sequences exposed by control-character removal', () => {
+		expect(sanitizeFilename('.\x00./secret.txt')).toBe('secret.txt');
+		expect(sanitizeFilename('audio/.\x01./song.wav')).toBe('audio/song.wav');
+	});
+
 	it('removes DEL character (0x7f)', () => {
 		expect(sanitizeFilename('file\x7fname.wav')).toBe('filename.wav');
 	});

--- a/packages/dtx-api/src/lib/sanitizeFilename.test.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.test.ts
@@ -132,6 +132,23 @@ describe('sanitizeFilename', () => {
 		expect(sanitizeFilename('foo/.')).toBe('foo');
 	});
 
+	it('re-trims separators after dropping dot segments adjacent to repeated slashes', () => {
+		// The final segment filter removes "." / ".." segments but preserves the
+		// empty segments next to them, so join('/') reintroduces a leading or
+		// trailing slash. A trailing normalizeTraversal pass must strip them.
+		expect(sanitizeFilename('.//song.dtx')).toBe('song.dtx');
+		expect(sanitizeFilename('...///song.dtx')).toBe('song.dtx');
+		expect(sanitizeFilename('folder//.')).toBe('folder');
+		expect(sanitizeFilename('./folder/.')).toBe('folder');
+		expect(sanitizeFilename('folder/./sub/.')).toBe('folder/sub');
+		// Leading/trailing separators must never survive sanitization, otherwise
+		// the upload caller builds keys like `42//song.dtx` and catalog discovery
+		// (r2Enrichment.isTopLevelKey) misclassifies a top-level file as nested.
+		const result = sanitizeFilename('.//song.dtx');
+		expect(result.startsWith('/')).toBe(false);
+		expect(result.endsWith('/')).toBe(false);
+	});
+
 	it('preserves complex directory structures with DTX-style paths', () => {
 		expect(sanitizeFilename('graphics/jacket.png')).toBe('graphics/jacket.png');
 		expect(sanitizeFilename('sound/snare.wav')).toBe('sound/snare.wav');

--- a/packages/dtx-api/src/lib/sanitizeFilename.test.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.test.ts
@@ -149,6 +149,17 @@ describe('sanitizeFilename', () => {
 		expect(result.endsWith('/')).toBe(false);
 	});
 
+	it('preserves a multi-segment dot/underscore/hyphen path rather than falling back to file_<timestamp>', () => {
+		// The fallback regex /^[._-]*$/ matches strings made only of '.', '_', '-'.
+		// A multi-segment path separated by real slashes contains '/' and so must NOT
+		// match the fallback — each segment keeps its non-traversal characters and the
+		// joined result is preserved instead of being replaced with `file_<timestamp>`.
+		const input = '._-/_-.';
+		const result = sanitizeFilename(input);
+		expect(result).toBe('._-/_-.');
+		expect(result).not.toMatch(/^file_\d+$/);
+	});
+
 	it('preserves complex directory structures with DTX-style paths', () => {
 		expect(sanitizeFilename('graphics/jacket.png')).toBe('graphics/jacket.png');
 		expect(sanitizeFilename('sound/snare.wav')).toBe('sound/snare.wav');

--- a/packages/dtx-api/src/lib/sanitizeFilename.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.ts
@@ -1,3 +1,25 @@
+// Iteratively strip path-traversal sequences and collapse dot-runs that could
+// resolve to traversal after separator normalization. Runs until stable.
+// Handles both forward and back slashes so it is valid before separator
+// normalization as well as after.
+const normalizeTraversal = (value: string): string => {
+	let result = value;
+	// Iteratively remove path traversal sequences until the string stabilizes.
+	let previous: string;
+	do {
+		previous = result;
+		result = result
+			.replace(/\.\.(?:\/|\\)/g, '')
+			.replace(/[/\\]\.\.$/, '')
+			.replace(/^[/\\]+/, '')
+			.replace(/[/\\]+$/, '');
+	} while (result !== previous);
+
+	// Collapse runs of dots followed by slashes (e.g., "....//" -> "")
+	result = result.replace(/\.{2,}([/\\]+)/g, '');
+	return result;
+};
+
 // Helper function to sanitize filename for safe storage keys.
 // Preserves directory structure and non-ASCII characters while preventing path traversal.
 export const sanitizeFilename = (filename: string): string => {
@@ -7,24 +29,14 @@ export const sanitizeFilename = (filename: string): string => {
 	// eslint-disable-next-line no-control-regex
 	sanitized = sanitized.replace(/[\x00-\x1f\x7f]/g, '');
 
-	// Iteratively remove path traversal sequences until the string stabilizes.
-	let previousSanitized: string;
-	do {
-		previousSanitized = sanitized;
-		sanitized = sanitized
-			.replace(/\.\.(?:\/|\\)/g, '')
-			.replace(/[/\\]\.\.$/, '')
-			.replace(/^[/\\]+/, '')
-			.replace(/[/\\]+$/, '');
-	} while (sanitized !== previousSanitized);
-
-	// Collapse runs of dots followed by slashes (e.g., "....//" -> "")
-	sanitized = sanitized.replace(/\.{2,}([/\\]+)/g, '');
+	sanitized = normalizeTraversal(sanitized);
 
 	// Normalize path separators to forward slash for consistency
 	sanitized = sanitized.replace(/\\/g, '/');
 
-	// Truncate to reasonable max length (1024 chars for S3/object storage compatibility)
+	// Truncate to reasonable max length (1024 chars for S3/object storage compatibility).
+	// Truncation can create new dot-only path segments (e.g. "aaa/..x/bbb" sliced to
+	// "aaa/.."), so traversal normalization MUST run again afterwards.
 	const MAX_LENGTH = 1024;
 	if (sanitized.length > MAX_LENGTH) {
 		const lastSlash = sanitized.lastIndexOf('/');
@@ -42,6 +54,19 @@ export const sanitizeFilename = (filename: string): string => {
 			sanitized = sanitized.slice(0, MAX_LENGTH);
 		}
 	}
+
+	// Re-normalize after truncation: slicing can expose a trailing "/.." or "/."
+	// segment that wasn't present before the cut.
+	sanitized = normalizeTraversal(sanitized);
+
+	// Final guard: drop any remaining "." or ".." segments introduced by a
+	// transformation that changed segment boundaries. encodeURIComponent leaves
+	// "." and ".." untouched, so URL canonicalization would otherwise resolve
+	// them as directory traversal against the public bucket.
+	sanitized = sanitized
+		.split('/')
+		.filter((segment) => segment !== '.' && segment !== '..')
+		.join('/');
 
 	// Fallback if result is empty or just dots/slashes
 	if (!sanitized || /^[./\\_-]*$/.test(sanitized)) {

--- a/packages/dtx-api/src/lib/sanitizeFilename.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.ts
@@ -3,6 +3,10 @@
 export const sanitizeFilename = (filename: string): string => {
 	let sanitized = filename;
 
+	// Remove control characters before path traversal checks because their removal can join segments.
+	// eslint-disable-next-line no-control-regex
+	sanitized = sanitized.replace(/[\x00-\x1f\x7f]/g, '');
+
 	// Iteratively remove path traversal sequences until the string stabilizes.
 	let previousSanitized: string;
 	do {
@@ -19,10 +23,6 @@ export const sanitizeFilename = (filename: string): string => {
 
 	// Normalize path separators to forward slash for consistency
 	sanitized = sanitized.replace(/\\/g, '/');
-
-	// Remove null bytes, control characters, and DEL
-	// eslint-disable-next-line no-control-regex
-	sanitized = sanitized.replace(/[\x00-\x1f\x7f]/g, '');
 
 	// Truncate to reasonable max length (1024 chars for S3/object storage compatibility)
 	const MAX_LENGTH = 1024;

--- a/packages/dtx-api/src/lib/sanitizeFilename.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.ts
@@ -68,6 +68,15 @@ export const sanitizeFilename = (filename: string): string => {
 		.filter((segment) => segment !== '.' && segment !== '..')
 		.join('/');
 
+	// Re-trim separators after the segment filter. Removing a leading or
+	// trailing "." / ".." segment leaves an adjacent empty segment, which
+	// join('/') turns back into a leading or trailing slash (e.g. ".//song"
+	// -> "/song", "folder//." -> "folder/"). That violates the sanitizer's
+	// no-leading/trailing-separator contract and, at the upload caller, also
+	// makes catalog discovery misclassify a top-level file as nested because
+	// the portion after the `${simfileId}/` prefix still contains a slash.
+	sanitized = normalizeTraversal(sanitized);
+
 	// Fallback if result is empty or just dots/slashes
 	if (!sanitized || /^[./\\_-]*$/.test(sanitized)) {
 		sanitized = `file_${Date.now()}`;

--- a/packages/dtx-api/src/lib/sanitizeFilename.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.ts
@@ -1,42 +1,27 @@
-// Iteratively strip path-traversal sequences and collapse dot-runs that could
-// resolve to traversal after separator normalization. Runs until stable.
-// Handles both forward and back slashes so it is valid before separator
-// normalization as well as after.
-const normalizeTraversal = (value: string): string => {
-	let result = value;
-	// Iteratively remove path traversal sequences until the string stabilizes.
-	let previous: string;
-	do {
-		previous = result;
-		result = result
-			.replace(/\.\.(?:\/|\\)/g, '')
-			.replace(/[/\\]\.\.$/, '')
-			.replace(/^[/\\]+/, '')
-			.replace(/[/\\]+$/, '');
-	} while (result !== previous);
-
-	// Collapse runs of dots followed by slashes (e.g., "....//" -> "")
-	result = result.replace(/\.{2,}([/\\]+)/g, '');
-	return result;
-};
+// Normalize separators and discard empty or dot-only path segments.
+// This avoids removal-based traversal sanitization, where deleting one
+// substring can expose a new dangerous sequence at the same boundary.
+const normalizePathSegments = (value: string): string =>
+	value
+		.replace(/\\/g, '/')
+		.split('/')
+		.filter((segment) => segment.length > 0 && !/^\.+$/.test(segment))
+		.join('/');
 
 // Helper function to sanitize filename for safe storage keys.
 // Preserves directory structure and non-ASCII characters while preventing path traversal.
 export const sanitizeFilename = (filename: string): string => {
 	let sanitized = filename;
 
-	// Remove control characters before path traversal checks because their removal can join segments.
+	// Remove control characters before segment parsing because their removal can join tokens.
 	// eslint-disable-next-line no-control-regex
 	sanitized = sanitized.replace(/[\x00-\x1f\x7f]/g, '');
 
-	sanitized = normalizeTraversal(sanitized);
-
-	// Normalize path separators to forward slash for consistency
-	sanitized = sanitized.replace(/\\/g, '/');
+	// Parse the path structurally rather than deleting traversal substrings.
+	sanitized = normalizePathSegments(sanitized);
 
 	// Truncate to reasonable max length (1024 chars for S3/object storage compatibility).
-	// Truncation can create new dot-only path segments (e.g. "aaa/..x/bbb" sliced to
-	// "aaa/.."), so traversal normalization MUST run again afterwards.
+	// Truncation can create a new dot-only trailing segment, so segment parsing runs again below.
 	const MAX_LENGTH = 1024;
 	if (sanitized.length > MAX_LENGTH) {
 		const lastSlash = sanitized.lastIndexOf('/');
@@ -55,30 +40,11 @@ export const sanitizeFilename = (filename: string): string => {
 		}
 	}
 
-	// Re-normalize after truncation: slicing can expose a trailing "/.." or "/."
-	// segment that wasn't present before the cut.
-	sanitized = normalizeTraversal(sanitized);
+	// Re-parse after truncation so newly exposed empty or dot-only segments cannot survive.
+	sanitized = normalizePathSegments(sanitized);
 
-	// Final guard: drop any remaining "." or ".." segments introduced by a
-	// transformation that changed segment boundaries. encodeURIComponent leaves
-	// "." and ".." untouched, so URL canonicalization would otherwise resolve
-	// them as directory traversal against the public bucket.
-	sanitized = sanitized
-		.split('/')
-		.filter((segment) => segment !== '.' && segment !== '..')
-		.join('/');
-
-	// Re-trim separators after the segment filter. Removing a leading or
-	// trailing "." / ".." segment leaves an adjacent empty segment, which
-	// join('/') turns back into a leading or trailing slash (e.g. ".//song"
-	// -> "/song", "folder//." -> "folder/"). That violates the sanitizer's
-	// no-leading/trailing-separator contract and, at the upload caller, also
-	// makes catalog discovery misclassify a top-level file as nested because
-	// the portion after the `${simfileId}/` prefix still contains a slash.
-	sanitized = normalizeTraversal(sanitized);
-
-	// Fallback if result is empty or just dots/slashes
-	if (!sanitized || /^[./\\_-]*$/.test(sanitized)) {
+	// Fallback if result is empty or contains no usable filename characters.
+	if (!sanitized || /^[._-]*$/.test(sanitized)) {
 		sanitized = `file_${Date.now()}`;
 	}
 

--- a/packages/dtx-api/src/lib/sanitizeFilename.ts
+++ b/packages/dtx-api/src/lib/sanitizeFilename.ts
@@ -1,12 +1,37 @@
-// Normalize separators and discard empty or dot-only path segments.
-// This avoids removal-based traversal sanitization, where deleting one
-// substring can expose a new dangerous sequence at the same boundary.
-const normalizePathSegments = (value: string): string =>
-	value
-		.replace(/\\/g, '/')
-		.split('/')
-		.filter((segment) => segment.length > 0 && !/^\.+$/.test(segment))
-		.join('/');
+// Normalize separators and discard empty or traversal-only path segments.
+// This avoids removal-based sanitization, where deleting one substring can
+// expose a new dangerous sequence at the same boundary.
+const normalizePathSegments = (value: string): string => {
+	const rawSegments = value.replace(/\\/g, '/').split('/');
+	const normalized: string[] = [];
+	let safeDotPrefix = '';
+
+	for (let index = 0; index < rawSegments.length; index++) {
+		const segment = rawSegments[index];
+		if (!segment) {
+			safeDotPrefix = '';
+			continue;
+		}
+
+		if (/^\.+$/.test(segment)) {
+			// Exact dot segments are traversal syntax and are discarded. Longer
+			// dot runs followed by one separator retain only their non-traversal
+			// remainder as a prefix on the next filename segment ("..../x" -> "..x").
+			// A repeated separator clears that prefix ("....//x" -> "x").
+			if (segment.length > 2 && rawSegments[index + 1]) {
+				safeDotPrefix = segment.slice(2);
+			} else {
+				safeDotPrefix = '';
+			}
+			continue;
+		}
+
+		normalized.push(safeDotPrefix + segment);
+		safeDotPrefix = '';
+	}
+
+	return normalized.join('/');
+};
 
 // Helper function to sanitize filename for safe storage keys.
 // Preserves directory structure and non-ASCII characters while preventing path traversal.


### PR DESCRIPTION
## Summary

- Fix a control-character path-traversal bypass in `sanitizeFilename` and add regression coverage.
- Declare least-privilege `GITHUB_TOKEN` permissions for test, lint, and desktop build/deploy workflows.
- Enable GitHub Secret Scanning for the repository.

## Root cause

Control characters were removed after traversal normalization. An input such as `.\0./secret.txt` therefore became `../secret.txt` after the traversal checks had already run. Controls are now stripped before traversal normalization.

## Validation

- `bun run test` (7 Turbo tasks successful)
- `actionlint` on the four changed workflows
- `dtx-api` typecheck and focused sanitizer regression tests
- Adversarial filename sanitizer fuzz check

## Follow-up

Dependabot alert #81 for `glib` remains open intentionally: Tauri 2.11.5's Linux GTK3 dependency chain requires `glib ^0.18`, which cannot resolve the patched `0.20` release. Addressing it requires an upstream/fork or GTK4 migration decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename handling to prevent unsafe path traversal and malformed filenames.
  * Secured uploaded-file download links by validating destinations and safely encoding file paths.
  * Invalid or unsafe download locations now show a placeholder instead of an unusable link.
  * Preserved support for valid filenames containing spaces, punctuation, and special characters.

* **Security**
  * Added safer handling for external download destinations and prevented opener-based security risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->