### PR TITLE
ci: skip runner jobs for draft pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the `build-mode` for that language to customize how
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
@@ -86,7 +86,7 @@ jobs:
 
       # If the analyze step fails for one of the languages you are analyzing with
       # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual". Then modify this step
+      # to set the build mode to "manual" for that language. Then modify this step
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,11 +16,13 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: '45 14 * * 4'
 
 jobs:
   analyze:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -57,7 +59,7 @@ jobs:
         # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # If you are analyzing a compiled language, you can modify the `build-mode` for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
@@ -84,7 +86,7 @@ jobs:
 
       # If the analyze step fails for one of the languages you are analyzing with
       # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual" for that language. Then modify this step
+      # to set the build mode to "manual". Then modify this step
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/desktop-build-deploy.yml
+++ b/.github/workflows/desktop-build-deploy.yml
@@ -3,6 +3,7 @@ name: Desktop App Cross-Platform Build and Deploy
 on:
   pull_request:
     branches: [main, master]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - preview
@@ -46,7 +47,7 @@ jobs:
     permissions:
       contents: read
     name: Windows Tauri Build
-    if: github.event_name != 'pull_request' || github.head_ref != 'preview'
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.head_ref != 'preview')
     runs-on: windows-latest
     # Each platform build targets its own GitHub environment so concurrent
     # build-windows / build-mac runs each get their own "active" deployment
@@ -195,7 +196,7 @@ jobs:
     permissions:
       contents: read
     name: macOS Tauri Build
-    if: github.event_name != 'pull_request' || github.head_ref != 'preview'
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.head_ref != 'preview')
     runs-on: macos-latest
     # See build-windows for the rationale on per-platform environments.
     environment: Desktop-macOS

--- a/.github/workflows/desktop-e2e-test.yml
+++ b/.github/workflows/desktop-e2e-test.yml
@@ -18,6 +18,7 @@ on:
     branches:
       - main
       - master
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'packages/dtx-desktop/**'
       - 'packages/e2e-desktop/**'
@@ -33,6 +34,7 @@ permissions:
 
 jobs:
   desktop-e2e:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Tauri Integration Test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,12 +4,14 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -6,12 +6,14 @@ on:
       - main
       - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   lint-and-format:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tauri-rust-ci.yml
+++ b/.github/workflows/tauri-rust-ci.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Minimal permissions: this workflow only builds, lints, and tests — it never
 # pushes commits, creates releases, or deploys. Reduces blast radius if the
@@ -22,6 +23,7 @@ permissions:
 
 jobs:
   build-and-lint:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Build & Lint
     runs-on: ubuntu-latest
     defaults:
@@ -98,6 +100,7 @@ jobs:
         run: cargo build --locked
 
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Unit Tests
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,12 +6,14 @@ on:
       - main
       - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- skip frontend lint/unit/E2E, Tauri Rust CI, desktop E2E, CodeQL, and unsigned Windows/macOS desktop builds while a pull request is draft
- preserve existing path filters and the desktop `preview` exclusion
- preserve push, scheduled CodeQL, manual release, R2 deploy, and GitHub release behavior
- add `ready_for_review` to every PR-triggered workflow

## Why

GitHub Actions cannot filter `pull_request` events by draft state. These job-level guards avoid substantial Bun, Rust, Playwright, Supabase, CodeQL, Windows, and macOS runner work during draft iteration while retaining the same CI once review begins.

## Validation

- workflow-only changes
- release/deploy-only jobs are unchanged
- existing desktop PR safety/signing conditions are preserved and combined with the draft guard
