### PR TITLE
ci: lower Codecov coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,13 +2,13 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        target: 90%
         threshold: 0%
         informational: false
         if_not_found: failure
     patch:
       default:
-        target: 95%
+        target: 90%
         threshold: 0%
         informational: false
         if_not_found: failure


### PR DESCRIPTION
## Summary

Lower Codecov project and patch targets from 95% to 90%, while preserving zero tolerance, blocking statuses, and missing-report failure.

## Validation

- `codecov.yml` only
