### PR TITLE
docs: plan HPA-614 current simfile model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,9 @@ If needed, cache can be manually cleared via browser dev tools:
 simFileService.clearCache();
 
 // Or clear specific localStorage items
-localStorage.removeItem('simfiles_cache');
-localStorage.removeItem('simfiles_cache_timestamp');
+localStorage.removeItem('simfiles_cache_v2');
+localStorage.removeItem('simfiles_cache_timestamp_v2');
+localStorage.removeItem('dtx_linkage_cache_v2');
 localStorage.removeItem('song_templates');
 
 // DO NOT clear these (breaks auth/workspace)

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "drumery",

--- a/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
@@ -37,12 +37,14 @@
 ## Task 1: Add the neutral model and migrate `ChartDetail`
 
 **Files:**
+
 - Create: `packages/common/src/lib/types/simfile.ts`
 - Modify: `packages/common/src/lib/index.ts`
 - Modify: `packages/common/src/lib/components/ChartDetail.svelte`
 - Modify: `packages/common/src/lib/components/ChartDetail.test.ts`
 
 **Interfaces:**
+
 - Produces: `SimfileModel`, `SimfileDtxFile`, `SimfileAssetFile` from the main `@dtx/common` barrel.
 - Temporarily preserves: existing main-barrel `SimfileWithDtx`, D1 row exports, and `toSimfileWithDtx` until Task 5.
 
@@ -180,6 +182,7 @@ git commit -m "refactor(common): add current simfile model"
 ## Task 2: Migrate the web GraphQL boundary and web consumers
 
 **Files:**
+
 - Modify: `packages/dtx-web/src/lib/api/chart.ts`
 - Modify: `packages/dtx-web/src/lib/api/chart.test.ts`
 - Modify: `packages/dtx-web/src/lib/components/ChartList.helpers.ts`
@@ -195,6 +198,7 @@ git commit -m "refactor(common): add current simfile model"
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts`
 
 **Interfaces:**
+
 - Consumes: `SimfileModel`, `SimfileDtxFile` from Task 1.
 - Produces: `toSimfileModel()` as the only web GraphQL→full-model adapter.
 
@@ -318,13 +322,13 @@ Do not alter UI behavior/styling.
 Rename:
 
 ```ts
-formatLevelDisplay(dtx_files)
+formatLevelDisplay(dtx_files);
 ```
 
 to:
 
 ```ts
-formatLevelDisplay(dtxFiles)
+formatLevelDisplay(dtxFiles);
 ```
 
 and update the comment to describe DTX level values rather than naming the D1 column. Keep the function behavior unchanged.
@@ -343,7 +347,7 @@ let simfile: SimfileModel | null = $state(null);
 Delete the `LegacySimfile` import and render:
 
 ```svelte
-<ChartDetail simfile={simfile} ... />
+<ChartDetail {simfile} ... />
 ```
 
 with no `SimfileWithDtxFiles` cast. Update page-level field reads and tests to camelCase.
@@ -388,11 +392,13 @@ git commit -m "refactor(web): consume current simfile model"
 ## Task 3: Make the Rust/Tauri full-simfile boundary emit the current model
 
 **Files:**
+
 - Create: `packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json`
 - Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
 
 **Interfaces:**
+
 - Produces: camelCase full-model JSON from `simfile_model_from_graphql`.
 - Produces: one cross-language behavioral fixture consumed again in Task 4.
 - Preserves: score-search string ids and general-update exclusion of `googleDriveFileId`.
@@ -403,23 +409,21 @@ Create:
 
 ```json
 {
-  "id": 42,
-  "displayId": 7,
-  "title": "Fixture Song",
-  "artist": "Fixture Artist",
-  "bpm": 123.5,
-  "userId": "user-1",
-  "googleDriveFileId": null,
-  "isPublished": true,
-  "downloadUrl": "https://example.test/chart.zip",
-  "previewUrl": null,
-  "videoPreviewUrl": null,
-  "publishDate": "2026-08-15",
-  "createdAt": "2026-08-15T00:00:00Z",
-  "updatedAt": "2026-08-15T00:00:01Z",
-  "dtxFiles": [
-    { "id": 99, "label": "EXT", "level": 85 }
-  ]
+	"id": 42,
+	"displayId": 7,
+	"title": "Fixture Song",
+	"artist": "Fixture Artist",
+	"bpm": 123.5,
+	"userId": "user-1",
+	"googleDriveFileId": null,
+	"isPublished": true,
+	"downloadUrl": "https://example.test/chart.zip",
+	"previewUrl": null,
+	"videoPreviewUrl": null,
+	"publishDate": "2026-08-15",
+	"createdAt": "2026-08-15T00:00:00Z",
+	"updatedAt": "2026-08-15T00:00:01Z",
+	"dtxFiles": [{ "id": 99, "label": "EXT", "level": 85 }]
 }
 ```
 
@@ -555,6 +559,7 @@ Do not open/merge this native change as a separate implementation PR. Continue i
 ## Task 4: Migrate every desktop consumer, test fixture, cache seed, and score projection
 
 **Files — services/stores/app:**
+
 - Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/services/linkageCacheService.ts`
@@ -569,6 +574,7 @@ Do not open/merge this native change as a separate implementation PR. Continue i
 - Modify as fixtures require: `packages/dtx-desktop/src/renderer/src/App.test.ts`
 
 **Files — renderer components:**
+
 - Modify: `packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte`
@@ -582,16 +588,19 @@ Do not open/merge this native change as a separate implementation PR. Continue i
 - Modify: `packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.test.ts`
 
 **Files — score projection:**
+
 - Modify: `packages/dtx-desktop/src/renderer/src/lib/scoreTypes.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/ScoreSongCard.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/Scores.test.ts`
 
 **Files — desktop E2E:**
+
 - Modify: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
 - Modify: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
 
 **Interfaces:**
+
 - Consumes: `SimfileModel` and camelCase full native JSON from Tasks 1/3.
 - Consumes: `packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json` in Vitest as behavioral seam proof.
 - Keeps separate: score-link `Record<string, string>` and string-id `CloudSong` projection.
@@ -618,8 +627,8 @@ This test is behavioral. Do not claim the fixture import type-checks `SimfileMod
 Migrate cache expectations to:
 
 ```ts
-'simfiles_cache_v2'
-'simfiles_cache_timestamp_v2'
+'simfiles_cache_v2';
+'simfiles_cache_timestamp_v2';
 ```
 
 Add a test where a valid-looking old shape exists only under `simfiles_cache`; verify IPC is still called.
@@ -803,13 +812,16 @@ In `google-drive-upload.e2e.ts`, seed a camelCase object containing at least:
 Use:
 
 ```ts
-localStorage.setItem('dtx_linkage_cache_v2', JSON.stringify({
-	[songPath]: {
-		linkedSimFileId: String(cloudSong.id),
-		linkedAt: '2026-07-25T00:00:00.000Z',
-		cloudSongData: cloudSong
-	}
-}));
+localStorage.setItem(
+	'dtx_linkage_cache_v2',
+	JSON.stringify({
+		[songPath]: {
+			linkedSimFileId: String(cloudSong.id),
+			linkedAt: '2026-07-25T00:00:00.000Z',
+			cloudSongData: cloudSong
+		}
+	})
+);
 ```
 
 Apply the same key/shape migration in `scripts/google-drive-crash-recovery.ts`. Do not seed v1 as fallback.
@@ -918,6 +930,7 @@ The current docs-only PR may remain draft; this requirement applies to the later
 ## Task 5: Delete compatibility residue, update docs, and run load-bearing completion gates
 
 **Files:**
+
 - Modify: `packages/common/src/lib/index.ts`
 - Modify: `packages/common/src/lib/server.ts`
 - Modify: `packages/common/src/lib/types/d1.types.ts`
@@ -927,6 +940,7 @@ The current docs-only PR may remain draft; this requirement applies to the later
 - Modify only if final gates reveal a missed active consumer: files under `packages/dtx-web`, `packages/dtx-desktop`, or `packages/e2e-desktop`
 
 **Interfaces:**
+
 - Deletes: `SimfileWithDtx` and application-barrel D1/compatibility exports.
 - Keeps: `SimfileWithDtxFiles`, D1 rows/helpers under `@dtx/common/server`; `Database` auth type; narrow `PreviewSimfile` and string-id `CloudSong` projections.
 

--- a/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
@@ -1,0 +1,850 @@
+# HPA-614 Current Simfile Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Supabase/REST-era simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, and the desktop renderer while keeping D1 snake_case types server-only.
+
+**Architecture:** `@dtx/common` owns the neutral application model. Web generated GraphQL responses and desktop Rust GraphQL responses each normalize once at their transport boundary. Shared/web/desktop application code consumes the neutral model directly. Old localStorage simfile shapes are invalidated by versioned cache keys rather than migrated.
+
+**Tech Stack:** TypeScript, Svelte 5, Vitest, GraphQL Codegen types, Rust/Tauri, serde_json, Bun workspaces.
+
+## Global Constraints
+
+- Keep D1/Drizzle row types and snake_case fields in server persistence code; do not move them into the application model.
+- Use exactly one shared application model: `SimfileModel` plus its nested `SimfileDtxFile` / `SimfileAssetFile` value types.
+- Do not add a DTO/mapper framework, runtime schema library, repository layer, cache migration framework, or compatibility aliases.
+- Do not change the D1 schema or GraphQL schema.
+- Do not add production `ts-rs` or generated Tauri contracts; that is HPA-615.
+- Do not extract `api.rs` / `SongDetails`; that is HPA-616.
+- Keep `Database` in `packages/common/src/lib/types/supabase.types.ts`, its main-barrel export, and root `gen-types`: current web auth code still consumes `SupabaseClient<Database>`.
+- Version caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read or adapt the old keys.
+- This is a breaking internal migration. Do not retain `LegacySimfile`, `SimfileWithDtx`, snake_case renderer properties, or deprecated aliases.
+
+---
+
+## Task 1: Add the neutral shared model and migrate `ChartDetail`
+
+**Files:**
+- Create: `packages/common/src/lib/types/simfile.ts`
+- Modify: `packages/common/src/lib/index.ts`
+- Modify: `packages/common/src/lib/types/d1.types.ts`
+- Modify: `packages/common/src/lib/types/d1.types.test.ts`
+- Modify: `packages/common/src/lib/components/ChartDetail.svelte`
+- Modify: `packages/common/src/lib/components/ChartDetail.test.ts`
+
+- [ ] **Step 1: Make the `ChartDetail` test describe the new contract first**
+
+Change `mockSimfile` in `ChartDetail.test.ts` to camelCase and remove the D1-only `simfile_id` field:
+
+```ts
+const mockSimfile = {
+	id: 1,
+	title: 'Test Song',
+	artist: 'Test Artist',
+	bpm: 140,
+	isPublished: true,
+	displayId: 1,
+	downloadUrl: 'https://example.com/download',
+	publishDate: '2024-01-01',
+	videoPreviewUrl: null,
+	dtxFiles: [
+		{ id: 1, label: 'BASIC', level: 30 },
+		{ id: 2, label: 'ADVANCED', level: 60 }
+	]
+};
+```
+
+Rename the DTX-list assertions from `dtx_files` to `dtxFiles`.
+
+- [ ] **Step 2: Run the focused test and confirm the old component contract fails**
+
+Run:
+
+```bash
+cd packages/common
+bun vitest run src/lib/components/ChartDetail.test.ts
+```
+
+Expected: FAIL because `ChartDetail` still reads `display_id`, `is_published`, `download_url`, `publish_date`, `video_preview_url`, and `dtx_files`.
+
+- [ ] **Step 3: Add the shared current model**
+
+Create `packages/common/src/lib/types/simfile.ts` with:
+
+```ts
+export interface SimfileDtxFile {
+	id?: number;
+	label: string;
+	level: number;
+}
+
+export interface SimfileAssetFile {
+	key: string;
+	size: number;
+	uploaded: string;
+}
+
+export interface SimfileModel {
+	id: number;
+	title: string;
+	artist: string;
+	bpm: number;
+	displayId: number | null;
+	userId: string | null;
+	googleDriveFileId: string | null;
+	isPublished: boolean;
+	downloadUrl: string | null;
+	previewUrl: string | null;
+	videoPreviewUrl: string | null;
+	publishDate: string | null;
+	createdAt: string | null;
+	updatedAt: string | null;
+	dtxFiles: SimfileDtxFile[];
+	files?: SimfileAssetFile[];
+	hasUploadedFiles?: boolean;
+}
+```
+
+`id` on nested DTX files is optional because list projections do not require it. Do not add `simfileId`/`simfile_id` to this UI model.
+
+- [ ] **Step 4: Make the browser-facing common barrel expose the application model, not D1 rows**
+
+In `packages/common/src/lib/index.ts`:
+
+```ts
+export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
+```
+
+Remove the main-barrel exports of `SimfileRow`, `SimfileInsert`, `SimfileUpdate`, `DtxFileRow`, `DtxFileInsert`, `UserProfileRow`, `UserProfileInsert`, `UserProfileUpdate`, `SimfileWithDtxFiles`, `SimfileWithDtx`, and `toSimfileWithDtx`.
+
+Leave `Database` exported because web auth still uses it. Leave all persistence exports in `packages/common/src/lib/server.ts` unchanged except for removal of `SimfileWithDtx` after Step 5.
+
+- [ ] **Step 5: Delete the desktop-compatible D1 shape**
+
+Delete `SimfileWithDtx` from `packages/common/src/lib/types/d1.types.ts` and remove only tests/imports that exist solely to validate that compatibility shape.
+
+Keep `SimfileWithDtxFiles` and `toSimfileWithDtx` server-side because `dtx-api`/D1 still use them. Do not rename or relocate those server types in HPA-614.
+
+Update `packages/common/src/lib/server.ts` so it no longer exports the deleted `SimfileWithDtx` symbol but still exports current D1/server types.
+
+- [ ] **Step 6: Migrate `ChartDetail` mechanically to camelCase**
+
+Change the prop type to:
+
+```ts
+import type { SimfileModel } from '../types/simfile';
+
+interface Props {
+	simfile?: Partial<SimfileModel> | null;
+	// existing non-simfile props unchanged
+}
+```
+
+Update only the field reads/bind defaults:
+
+```ts
+displayId = $bindable(simfile?.displayId ?? 0);
+publishDate = $bindable(simfile?.publishDate ?? new Date().toISOString().split('T')[0]);
+isPublished = $bindable(simfile?.isPublished ?? true);
+downloadUrl = $bindable(simfile?.downloadUrl ?? '');
+videoPreviewUrl = $bindable(simfile?.videoPreviewUrl ?? '');
+let dtxFiles = $derived(simfile?.dtxFiles ?? []);
+```
+
+Do not change the component layout or its existing camelCase save event payload.
+
+- [ ] **Step 7: Run common verification**
+
+Run:
+
+```bash
+cd packages/common
+bun vitest run src/lib/components/ChartDetail.test.ts src/lib/types/d1.types.test.ts
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the shared-model slice**
+
+```bash
+git add packages/common/src/lib/types/simfile.ts \
+  packages/common/src/lib/index.ts \
+  packages/common/src/lib/server.ts \
+  packages/common/src/lib/types/d1.types.ts \
+  packages/common/src/lib/types/d1.types.test.ts \
+  packages/common/src/lib/components/ChartDetail.svelte \
+  packages/common/src/lib/components/ChartDetail.test.ts
+git commit -m "refactor(common): define current simfile model"
+```
+
+---
+
+## Task 2: Migrate the web GraphQL boundary and web consumers
+
+**Files:**
+- Modify: `packages/dtx-web/src/lib/api/chart.ts`
+- Modify: `packages/dtx-web/src/lib/api/chart.test.ts`
+- Modify: `packages/dtx-web/src/lib/components/ChartList.helpers.ts`
+- Modify: `packages/dtx-web/src/lib/components/ChartList.helpers.test.ts`
+- Modify: `packages/dtx-web/src/lib/components/ChartList.svelte`
+- Modify: `packages/dtx-web/src/lib/components/ChartListItem.svelte`
+- Modify: `packages/dtx-web/src/lib/components/ChartListItem.test.ts`
+- Modify: `packages/dtx-web/src/lib/components/ChartListTableItem.svelte`
+- Modify: `packages/dtx-web/src/lib/components/ChartListTableItem.test.ts`
+- Modify: `packages/dtx-web/src/lib/utils.test.ts`
+- Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte`
+- Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts`
+
+- [ ] **Step 1: Change the API adapter tests to the new public shape**
+
+In `chart.test.ts`, replace snake_case output assertions with camelCase assertions. Cover one complete adapter result, including nullable fields and nested DTX files:
+
+```ts
+expect(result).toMatchObject({
+	id: 7,
+	title: 't',
+	googleDriveFileId: 'drive-file-123',
+	displayId: null,
+	isPublished: false,
+	dtxFiles: []
+});
+```
+
+Update list tests to assert `hasUploadedFiles`, and Drive-binding tests to expect:
+
+```ts
+{
+	id: 9,
+	googleDriveFileId: 'drive-file-123',
+	downloadUrl
+}
+```
+
+Keep the existing invalid numeric-id test.
+
+- [ ] **Step 2: Change chart-list helper tests to camelCase before implementation**
+
+Update helper fixtures and expectations so navigation/selectability uses:
+
+```ts
+{ id: 1, isPublished: true, hasUploadedFiles: true }
+```
+
+Run:
+
+```bash
+cd packages/dtx-web
+bun vitest run src/lib/api/chart.test.ts src/lib/components/ChartList.helpers.test.ts
+```
+
+Expected: FAIL while the web adapter/helpers still emit/read snake_case.
+
+- [ ] **Step 3: Replace `LegacySimfile` with a typed `SimfileModel` adapter**
+
+In `chart.ts`:
+
+```ts
+import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
+```
+
+Delete `LegacySimfile`. Rename/refocus `adaptSimfile` to `toSimfileModel` and return `SimfileModel`.
+
+The adapter must use the current field names and stable null defaults:
+
+```ts
+const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
+	id: parseSimfileId(simfile.id),
+	title: simfile.title ?? '',
+	artist: simfile.artist ?? '',
+	bpm: Number(simfile.bpm ?? 0),
+	displayId: simfile.displayId ?? null,
+	userId: simfile.userId ?? null,
+	googleDriveFileId: simfile.googleDriveFileId ?? null,
+	isPublished: simfile.isPublished ?? false,
+	downloadUrl: simfile.downloadUrl ?? null,
+	previewUrl: simfile.previewUrl ?? null,
+	videoPreviewUrl: simfile.videoPreviewUrl ?? null,
+	publishDate: simfile.publishDate ?? null,
+	createdAt: simfile.createdAt ?? null,
+	updatedAt: simfile.updatedAt ?? null,
+	dtxFiles: (simfile.dtxFiles ?? []).map((file): SimfileDtxFile => ({
+		...(file.id == null ? {} : { id: parseSimfileId(file.id) }),
+		label: file.label,
+		level: Number(file.level)
+	})),
+	...(simfile.files == null ? {} : { files: simfile.files }),
+	...(simfile.hasUploadedFiles == null
+		? {}
+		: { hasUploadedFiles: simfile.hasUploadedFiles })
+});
+```
+
+Use the existing numeric-id helper/error behavior rather than adding validation machinery.
+
+Make `listSimfiles`, `getSimfile`, and `updateSimfile` return this model. Make `updateSimfileDriveFile` return camelCase `{ id, googleDriveFileId, downloadUrl }`.
+
+- [ ] **Step 4: Migrate chart-list helpers and components**
+
+In `ChartList.helpers.ts` rename the narrow navigation fields:
+
+```ts
+export type ChartNavigationItem = {
+	id?: number;
+	isPublished?: boolean;
+	hasUploadedFiles?: boolean;
+};
+```
+
+Update `canBulkSelect`, `isPreviewable`, and `chartTitleHref` to use `hasUploadedFiles` / `isPublished`.
+
+In `ChartList.svelte`, use `SimfileModel[]` directly and change all list state/filter/toggle reads to `isPublished`, `hasUploadedFiles`, `displayId`, and `dtxFiles`.
+
+In `ChartListItem.svelte` and `ChartListTableItem.svelte`, replace `SimfileWithDtx` with `SimfileModel` and migrate their field reads. In particular:
+
+```svelte
+<DownloadDropdown
+	simfileId={item.id}
+	externalUrl={item.downloadUrl ?? null}
+	hasUploadedFiles={item.hasUploadedFiles}
+/>
+```
+
+Do not change UI behavior or styling.
+
+- [ ] **Step 5: Remove the last web D1 test dependency**
+
+In `packages/dtx-web/src/lib/utils.test.ts`, replace `DtxFileRow[]` fixtures with `SimfileDtxFile[]` (or the function's existing minimal `{ level }[]` structural type) and delete `simfile_id` from those fixtures.
+
+This is necessary so the main `@dtx/common` barrel can stop exposing D1 row types.
+
+- [ ] **Step 6: Migrate the web chart-detail page without a cast**
+
+In `+page.svelte`:
+
+```ts
+import type { SimfileModel } from '@dtx/common';
+
+let simfile: SimfileModel | null = $state(null);
+```
+
+Delete the `LegacySimfile` import and the cast:
+
+```svelte
+<ChartDetail simfile={simfile} ... />
+```
+
+Change page-level reads from `is_published` and other snake_case names to the current camelCase fields. Keep `files` handling unchanged apart from the new model type.
+
+Update `chart-detail-page.test.ts` fixtures to camelCase and preserve the current load/save/error behavior assertions.
+
+- [ ] **Step 7: Run web tests and type check**
+
+Run:
+
+```bash
+cd packages/dtx-web
+bun vitest run \
+  src/lib/api/chart.test.ts \
+  src/lib/components/ChartList.helpers.test.ts \
+  src/lib/components/ChartListItem.test.ts \
+  src/lib/components/ChartListTableItem.test.ts \
+  src/lib/utils.test.ts \
+  'src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts'
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the web migration**
+
+```bash
+git add packages/dtx-web/src/lib/api/chart.ts \
+  packages/dtx-web/src/lib/api/chart.test.ts \
+  packages/dtx-web/src/lib/components/ChartList.helpers.ts \
+  packages/dtx-web/src/lib/components/ChartList.helpers.test.ts \
+  packages/dtx-web/src/lib/components/ChartList.svelte \
+  packages/dtx-web/src/lib/components/ChartListItem.svelte \
+  packages/dtx-web/src/lib/components/ChartListItem.test.ts \
+  packages/dtx-web/src/lib/components/ChartListTableItem.svelte \
+  packages/dtx-web/src/lib/components/ChartListTableItem.test.ts \
+  packages/dtx-web/src/lib/utils.test.ts \
+  'packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte' \
+  'packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts'
+git commit -m "refactor(web): consume current simfile model"
+```
+
+---
+
+## Task 3: Make the Rust/Tauri simfile boundary emit the current model
+
+**Files:**
+- Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
+
+- [ ] **Step 1: Rewrite native API assertions to require camelCase renderer output**
+
+Update the existing `renderer_simfile_from_graphql`/fetch/create/update/search tests in `api_tests.rs` so expected JSON uses:
+
+```json
+{
+  "id": 42,
+  "displayId": 7,
+  "userId": "user-1",
+  "googleDriveFileId": null,
+  "isPublished": true,
+  "downloadUrl": null,
+  "previewUrl": null,
+  "videoPreviewUrl": null,
+  "publishDate": "2026-08-15",
+  "createdAt": "2026-08-15T00:00:00Z",
+  "updatedAt": "2026-08-15T00:00:00Z",
+  "dtxFiles": [{ "id": 99, "label": "EXT", "level": 85 }]
+}
+```
+
+Update cloud-search expectations from `is_published` to `isPublished`, and make search ids numeric so the renderer does not retain another incompatible id representation.
+
+Add/update the update-command test so the renderer input is camelCase:
+
+```json
+{
+  "displayId": 7,
+  "publishDate": "2026-08-15",
+  "isPublished": true,
+  "downloadUrl": "https://example.test/chart.zip",
+  "videoPreviewUrl": "https://example.test/video"
+}
+```
+
+and the GraphQL mock receives those names unchanged.
+
+- [ ] **Step 2: Run the native API test module and confirm failure**
+
+Run:
+
+```bash
+cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
+```
+
+Expected: FAIL because native mapping still emits snake_case and update input still passes through `update_input_from_renderer`.
+
+- [ ] **Step 3: Replace the renderer compatibility mapper**
+
+Rename:
+
+```rust
+renderer_simfile_from_graphql
+```
+
+to:
+
+```rust
+simfile_model_from_graphql
+```
+
+Keep `number_id` validation, but emit current JSON keys:
+
+```rust
+mapped.insert("id".to_string(), json!(number_id(&simfile["id"])?));
+mapped.insert("displayId".to_string(), simfile["displayId"].clone());
+mapped.insert("userId".to_string(), simfile["userId"].clone());
+mapped.insert(
+    "googleDriveFileId".to_string(),
+    simfile["googleDriveFileId"].clone(),
+);
+mapped.insert("isPublished".to_string(), simfile["isPublished"].clone());
+mapped.insert("downloadUrl".to_string(), simfile["downloadUrl"].clone());
+mapped.insert("previewUrl".to_string(), simfile["previewUrl"].clone());
+mapped.insert(
+    "videoPreviewUrl".to_string(),
+    simfile["videoPreviewUrl"].clone(),
+);
+mapped.insert("publishDate".to_string(), simfile["publishDate"].clone());
+mapped.insert("createdAt".to_string(), simfile["createdAt"].clone());
+mapped.insert("updatedAt".to_string(), simfile["updatedAt"].clone());
+```
+
+Keep `title`, `artist`, and `bpm` unchanged. Emit the nested collection as `dtxFiles` with only `id` when present plus `label`/`level`. Delete the positional id fallback that existed only for old cached renderer records.
+
+Use `simfile_model_from_graphql` in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
+
+- [ ] **Step 4: Delete the renderer-to-GraphQL snake_case round trip**
+
+Delete `update_input_from_renderer`.
+
+Change `update_simfile_record_impl` from:
+
+```rust
+"input": update_input_from_renderer(update_data),
+```
+
+to:
+
+```rust
+"input": update_data,
+```
+
+The renderer will send only current GraphQL input names. Do not introduce an allowlist/mapper here; the GraphQL input remains the validation boundary.
+
+- [ ] **Step 5: Make cloud search use the current projection names**
+
+In `search_cloud_songs_impl`, return numeric `id` and camelCase `isPublished`:
+
+```rust
+json!({
+    "id": number_id(&song["id"]),
+    "title": song["title"],
+    "artist": song["artist"],
+    "bpm": song["bpm"],
+    "isPublished": song["isPublished"],
+})
+```
+
+If the closure needs fallible id parsing, collect a `Result<Vec<Value>>` rather than falling back to a string or `0`.
+
+- [ ] **Step 6: Run Rust formatting and tests**
+
+Run:
+
+```bash
+cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml -- --check
+cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
+```
+
+If `cargo fmt --check` reports formatting changes, run `cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml`, then rerun both commands.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the native boundary change**
+
+```bash
+git add packages/dtx-desktop/src-tauri/src/api.rs \
+  packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
+git commit -m "refactor(desktop): emit current simfile model from native API"
+```
+
+---
+
+## Task 4: Migrate desktop renderer state, consumers, and caches
+
+**Files:**
+- Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/linkageCacheService.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/linkageCacheService.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/stores/simFileStore.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/stores/simFileStore.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/stores/workspaceStore.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/stores/workspaceStore.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/lib/scoreTypes.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/SimFileList.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/SimFileList.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.test.ts`
+- Modify as required by the same `CloudSong` type rename: `packages/dtx-desktop/src/renderer/src/components/ScoreSongCard.svelte`, `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`, and their existing tests.
+
+- [ ] **Step 1: Make cache tests prove old shapes are not read**
+
+In `simFileService.test.ts`, update fixtures to camelCase and assert the service only accesses:
+
+```ts
+'simfiles_cache_v2'
+'simfiles_cache_timestamp_v2'
+```
+
+Add a test where the mock returns old data only for `simfiles_cache` and confirm `fetchUserSimfiles` is still called. This proves the old cache is ignored, not adapted.
+
+In `linkageCacheService.test.ts`, update `sampleSimfile` to `SimfileModel`, expect writes/removals against `dtx_linkage_cache_v2`, and add the equivalent old-key-ignore test.
+
+Run:
+
+```bash
+cd packages/dtx-desktop
+bun vitest run \
+  src/renderer/src/services/simFileService.test.ts \
+  src/renderer/src/services/linkageCacheService.test.ts
+```
+
+Expected: FAIL because the implementation still uses v1 keys and `SimfileWithDtx`.
+
+- [ ] **Step 2: Version the caches without migration code**
+
+In `simFileService.ts`:
+
+```ts
+import type { SimfileModel } from '@dtx/common';
+
+const CACHE_KEY = 'simfiles_cache_v2';
+const CACHE_TIMESTAMP_KEY = 'simfiles_cache_timestamp_v2';
+```
+
+Change `MainProcessSimFileResult`, `SimFileServiceResult`, `getCachedData`, and `setCachedData` from `SimfileWithDtx` to `SimfileModel`.
+
+In `linkageCacheService.ts`:
+
+```ts
+import type { SimfileModel } from '@dtx/common';
+
+const LINKAGE_CACHE_KEY = 'dtx_linkage_cache_v2';
+```
+
+Change `cloudSongData` and `saveLinkage` to `SimfileModel`. Do not read, delete, or transform `dtx_linkage_cache`; leaving an unreachable old localStorage entry is cheaper and safer than migration logic.
+
+- [ ] **Step 3: Migrate desktop stores to `SimfileModel`**
+
+In `simFileStore.ts`, replace every `SimfileWithDtx` annotation with `SimfileModel`.
+
+In `workspaceStore.ts`:
+
+```ts
+import type { SimfileModel } from '@dtx/common';
+```
+
+Use it for `TreeNode.linkedSimFile`, `selectedCloudSimFile`, `selectCloudSimFile`, and `linkSimFileToFolder`.
+
+Keep `GoogleDriveFields` camelCase and stop translating them back to snake_case:
+
+```ts
+const driveUpdates: Partial<SimfileModel> = {};
+if (fields.googleDriveFileId) {
+	driveUpdates.googleDriveFileId = fields.googleDriveFileId;
+}
+if (fields.downloadUrl) {
+	driveUpdates.downloadUrl = fields.downloadUrl;
+}
+```
+
+Update both store test fixture families to camelCase.
+
+- [ ] **Step 4: Migrate the desktop score/link projections to the current naming**
+
+In `scoreTypes.ts`, import `SimfileModel` and make the cloud-search projection reuse the current model keys:
+
+```ts
+export type CloudSong = Pick<SimfileModel, 'id' | 'title' | 'artist' | 'isPublished'>;
+```
+
+Delete the old `CloudSongData` snake_case interface. Make the fetch envelope default to the full current model:
+
+```ts
+export interface FetchCloudSongResult<T = SimfileModel> {
+	success: boolean;
+	cloudSongData?: T;
+	error?: string;
+}
+```
+
+Update `CloudSongAutocomplete.svelte` to use the shared `CloudSong` type instead of redeclaring a second interface. Its exclusion check must compare `String(song.id)` with the existing string id list.
+
+Update `ScoreSongCard.svelte`, `Scores.svelte`, and their tests only where the `CloudSong.id` number / `isPublished` rename requires it. Do not refactor score matching in this ticket.
+
+- [ ] **Step 5: Migrate read-only cloud components**
+
+In `CloudSongDetail.svelte`:
+
+- `SimfileWithDtx` -> `SimfileModel`
+- `dtx_files` -> `dtxFiles`
+- `publish_date` -> `publishDate`
+- `is_published` -> `isPublished`
+
+In `SimFileList.svelte`:
+
+- `publish_date` -> `publishDate`
+- `dtx_files` -> `dtxFiles`
+- `is_published` -> `isPublished`
+
+Update their tests mechanically. No markup/layout redesign.
+
+- [ ] **Step 6: Migrate `SongDetails` and delete renderer compatibility normalization**
+
+Replace the imports with:
+
+```ts
+import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
+```
+
+Change create/update/fetch result types from `SimfileWithDtx` to `SimfileModel` / `Partial<SimfileModel>`.
+
+Rename the small IPC guard to `isSimfileModel` and keep it minimal until HPA-615, e.g. validate only the object/id/title shape needed to reject obviously malformed IPC data. Do not add Zod or a schema abstraction.
+
+Delete `normalizeSimfile`. Native now returns the current model, so linking becomes:
+
+```ts
+if (result.success && result.cloudSongData && isSimfileModel(result.cloudSongData)) {
+	const linkedSimfile = result.cloudSongData;
+	song.linkedSimFileId = String(linkedSimfile.id);
+	song.linkedSimFile = linkedSimfile;
+	workspaceStore.linkSimFileToFolder(song.path, linkedSimfile);
+}
+```
+
+Build local fallback levels as `SimfileDtxFile[]`:
+
+```ts
+const fallbackDtxFiles: SimfileDtxFile[] = parsedLocalData.levels?.map((level) => ({
+	label: level.label || 'Unknown',
+	level: Number(level.level || 0)
+})) ?? [];
+```
+
+Build `simfileData` as `Partial<SimfileModel>` with `publishDate`, `displayId`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, and `dtxFiles`.
+
+Change the update payload sent to `desktopHost.updateSimfileRecord` to GraphQL/current names:
+
+```ts
+const updateData: Record<string, unknown> = {
+	displayId: Number(event.detail.displayId),
+	publishDate: String(event.detail.publishDate),
+	isPublished: Boolean(event.detail.isPublished),
+	videoPreviewUrl: String(event.detail.videoPreviewUrl)
+};
+if (!isDriveBound) {
+	updateData.downloadUrl = String(event.detail.downloadUrl);
+}
+```
+
+Change all linked-record reads such as `google_drive_file_id` / `download_url` to `googleDriveFileId` / `downloadUrl`.
+
+Update `SongDetails.test.ts` fixtures/IPC assertions accordingly. Preserve all existing stale-selection, concurrent action, linking, save, and Drive upload behavior tests.
+
+- [ ] **Step 7: Run desktop renderer tests and type check**
+
+Run:
+
+```bash
+cd packages/dtx-desktop
+bun vitest run \
+  src/renderer/src/services/simFileService.test.ts \
+  src/renderer/src/services/linkageCacheService.test.ts \
+  src/renderer/src/stores/simFileStore.test.ts \
+  src/renderer/src/stores/workspaceStore.test.ts \
+  src/renderer/src/components/SongDetails.test.ts \
+  src/renderer/src/components/CloudSongDetail.test.ts \
+  src/renderer/src/components/SimFileList.test.ts \
+  src/renderer/src/components/CloudSongAutocomplete.test.ts \
+  src/renderer/src/components/ScoreSongCard.test.ts \
+  src/renderer/src/components/Scores.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the renderer/cache migration**
+
+```bash
+git add packages/dtx-desktop/src/renderer/src
+git commit -m "refactor(desktop): consume current simfile model"
+```
+
+---
+
+## Task 5: Remove compatibility residue and verify the full seam
+
+**Files:**
+- Modify only files surfaced by the explicit searches below if they are active application consumers of the removed compatibility contract.
+- Do **not** edit `packages/common/src/lib/types/supabase.types.ts` or D1/server snake_case code merely because the searches find them.
+
+- [ ] **Step 1: Prove the obsolete named types are gone**
+
+Run from the repo root:
+
+```bash
+rg -n "LegacySimfile|SimfileWithDtx\b" packages/common packages/dtx-web packages/dtx-desktop
+```
+
+Expected: no matches in source/test code. Historical docs may still mention them and do not need rewriting.
+
+- [ ] **Step 2: Prove snake_case simfile properties no longer leak into app/UI code**
+
+Run:
+
+```bash
+rg -n "\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|preview_url|video_preview_url|publish_date|created_at|updated_at|user_id)\b" \
+  packages/common/src/lib/components \
+  packages/dtx-web/src \
+  packages/dtx-desktop/src/renderer/src
+```
+
+Expected application exceptions must be justified narrowly before leaving them. In particular:
+
+- D1/server files are outside this search and remain snake_case.
+- `packages/common/src/lib/types/supabase.types.ts` is intentionally retained and is outside shared UI.
+- Native Rust identifiers may remain idiomatic snake_case internally, but JSON keys crossing to the renderer must be camelCase.
+
+Fix active UI/renderer matches by using `SimfileModel`; do not add aliases.
+
+- [ ] **Step 3: Confirm the retained Supabase auth type is still genuinely used**
+
+Run:
+
+```bash
+rg -n "SupabaseClient<Database>|createServerClient<Database>|type \{ Database \}" packages/dtx-web packages/common
+```
+
+Expected: current uses in `packages/dtx-web/src/app.d.ts` and `packages/dtx-web/src/hooks.server.ts`. Leave `Database` and `gen-types` in place.
+
+- [ ] **Step 4: Run all affected checks**
+
+Run:
+
+```bash
+cd packages/common && bun run test && bun run check
+cd ../dtx-web && bun run test && bun run check
+cd ../dtx-desktop && bun run test && bun run typecheck
+cd ../..
+cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
+```
+
+Expected: PASS. If the repo-wide test suites expose unrelated pre-existing failures, record those separately and still require every HPA-614-focused test changed above to pass.
+
+- [ ] **Step 5: Review the diff for scope discipline**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat main...HEAD
+git diff main...HEAD -- \
+  packages/common \
+  packages/dtx-web \
+  packages/dtx-desktop
+```
+
+Verify:
+
+- no GraphQL schema/D1 schema changes;
+- no runtime schema/codegen framework;
+- no compatibility alias for snake_case fields;
+- no unrelated UI refactor;
+- no deletion of the live Supabase auth `Database` type;
+- cache changes are only the three explicit v2 keys.
+
+- [ ] **Step 6: Commit any final mechanical cleanup**
+
+If Step 1/2 surfaced active compatibility residue and it was fixed:
+
+```bash
+git add packages/common packages/dtx-web packages/dtx-desktop
+git commit -m "refactor: remove legacy simfile compatibility residue"
+```
+
+If there were no cleanup edits, do not create an empty commit.
+
+---
+
+## Expected End State
+
+- `@dtx/common` main exports `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types remain server-only.
+- `ChartDetail` accepts `Partial<SimfileModel>` and has no D1 import.
+- Web GraphQL code adapts generated results directly into camelCase `SimfileModel`; `LegacySimfile` and the chart-page cast are gone.
+- Desktop Rust emits camelCase current-model JSON and accepts camelCase update input without `update_input_from_renderer`.
+- Desktop stores/services/components use `SimfileModel`; `SimfileWithDtx` and `normalizeSimfile` are gone.
+- Desktop cache keys are `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`; old cached shapes are ignored.
+- `Database`/`gen-types` remain because auth still uses them.
+- HPA-615 can now generate Tauri TypeScript bindings against one stable renderer-facing model instead of encoding a legacy compatibility contract.

--- a/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
@@ -2,31 +2,39 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace Supabase/REST-era simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, desktop renderer code, and desktop E2E linkage fixtures while keeping D1 snake_case types server-only.
+**Goal:** Replace Supabase/REST-era full-simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, desktop renderer code, caches, and desktop E2E linkage fixtures while keeping D1 snake_case types server-only.
 
-**Architecture:** `@dtx/common` owns the neutral application model. Web generated GraphQL results and desktop Rust GraphQL results each normalize once at their real transport boundary. Application code consumes that model directly. Renderer caches are invalidated by versioned keys, and desktop E2E seeds use the same current key/shape.
+**Architecture:** `@dtx/common` owns the neutral full application model. Web generated GraphQL results and desktop Rust GraphQL results each normalize once at their real transport boundary. Renderer caches are version-invalidated rather than migrated. A single JSON fixture is consumed by Rust and Vitest as behavioral proof that both sides agree on the same renderer-facing field names.
 
 **Tech Stack:** TypeScript, Svelte 5, Vitest, generated GraphQL types, Rust/Tauri, `serde_json`, Bun workspaces, WebdriverIO desktop E2E.
 
 ## Global Constraints
 
-- Keep D1/Drizzle row types and snake_case fields in server persistence code; do not move them into the application model.
-- Use one shared application model: `SimfileModel` plus `SimfileDtxFile` / `SimfileAssetFile` nested value types.
+- Keep D1/Drizzle row types and snake_case fields in server persistence code.
+- Use one shared full application model: `SimfileModel` plus `SimfileDtxFile` / `SimfileAssetFile`.
+- `publishDate`, `createdAt`, and `updatedAt` are required strings because the GraphQL schema declares them non-null.
+- Add `createdAt` / `updatedAt` to the desktop list query rather than weakening the model for an omitted projection.
+- Keep `files?` / `hasUploadedFiles?` optional because those are projection-specific extras.
+- Keep `SimfileDtxFile.id?` optional; the web full fragment does not select it and shared UI does not require it.
+- Keep score-page `CloudSong.id` as `string`; only migrate `is_published` → `isPublished` there.
+- Keep `PreviewSimfile` as its existing purpose-specific projection.
 - Do not add a generic DTO/mapper layer, runtime schema library, repository abstraction, cache migration framework, or compatibility aliases.
 - Do not change the D1 schema or GraphQL schema.
-- Do not add production Rust→TypeScript generation; that is HPA-615.
-- Do not extract `api.rs` or `SongDetails.svelte`; that is HPA-616.
-- Keep `Database` in `packages/common/src/lib/types/supabase.types.ts`, its existing export, and root `gen-types`: current web auth still consumes `SupabaseClient<Database>` / `createServerClient<Database>`.
-- Invalidate renderer caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read or adapt the old keys.
-- Desktop E2E linkage seeds must use `dtx_linkage_cache_v2` and camelCase current-model data, without adding an `@dtx/common` dependency to the E2E package.
-- This is a breaking internal migration. Do not retain `LegacySimfile`, `SimfileWithDtx`, snake_case renderer properties, or deprecated aliases after final cleanup.
-- Do not remove old `@dtx/common` application-barrel D1/compatibility exports until all web/desktop consumers have migrated; never redirect renderer code to `@dtx/common/server` as an intermediate fix.
-- Preserve `ChartDetail`'s current `dayjs().format('YYYY-MM-DD')` publish-date fallback while renaming fields.
-- General simfile updates must never send `googleDriveFileId`; Drive binding remains owned by the dedicated Drive mutation.
+- Do not add production Rust→TypeScript generation; HPA-615 owns that.
+- Do not extract `api.rs` or `SongDetails.svelte`; HPA-616 owns that.
+- Keep `Database` / root `gen-types`; current web auth still consumes `SupabaseClient<Database>` / `createServerClient<Database>`.
+- Invalidate renderer caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read/adapt v1 keys.
+- Desktop E2E linkage seeds must use `dtx_linkage_cache_v2` and camelCase current-model data.
+- Do not remove existing main-barrel D1/compatibility exports until Task 5, after every consumer has migrated.
+- Preserve `ChartDetail`'s current `dayjs().format('YYYY-MM-DD')` publish-date fallback.
+- General simfile updates must never send `googleDriveFileId`; Drive binding remains owned by the dedicated mutation.
+- Renderer update payloads are explicit picks, never `{ ...simfile }`.
+- Tasks 3 and 4 belong in one implementation PR. Do not merge/publish the native boundary without its renderer consumers.
+- The implementation PR must be marked ready for review after Tasks 3–4 so `.github/workflows/desktop-e2e-test.yml` actually runs before merge.
 
 ---
 
-## Task 1: Add the neutral shared model and migrate `ChartDetail`
+## Task 1: Add the neutral model and migrate `ChartDetail`
 
 **Files:**
 - Create: `packages/common/src/lib/types/simfile.ts`
@@ -35,12 +43,12 @@
 - Modify: `packages/common/src/lib/components/ChartDetail.test.ts`
 
 **Interfaces:**
-- Produces: `SimfileModel`, `SimfileDtxFile`, `SimfileAssetFile` exported from the main `@dtx/common` barrel.
-- Keeps temporarily: existing D1/compatibility exports, including `SimfileWithDtx`, until Task 5.
+- Produces: `SimfileModel`, `SimfileDtxFile`, `SimfileAssetFile` from the main `@dtx/common` barrel.
+- Temporarily preserves: existing main-barrel `SimfileWithDtx`, D1 row exports, and `toSimfileWithDtx` until Task 5.
 
-- [ ] **Step 1: Make `ChartDetail` tests describe the new contract first**
+- [ ] **Step 1: Change `ChartDetail` tests to the current names first**
 
-Change `mockSimfile` in `ChartDetail.test.ts` to camelCase and remove D1-only `simfile_id`:
+Use a camelCase fixture:
 
 ```ts
 const mockSimfile = {
@@ -52,6 +60,8 @@ const mockSimfile = {
 	displayId: 1,
 	downloadUrl: 'https://example.com/download',
 	publishDate: '2024-01-01',
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-02T00:00:00Z',
 	videoPreviewUrl: null,
 	dtxFiles: [
 		{ id: 1, label: 'BASIC', level: 30 },
@@ -60,16 +70,16 @@ const mockSimfile = {
 };
 ```
 
-Rename DTX-list fixtures/assertions from `dtx_files` to `dtxFiles`.
+Rename `dtx_files` assertions/fixtures to `dtxFiles`. Do not alter component layout behavior.
 
-- [ ] **Step 2: Run the focused test and confirm the old component contract fails**
+- [ ] **Step 2: Run the focused test and confirm the old contract fails**
 
 ```bash
 cd packages/common
 bun vitest run src/lib/components/ChartDetail.test.ts
 ```
 
-Expected: FAIL because `ChartDetail` still reads snake_case simfile fields.
+Expected: FAIL because `ChartDetail` still reads snake_case properties.
 
 - [ ] **Step 3: Add the current shared model**
 
@@ -100,28 +110,26 @@ export interface SimfileModel {
 	downloadUrl: string | null;
 	previewUrl: string | null;
 	videoPreviewUrl: string | null;
-	publishDate: string | null;
-	createdAt: string | null;
-	updatedAt: string | null;
+	publishDate: string;
+	createdAt: string;
+	updatedAt: string;
 	dtxFiles: SimfileDtxFile[];
 	files?: SimfileAssetFile[];
 	hasUploadedFiles?: boolean;
 }
 ```
 
-Keep `SimfileDtxFile.id` optional because not every web projection currently requests chart ids. Do not add `simfileId` / `simfile_id` to this application model.
+- [ ] **Step 4: Export the model without deleting old barrel exports yet**
 
-- [ ] **Step 4: Export the new model without removing old application-barrel exports yet**
-
-Add to `packages/common/src/lib/index.ts`:
+Add:
 
 ```ts
 export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
 ```
 
-Do **not** remove `SimfileWithDtx`, `SimfileWithDtxFiles`, D1 row types, or `toSimfileWithDtx` from the main barrel in this task. Current web/desktop consumers and `constants.test.ts` still rely on them; removal belongs in Task 5 after the consumer migration.
+Do **not** remove `SimfileWithDtx`, D1 row types, `SimfileWithDtxFiles`, or `toSimfileWithDtx` from the main barrel in Task 1. Current downstream consumers and `constants.test.ts` still require them; Task 5 removes them after the migration is complete.
 
-- [ ] **Step 5: Migrate `ChartDetail` mechanically to camelCase**
+- [ ] **Step 5: Migrate `ChartDetail` mechanically**
 
 Use:
 
@@ -134,7 +142,7 @@ interface Props {
 }
 ```
 
-Rename the existing bindings/reads:
+Rename only the compatibility reads/bindings:
 
 ```ts
 displayId = $bindable(simfile?.displayId ?? 0);
@@ -145,9 +153,9 @@ videoPreviewUrl = $bindable(simfile?.videoPreviewUrl ?? '');
 let dtxFiles = $derived(simfile?.dtxFiles ?? []);
 ```
 
-Keep the existing `dayjs` import and fallback. Do not replace it with `new Date().toISOString()` in this migration.
+Keep the existing `dayjs` import and save-event payload.
 
-- [ ] **Step 6: Verify common without removing live barrel exports**
+- [ ] **Step 6: Verify common while compatibility exports are still live**
 
 ```bash
 cd packages/common
@@ -155,7 +163,7 @@ bun vitest run src/lib/components/ChartDetail.test.ts src/lib/constants.test.ts
 bun run check
 ```
 
-Expected: PASS. `constants.test.ts` must still pass because the old barrel exports remain until Task 5.
+Expected: PASS.
 
 - [ ] **Step 7: Commit**
 
@@ -181,17 +189,18 @@ git commit -m "refactor(common): add current simfile model"
 - Modify: `packages/dtx-web/src/lib/components/ChartListItem.test.ts`
 - Modify: `packages/dtx-web/src/lib/components/ChartListTableItem.svelte`
 - Modify: `packages/dtx-web/src/lib/components/ChartListTableItem.test.ts`
+- Modify: `packages/dtx-web/src/lib/utils.ts`
 - Modify: `packages/dtx-web/src/lib/utils.test.ts`
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts`
 
 **Interfaces:**
 - Consumes: `SimfileModel`, `SimfileDtxFile` from Task 1.
-- Produces: `toSimfileModel()` as the single web GraphQL→application adapter.
+- Produces: `toSimfileModel()` as the only web GraphQL→full-model adapter.
 
-- [ ] **Step 1: Change API adapter tests to the new public shape**
+- [ ] **Step 1: Change adapter tests to required current-model fields**
 
-In `chart.test.ts`, replace snake_case result assertions with camelCase assertions and cover nullable metadata/nested levels:
+Update `chart.test.ts` expectations to camelCase and include the non-null timestamps:
 
 ```ts
 expect(result).toMatchObject({
@@ -200,11 +209,14 @@ expect(result).toMatchObject({
 	googleDriveFileId: 'drive-file-123',
 	displayId: null,
 	isPublished: false,
+	publishDate: '2026-08-15',
+	createdAt: '2026-08-15T00:00:00Z',
+	updatedAt: '2026-08-15T00:00:01Z',
 	dtxFiles: []
 });
 ```
 
-Update list tests to assert `hasUploadedFiles`. Update Drive-binding expectations to:
+Update list tests to assert `hasUploadedFiles`. Update Drive-binding expectations to camelCase:
 
 ```ts
 {
@@ -214,24 +226,21 @@ Update list tests to assert `hasUploadedFiles`. Update Drive-binding expectation
 }
 ```
 
-Keep the existing invalid numeric-id test.
+Keep invalid numeric-id coverage.
 
-- [ ] **Step 2: Change chart-list fixtures/helper expectations before implementation**
+- [ ] **Step 2: Change chart-list fixtures/helper expectations first**
 
-`ChartList.test.ts` owns both component and `ChartList.helpers` coverage. Migrate `mockListedChart` and helper assertions to camelCase:
+`ChartList.test.ts` owns helper coverage. Migrate its fixture to current names, including:
 
 ```ts
-const mockListedChart = {
+{
 	id: 1,
-	title: 'Test Song 1',
-	artist: 'Test Artist 1',
-	bpm: 120,
 	isPublished: true,
 	hasUploadedFiles: true,
 	downloadUrl: 'https://example.com/download1',
 	displayId: 1,
 	dtxFiles: [{ level: 3, label: 'BSC' }]
-};
+}
 ```
 
 Run:
@@ -241,51 +250,50 @@ cd packages/dtx-web
 bun vitest run src/lib/api/chart.test.ts src/lib/components/ChartList.test.ts
 ```
 
-Expected: FAIL while the adapter/list code still emits or reads snake_case.
+Expected: FAIL while web code still emits/reads snake_case.
 
-- [ ] **Step 3: Replace `LegacySimfile` with one typed GraphQL→model adapter**
+- [ ] **Step 3: Replace `LegacySimfile` with `toSimfileModel`**
 
-In `chart.ts` import:
+Import:
 
 ```ts
 import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 ```
 
-Delete `LegacySimfile`. Rename/refocus `adaptSimfile` to `toSimfileModel` and return `SimfileModel`:
+Delete `LegacySimfile`. Rename/refocus `adaptSimfile` to `toSimfileModel` and preserve schema nullability:
 
 ```ts
 const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
 	id: parseSimfileId(simfile.id),
-	title: simfile.title ?? '',
-	artist: simfile.artist ?? '',
-	bpm: Number(simfile.bpm ?? 0),
+	title: simfile.title,
+	artist: simfile.artist,
+	bpm: simfile.bpm,
 	displayId: simfile.displayId ?? null,
 	userId: simfile.userId ?? null,
 	googleDriveFileId: simfile.googleDriveFileId ?? null,
-	isPublished: simfile.isPublished ?? false,
+	isPublished: simfile.isPublished,
 	downloadUrl: simfile.downloadUrl ?? null,
 	previewUrl: simfile.previewUrl ?? null,
 	videoPreviewUrl: simfile.videoPreviewUrl ?? null,
-	publishDate: simfile.publishDate ?? null,
-	createdAt: simfile.createdAt ?? null,
-	updatedAt: simfile.updatedAt ?? null,
+	publishDate: simfile.publishDate,
+	createdAt: simfile.createdAt,
+	updatedAt: simfile.updatedAt,
 	dtxFiles: (simfile.dtxFiles ?? []).map((file): SimfileDtxFile => ({
-		...(file.id == null ? {} : { id: parseSimfileId(file.id) }),
 		label: file.label,
-		level: Number(file.level)
+		level: file.level
 	})),
 	...(simfile.files == null ? {} : { files: simfile.files }),
 	...(simfile.hasUploadedFiles == null ? {} : { hasUploadedFiles: simfile.hasUploadedFiles })
 });
 ```
 
-Use the existing numeric-id error behavior; do not add runtime validation machinery.
+Do not invent `null` for required schema fields. The generated fragment already carries `publishDate`, `createdAt`, and `updatedAt` as required strings.
 
-Make `listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. Make `updateSimfileDriveFile` return camelCase `{ id, googleDriveFileId, downloadUrl }`.
+Make `listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. Make `updateSimfileDriveFile` return `{ id, googleDriveFileId, downloadUrl }`.
 
 - [ ] **Step 4: Migrate chart-list helpers/components**
 
-Change the helper projection to:
+Use current projection names:
 
 ```ts
 export type ChartNavigationItem = {
@@ -295,9 +303,7 @@ export type ChartNavigationItem = {
 };
 ```
 
-Update `canBulkSelect`, `isPreviewable`, and `chartTitleHref` accordingly.
-
-In `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte`, use `SimfileModel` and replace only current-model property names:
+Update `canBulkSelect`, `isPreviewable`, `chartTitleHref`, `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte` mechanically:
 
 - `is_published` → `isPublished`
 - `has_uploaded_files` → `hasUploadedFiles`
@@ -305,13 +311,27 @@ In `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte`, 
 - `download_url` → `downloadUrl`
 - `dtx_files` → `dtxFiles`
 
-Do not alter layout or behavior.
+Do not alter UI behavior/styling.
 
-- [ ] **Step 5: Remove web test dependency on D1 row types**
+- [ ] **Step 5: Remove application-level D1 naming from the level-display helper**
 
-In `packages/dtx-web/src/lib/utils.test.ts`, replace `DtxFileRow[]` fixtures with `SimfileDtxFile[]` (or the helper's structural `{ level }[]` type) and remove `simfile_id` from fixtures.
+Rename:
 
-- [ ] **Step 6: Migrate the chart-detail page and delete its cast**
+```ts
+formatLevelDisplay(dtx_files)
+```
+
+to:
+
+```ts
+formatLevelDisplay(dtxFiles)
+```
+
+and update the comment to describe DTX level values rather than naming the D1 column. Keep the function behavior unchanged.
+
+Update `utils.test.ts` to use `SimfileDtxFile[]` or its existing structural level shape; remove D1-only `simfile_id` fixture fields.
+
+- [ ] **Step 6: Migrate the web chart-detail page and delete the cast**
 
 Use:
 
@@ -326,9 +346,7 @@ Delete the `LegacySimfile` import and render:
 <ChartDetail simfile={simfile} ... />
 ```
 
-without `as import('@dtx/common').SimfileWithDtxFiles`.
-
-Update page-level fields and `chart-detail-page.test.ts` fixtures to camelCase while preserving load/save/error behavior.
+with no `SimfileWithDtxFiles` cast. Update page-level field reads and tests to camelCase.
 
 - [ ] **Step 7: Verify web**
 
@@ -358,6 +376,7 @@ git add packages/dtx-web/src/lib/api/chart.ts \
   packages/dtx-web/src/lib/components/ChartListItem.test.ts \
   packages/dtx-web/src/lib/components/ChartListTableItem.svelte \
   packages/dtx-web/src/lib/components/ChartListTableItem.test.ts \
+  packages/dtx-web/src/lib/utils.ts \
   packages/dtx-web/src/lib/utils.test.ts \
   'packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte' \
   'packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts'
@@ -366,76 +385,118 @@ git commit -m "refactor(web): consume current simfile model"
 
 ---
 
-## Task 3: Make the Rust/Tauri simfile boundary emit the current model
+## Task 3: Make the Rust/Tauri full-simfile boundary emit the current model
 
 **Files:**
+- Create: `packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json`
 - Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
 
 **Interfaces:**
-- Produces: camelCase current-model JSON from `simfile_model_from_graphql`.
-- Preserves: general-update exclusion of `googleDriveFileId`.
+- Produces: camelCase full-model JSON from `simfile_model_from_graphql`.
+- Produces: one cross-language behavioral fixture consumed again in Task 4.
+- Preserves: score-search string ids and general-update exclusion of `googleDriveFileId`.
 
-- [ ] **Step 1: Rewrite native API assertions to require camelCase output**
+- [ ] **Step 1: Add one canonical renderer-facing fixture**
 
-Update fetch/create/update/search API tests so renderer-facing simfile JSON uses the current model, for example:
+Create:
 
 ```json
 {
   "id": 42,
   "displayId": 7,
+  "title": "Fixture Song",
+  "artist": "Fixture Artist",
+  "bpm": 123.5,
   "userId": "user-1",
   "googleDriveFileId": null,
   "isPublished": true,
-  "downloadUrl": null,
+  "downloadUrl": "https://example.test/chart.zip",
   "previewUrl": null,
   "videoPreviewUrl": null,
   "publishDate": "2026-08-15",
   "createdAt": "2026-08-15T00:00:00Z",
-  "updatedAt": "2026-08-15T00:00:00Z",
-  "dtxFiles": [{ "id": 99, "label": "EXT", "level": 85 }]
+  "updatedAt": "2026-08-15T00:00:01Z",
+  "dtxFiles": [
+    { "id": 99, "label": "EXT", "level": 85 }
+  ]
 }
 ```
 
-Update cloud-search expectations from `is_published` to `isPublished` and make search ids numeric.
+This fixture is expected output for a full native simfile, not a generated type artifact.
 
-Change the update-command request fixture to already use camelCase input names:
+- [ ] **Step 2: Change native tests to assert the shared fixture**
+
+Build a GraphQL input object whose mapped output should equal the fixture. Load the expected JSON from:
+
+```rust
+include_str!("../../tests/fixtures/simfile_model.json")
+```
+
+Deserialize to `serde_json::Value` and assert `simfile_model_from_graphql(&graphql_value)? == expected_fixture`.
+
+Also update create/fetch/update envelope assertions to current names.
+
+For cloud search, keep ids as GraphQL/persisted strings and change only:
 
 ```json
-{
-  "displayId": 7,
-  "publishDate": "2026-08-15",
-  "isPublished": true,
-  "downloadUrl": "https://example.test/chart.zip",
-  "videoPreviewUrl": "https://example.test/video"
-}
+{ "isPublished": false }
 ```
 
-Keep the Drive-id ownership test: after the general mapper is removed, rewrite it against `update_simfile_record_impl`'s one-field omission so it still proves `googleDriveFileId` cannot reach `UpdateSimfileInput`.
+instead of `is_published`.
 
-- [ ] **Step 2: Confirm the old native contract fails**
+- [ ] **Step 3: Add missing required timestamps to the desktop list query**
+
+In `LIST_SIMFILES_QUERY`, add:
+
+```graphql
+createdAt
+updatedAt
+```
+
+immediately with the other base simfile metadata. `publishDate` is already selected.
+
+Do not make timestamps optional/null in the application model to accommodate this omission.
+
+- [ ] **Step 4: Confirm the old native contract fails**
 
 ```bash
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Expected: FAIL because native mapping still emits snake_case and update input still uses the old general mapper.
+Expected: FAIL because the mapper still emits snake_case and list data omits timestamps.
 
-- [ ] **Step 3: Replace the renderer compatibility mapper**
+- [ ] **Step 5: Replace the renderer compatibility mapper**
 
 Rename `renderer_simfile_from_graphql` to `simfile_model_from_graphql`.
 
-Keep `number_id` validation, but emit current JSON keys: `displayId`, `userId`, `googleDriveFileId`, `isPublished`, `downloadUrl`, `previewUrl`, `videoPreviewUrl`, `publishDate`, `createdAt`, `updatedAt`, `dtxFiles`.
+Keep numeric-id validation for full simfiles and emit:
 
-Nested `dtxFiles` contain a real `id` when supplied plus `label` / `level`. Delete the positional id fallback that existed for older cached renderer records.
+- `id`
+- `displayId`
+- `title`
+- `artist`
+- `bpm`
+- `userId`
+- `googleDriveFileId`
+- `isPublished`
+- `downloadUrl`
+- `previewUrl`
+- `videoPreviewUrl`
+- `publishDate`
+- `createdAt`
+- `updatedAt`
+- `dtxFiles`
 
-Use the mapper in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
+Nested desktop `dtxFiles` use their real GraphQL `id`, `label`, and `level`. Delete the positional id fallback for old cached renderer records; every current desktop full query already selects `dtxFiles.id`.
 
-- [ ] **Step 4: Remove the general update mapper but preserve Drive ownership inline**
+Use this mapper in full-simfile fetch/create/update paths.
 
-Delete `update_input_from_renderer`; the renderer no longer sends snake_case.
+- [ ] **Step 6: Remove the general update mapper but preserve Drive ownership inline**
 
-Inside `update_simfile_record_impl`, remove only `googleDriveFileId` before constructing the GraphQL variables:
+Delete `update_input_from_renderer`; renderer updates are already camelCase after Task 4.
+
+Inside `update_simfile_record_impl`, remove only `googleDriveFileId` before constructing GraphQL variables:
 
 ```rust
 let input = match update_data {
@@ -445,62 +506,53 @@ let input = match update_data {
     }
     other => other,
 };
-
-let result = graphql_result_with_url(
-    base_url,
-    token,
-    &graphql_document(UPDATE_SIMFILE_MUTATION),
-    json!({
-        "id": simfile_id.to_string().trim_matches('"'),
-        "input": input,
-    }),
-)
-.await?;
 ```
 
-Do not create a replacement mapper/helper. The renderer constructs explicit update payloads in Task 4; this inline omission exists only to preserve Drive-id ownership at the native boundary.
+Then send `input` unchanged to `UPDATE_SIMFILE_MUTATION`.
 
-Update the existing native test to capture/assert the outgoing GraphQL request (or an extracted local input value already inside the test seam) and prove `googleDriveFileId` is absent while normal fields such as `title` remain.
+Do not create another mapper/allowlist. Keep/rewrite the existing native test so it inspects the outgoing GraphQL variables and proves `googleDriveFileId` is absent while ordinary fields such as `title` survive.
 
-- [ ] **Step 5: Make cloud search use current projection names and numeric ids**
+- [ ] **Step 7: Keep the score-search id boundary string-based**
 
-Keep invalid ids fallible:
+In `search_cloud_songs_impl`, do **not** convert search result ids to numbers. Preserve:
 
 ```rust
-let rows = songs
-    .iter()
-    .map(|song| -> Result<Value> {
-        Ok(json!({
-            "id": number_id(&song["id"])?,
-            "title": song["title"],
-            "artist": song["artist"],
-            "bpm": song["bpm"],
-            "isPublished": song["isPublished"],
-        }))
-    })
-    .collect::<Result<Vec<_>>>()?;
+"id": song["id"]
 ```
 
-- [ ] **Step 6: Verify Rust formatting and API tests**
+and rename only:
+
+```rust
+"isPublished": song["isPublished"]
+```
+
+This projection feeds persisted score links and `fetchCloudSongCharts(string)`; numeric conversion would only add round trips/conversions.
+
+- [ ] **Step 8: Verify Rust**
 
 ```bash
 cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml -- --check
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Expected: PASS.
+If needed, run `cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml` and rerun both commands.
 
-- [ ] **Step 7: Commit**
+Expected: PASS, including exact equality with `simfile_model.json`.
+
+- [ ] **Step 9: Commit**
 
 ```bash
-git add packages/dtx-desktop/src-tauri/src/api.rs \
+git add packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json \
+  packages/dtx-desktop/src-tauri/src/api.rs \
   packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
 git commit -m "refactor(desktop): emit current simfile model from native API"
 ```
 
+Do not open/merge this native change as a separate implementation PR. Continue immediately to Task 4 on the same branch.
+
 ---
 
-## Task 4: Migrate every desktop renderer consumer and cache seed
+## Task 4: Migrate every desktop consumer, test fixture, cache seed, and score projection
 
 **Files — services/stores/app:**
 - Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.ts`
@@ -535,28 +587,46 @@ git commit -m "refactor(desktop): emit current simfile model from native API"
 - Modify: `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/Scores.test.ts`
 
-**Files — desktop E2E current-cache seeds:**
+**Files — desktop E2E:**
 - Modify: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
 - Modify: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
 
 **Interfaces:**
-- Consumes: `SimfileModel` and camelCase native JSON from Tasks 1/3.
-- Keeps separate: score-link `Record<string, string>` persistence.
+- Consumes: `SimfileModel` and camelCase full native JSON from Tasks 1/3.
+- Consumes: `packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json` in Vitest as behavioral seam proof.
+- Keeps separate: score-link `Record<string, string>` and string-id `CloudSong` projection.
 
-- [ ] **Step 1: Make renderer cache tests prove stale shapes are ignored**
+- [ ] **Step 1: Make renderer cache tests use the shared fixture and v2 keys**
 
-In `simFileService.test.ts`, migrate fixtures to camelCase and assert only these keys are read/written:
+In `simFileService.test.ts`, read the same native fixture with Node rather than adding `resolveJsonModule` to production config:
+
+```ts
+import { readFileSync } from 'node:fs';
+
+const sharedSimfileFixture = JSON.parse(
+	readFileSync(
+		new URL('../../../../src-tauri/tests/fixtures/simfile_model.json', import.meta.url),
+		'utf8'
+	)
+);
+```
+
+Use that object as `desktopHost.fetchUserSimfiles()` data and assert renderer code reads its title/current names correctly.
+
+This test is behavioral. Do not claim the fixture import type-checks `SimfileModel`; desktop `tsconfig.web.json` excludes tests.
+
+Migrate cache expectations to:
 
 ```ts
 'simfiles_cache_v2'
 'simfiles_cache_timestamp_v2'
 ```
 
-Add a test where valid-looking old data exists only under `simfiles_cache`; verify `desktopHost.fetchUserSimfiles()` is still called.
+Add a test where a valid-looking old shape exists only under `simfiles_cache`; verify IPC is still called.
 
-In `linkageCacheService.test.ts`, migrate `sampleSimfile` to `SimfileModel`, expect `dtx_linkage_cache_v2`, and add the equivalent old-key-ignore assertion.
+In `linkageCacheService.test.ts`, migrate fixtures to camelCase, expect `dtx_linkage_cache_v2`, and add the equivalent old-key-ignore test.
 
-Run:
+- [ ] **Step 2: Confirm cache tests fail before implementation**
 
 ```bash
 cd packages/dtx-desktop
@@ -565,9 +635,9 @@ bun vitest run \
   src/renderer/src/services/linkageCacheService.test.ts
 ```
 
-Expected: FAIL because implementation still uses v1 keys and `SimfileWithDtx`.
+Expected: FAIL while implementation still uses v1 keys/old shape.
 
-- [ ] **Step 2: Version caches without migration machinery**
+- [ ] **Step 3: Version caches without migration machinery**
 
 In `simFileService.ts`:
 
@@ -587,9 +657,9 @@ import type { SimfileModel } from '@dtx/common';
 const LINKAGE_CACHE_KEY = 'dtx_linkage_cache_v2';
 ```
 
-Change `cloudSongData` / `saveLinkage` to `SimfileModel`. Do not read, delete, or transform `dtx_linkage_cache`.
+Change `cloudSongData` / `saveLinkage` to `SimfileModel`. Do not read/delete/transform `dtx_linkage_cache`.
 
-- [ ] **Step 3: Migrate stores, auto-link service, app, command palette, and workspace fixtures**
+- [ ] **Step 4: Migrate stores, auto-linking, app, palette, and workspace fixtures**
 
 Replace `SimfileWithDtx` with `SimfileModel` in:
 
@@ -597,11 +667,16 @@ Replace `SimfileWithDtx` with `SimfileModel` in:
 - `workspaceStore.ts`
 - `linkingService.ts`
 - `App.svelte` (`triggerAutoLinking(remoteSimFiles: SimfileModel[])`)
-- `CommandPalette.svelte` (`FlatResult` cloud variant)
+- `CommandPalette.svelte` cloud result type
 
-Update their tests/fixtures, including `linkingService.test.ts`, `CommandPalette.test.ts`, `Workspace.test.ts`, and `App.test.ts` if its current mocks/fixtures encode the old shape.
+Update all associated fixtures/tests, including:
 
-In `workspaceStore.ts`, update Drive metadata with camelCase:
+- `linkingService.test.ts`
+- `CommandPalette.test.ts`
+- `Workspace.test.ts`
+- `App.test.ts` if its mocks/fixtures carry the old simfile contract
+
+In `workspaceStore.ts`, update Drive metadata using camelCase:
 
 ```ts
 const driveUpdates: Partial<SimfileModel> = {};
@@ -609,16 +684,21 @@ if (fields.googleDriveFileId) driveUpdates.googleDriveFileId = fields.googleDriv
 if (fields.downloadUrl) driveUpdates.downloadUrl = fields.downloadUrl;
 ```
 
-Do not alter linking heuristics, store ownership, command-palette behavior, or workspace UI behavior.
+Do not change linking heuristics or command/workspace behavior.
 
-- [ ] **Step 4: Migrate score-page cloud projections without changing persisted link format**
+- [ ] **Step 5: Keep score `CloudSong` narrow and string-id based**
 
 In `scoreTypes.ts`:
 
 ```ts
 import type { SimfileModel } from '@dtx/common';
 
-export type CloudSong = Pick<SimfileModel, 'id' | 'title' | 'artist' | 'isPublished'>;
+export interface CloudSong {
+	id: string;
+	title: string;
+	artist: string;
+	isPublished: boolean;
+}
 
 export interface FetchCloudSongResult<T = SimfileModel> {
 	success: boolean;
@@ -629,28 +709,30 @@ export interface FetchCloudSongResult<T = SimfileModel> {
 
 Delete the old snake_case `CloudSongData` interface.
 
-`CloudSong.id` is numeric, but `savedLinks` intentionally stays `Record<string, string>`. Keep conversions explicit in `Scores.svelte`:
+In `Scores.svelte`:
 
-```ts
-String(existing.id) === cloudId
-savedLinks = { ...savedLinks, [songKey(songRow)]: String(song.id) };
-```
+- keep saved `cloudId` strings as `CloudSong.id`;
+- when a full `fetchCloudSong` returns numeric `SimfileModel.id`, keep the existing persisted/search id (`cloudId`) on the narrow `CloudSong` object;
+- rename only `is_published` → `isPublished`;
+- keep `desktopHost.fetchCloudSongCharts(...)(song.id)` unchanged because it still takes `string`;
+- keep `savedLinks: Record<string, string>` unchanged;
+- keep `excludeIdsFor()` string-based.
 
-Use string ids only for score-link persistence/native calls that still take the persisted string id. Use numeric `song.id` inside current-model application state.
+In `CloudSongAutocomplete.svelte`, search results keep string ids and rename only `is_published` → `isPublished`.
 
-Update `excludeIdsFor()` to push `String(existing.id)`. In `CloudSongAutocomplete.svelte`, compare exclusions with `String(song.id)`. Rename `is_published` → `isPublished` in score fixtures/results.
+This avoids adding numeric↔string conversions at `Scores.svelte` chart-fetch call sites.
 
-- [ ] **Step 5: Migrate read-only cloud components**
+- [ ] **Step 6: Migrate read-only full-simfile components**
 
-Use `SimfileModel` in `CloudSongDetail.svelte` and `SimFileList.svelte`. Mechanically rename:
+Use `SimfileModel` in `CloudSongDetail.svelte` and `SimFileList.svelte` and mechanically rename:
 
 - `dtx_files` → `dtxFiles`
 - `publish_date` → `publishDate`
 - `is_published` → `isPublished`
 
-Update their existing tests. No markup redesign.
+Update tests. Do not redesign markup.
 
-- [ ] **Step 6: Migrate `SongDetails` and keep update payloads explicit**
+- [ ] **Step 7: Migrate `SongDetails` and keep updates explicit**
 
 Use:
 
@@ -660,7 +742,7 @@ import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 
 Change create/update/fetch result types to `SimfileModel` / `Partial<SimfileModel>`.
 
-Delete `normalizeSimfile`; native already returns the current model. Keep only the existing minimal IPC object/id guard until HPA-615 generates contracts.
+Delete `normalizeSimfile`; native full responses already match the current model. Keep only the existing minimal IPC object/id guard until HPA-615 generates contracts.
 
 Link current native data directly:
 
@@ -673,9 +755,9 @@ if (result.success && result.cloudSongData && isSimfileModel(result.cloudSongDat
 }
 ```
 
-Build fallback levels as `SimfileDtxFile[]` without `simfile_id`. Build the `ChartDetail` fallback as `Partial<SimfileModel>` with camelCase fields.
+Build fallback levels as `SimfileDtxFile[]` without `simfile_id`. Build `ChartDetail` draft data as `Partial<SimfileModel>`.
 
-General update payloads must be explicit picks, never `{ ...simfile }`:
+General update payloads are explicit picks:
 
 ```ts
 const updateData: Record<string, unknown> = {
@@ -690,45 +772,35 @@ if (parsedLocalData.artist) updateData.artist = parsedLocalData.artist;
 if (song.songTitle || song.name) updateData.title = song.songTitle || song.name;
 ```
 
-Determine Drive ownership from `targetSong.linkedSimFile?.googleDriveFileId`. Do not add `googleDriveFileId`, `dtxFiles`, `id`, `files`, or other `SimfileModel` fields to the general update payload.
+Determine `isDriveBound` from `targetSong.linkedSimFile?.googleDriveFileId`. Never spread a full `SimfileModel` into this payload and never include `googleDriveFileId`, `dtxFiles`, `id`, `files`, or `hasUploadedFiles`.
 
-Preserve stale-selection, concurrency, linking, save, and Drive-upload tests.
+- [ ] **Step 8: Update both desktop E2E linkage seeds**
 
-- [ ] **Step 7: Update desktop E2E linkage-cache seeds to the current key/shape**
+Do not add `@dtx/common` as an E2E dependency just to type a fixture. Keep E2E helper objects structural but match the current model fields exactly.
 
-Do not add `@dtx/common` as an E2E dependency just to type a fixture. Keep the helper structural/inferred, but make its data match `SimfileModel` exactly.
-
-In `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`, change the helper data to:
+In `google-drive-upload.e2e.ts`, seed a camelCase object containing at least:
 
 ```ts
-const linkedSimfile = ({
-	downloadUrl,
-	googleDriveFileId,
-	rendererTitle
-}: {
-	downloadUrl: string | null;
-	googleDriveFileId: string | null;
-	rendererTitle: string;
-}) => ({
+{
 	id: Number(simfileId),
 	title: rendererTitle,
 	artist: 'Integration Test',
 	bpm: 120,
-	isPublished: false,
-	publishDate: '2026-07-25',
 	displayId: Number(simfileId),
-	downloadUrl,
+	userId: null,
 	googleDriveFileId,
+	isPublished: false,
+	downloadUrl,
 	previewUrl: null,
 	videoPreviewUrl: null,
-	userId: null,
-	createdAt: null,
-	updatedAt: null,
+	publishDate: '2026-07-25',
+	createdAt: '2026-07-25T00:00:00.000Z',
+	updatedAt: '2026-07-25T00:00:00.000Z',
 	dtxFiles: []
-});
+}
 ```
 
-Seed:
+Use:
 
 ```ts
 localStorage.setItem('dtx_linkage_cache_v2', JSON.stringify({
@@ -740,9 +812,9 @@ localStorage.setItem('dtx_linkage_cache_v2', JSON.stringify({
 }));
 ```
 
-Apply the same key/field migration in `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`. Do not add a fallback seed under `dtx_linkage_cache`.
+Apply the same key/shape migration in `scripts/google-drive-crash-recovery.ts`. Do not seed v1 as fallback.
 
-- [ ] **Step 8: Verify desktop renderer consumer coverage**
+- [ ] **Step 9: Run the focused desktop behavior tests**
 
 ```bash
 cd packages/dtx-desktop
@@ -759,10 +831,9 @@ bun vitest run \
   src/renderer/src/components/Workspace.test.ts \
   src/renderer/src/components/shell/CommandPalette.test.ts \
   src/renderer/src/components/Scores.test.ts
-bun run typecheck
 ```
 
-If `App.test.ts` contains a migrated fixture or assertion, include it in the focused run:
+Run `App.test.ts` too if Task 4 changed its fixture/mocks:
 
 ```bash
 bun vitest run src/renderer/src/App.test.ts
@@ -770,26 +841,43 @@ bun vitest run src/renderer/src/App.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 9: Validate the affected Drive E2E setup path**
+Vitest executes these tests but does **not** type-check their TypeScript annotations.
 
-Run the existing desktop E2E command that owns both helpers:
+- [ ] **Step 10: Run production renderer typecheck, with its limitation stated explicitly**
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS for production renderer source.
+
+This uses `tsconfig.web.json`, which has `strict: false` and excludes `**/*.test.ts` / `**/*.spec.ts`. Do not treat this as proof that migrated test-only imports/types are valid.
+
+- [ ] **Step 11: Run the load-bearing legacy-type grep before deleting the type**
+
+From repository root:
+
+```bash
+rg -n "LegacySimfile|SimfileWithDtx\b" \
+  packages/dtx-web \
+  packages/dtx-desktop/src/renderer \
+  packages/e2e-desktop
+```
+
+Expected: no active web/renderer/E2E source/test imports or annotations remain. This grep is required precisely because desktop tests are excluded from typecheck and Vitest does not type-check them.
+
+Do not proceed to Task 5 deletion until this is clean.
+
+- [ ] **Step 12: Type-check the E2E package**
 
 ```bash
 cd packages/e2e-desktop
-bun run e2e
-```
-
-This runs the normal WDIO flow plus relaunch and Drive crash-recovery scripts. The Drive upload flow must reach linked Song Details using `dtx_linkage_cache_v2`, and crash recovery must restore the same linked song after reload.
-
-If the full native E2E environment is unavailable locally, still run the package's existing TypeScript check:
-
-```bash
 bun run check
 ```
 
-Record the environment limitation in the implementation PR; do not add compatibility code to make an old seed work.
+Expected: PASS. This covers the modified E2E TypeScript helpers/scripts.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 13: Commit the consumer migration**
 
 ```bash
 git add packages/dtx-desktop/src/renderer/src \
@@ -798,9 +886,36 @@ git add packages/dtx-desktop/src/renderer/src \
 git commit -m "refactor(desktop): consume current simfile model"
 ```
 
+- [ ] **Step 14: Make the implementation PR eligible for the real seam gate**
+
+Tasks 3 and 4 must be present in the same implementation PR. After both are complete and local focused checks pass, mark that implementation PR **ready for review**.
+
+Reason: `.github/workflows/desktop-e2e-test.yml` has:
+
+```yaml
+if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+```
+
+so the desktop-E2E job is skipped on draft PRs.
+
+Do not rely on a draft implementation PR for native→renderer verification.
+
+- [ ] **Step 15: Require desktop E2E before merge**
+
+If the local environment supports it:
+
+```bash
+cd packages/e2e-desktop
+bun run e2e
+```
+
+Regardless of local availability, require the non-draft implementation PR's **Desktop E2E Test / Tauri Integration Test** CI job to run and pass before merge.
+
+The current docs-only PR may remain draft; this requirement applies to the later implementation PR.
+
 ---
 
-## Task 5: Remove compatibility residue only after every consumer has migrated
+## Task 5: Delete compatibility residue, update docs, and run load-bearing completion gates
 
 **Files:**
 - Modify: `packages/common/src/lib/index.ts`
@@ -808,50 +923,48 @@ git commit -m "refactor(desktop): consume current simfile model"
 - Modify: `packages/common/src/lib/types/d1.types.ts`
 - Modify: `packages/common/src/lib/types/d1.types.test.ts`
 - Modify: `packages/common/src/lib/constants.test.ts`
-- Modify only if final grep finds a missed active consumer: files under `packages/dtx-web`, `packages/dtx-desktop`, or `packages/e2e-desktop`
+- Modify: `CLAUDE.md`
+- Modify only if final gates reveal a missed active consumer: files under `packages/dtx-web`, `packages/dtx-desktop`, or `packages/e2e-desktop`
 
 **Interfaces:**
-- Deletes: `SimfileWithDtx` and application-barrel D1/compatibility exports after consumers are gone.
-- Keeps: `SimfileWithDtxFiles`, D1 rows/helpers under `@dtx/common/server`; `Database` auth type.
+- Deletes: `SimfileWithDtx` and application-barrel D1/compatibility exports.
+- Keeps: `SimfileWithDtxFiles`, D1 rows/helpers under `@dtx/common/server`; `Database` auth type; narrow `PreviewSimfile` and string-id `CloudSong` projections.
 
-- [ ] **Step 1: Delete `SimfileWithDtx` now that renderer consumers are gone**
+- [ ] **Step 1: Delete `SimfileWithDtx` only after Task 4's grep is clean**
 
-Remove `SimfileWithDtx` from `packages/common/src/lib/types/d1.types.ts` and its `@dtx/common/server` export.
+Remove `SimfileWithDtx` from `packages/common/src/lib/types/d1.types.ts` and its server/main barrel exports.
 
-Keep `SimfileWithDtxFiles` and `toSimfileWithDtx` server-side because `dtx-api` still consumes them.
+Keep `SimfileWithDtxFiles` / `toSimfileWithDtx` under `@dtx/common/server` because `dtx-api` still uses them.
 
-- [ ] **Step 2: Remove D1/compatibility exports from the main application barrel**
+- [ ] **Step 2: Remove persistence exports from the main application barrel**
 
-In `packages/common/src/lib/index.ts`, keep:
+Keep:
 
 ```ts
 export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
 ```
 
-Remove main-barrel exports of persistence/application-compatibility symbols such as `SimfileRow`, `SimfileInsert`, `SimfileUpdate`, `DtxFileRow`, `DtxFileInsert`, `UserProfileRow`, `UserProfileInsert`, `UserProfileUpdate`, `SimfileWithDtxFiles`, `SimfileWithDtx`, and `toSimfileWithDtx`.
+Remove main-barrel exports of persistence/compatibility symbols such as:
 
-Do not remove those persistence types/helpers from `@dtx/common/server` except the deleted `SimfileWithDtx` compatibility shape.
+- `SimfileRow`
+- `SimfileInsert`
+- `SimfileUpdate`
+- `DtxFileRow`
+- `DtxFileInsert`
+- `UserProfileRow`
+- `UserProfileInsert`
+- `UserProfileUpdate`
+- `SimfileWithDtxFiles`
+- `SimfileWithDtx`
+- `toSimfileWithDtx`
 
-- [ ] **Step 3: Update barrel tests with the cleanup**
+Do not remove the still-used server exports except `SimfileWithDtx` itself.
 
-In `packages/common/src/lib/constants.test.ts`, remove the main-barrel import/assertion for `toSimfileWithDtx` but keep the server-barrel assertion:
+- [ ] **Step 3: Update barrel/D1 tests with the final cleanup**
 
-```ts
-import {
-	DTXFile as ServerDTXFile,
-	SimFile as ServerSimFile,
-	VALID_DTX_FILE_EXTENSIONS as ServerExtensions,
-	toSimfileWithDtx as ServerToSimfile
-} from './server';
-```
+In `constants.test.ts`, remove the main-barrel `toSimfileWithDtx` import/assertion but keep the server-barrel assertion for `ServerToSimfile`.
 
-Keep:
-
-```ts
-expect(ServerToSimfile).toBeDefined();
-```
-
-Update `d1.types.test.ts` only for deleted `SimfileWithDtx` compatibility coverage; keep D1 conversion coverage.
+Update `d1.types.test.ts` only for deleted `SimfileWithDtx` compatibility coverage; keep D1 conversion tests.
 
 Run:
 
@@ -863,7 +976,28 @@ bun run check
 
 Expected: PASS.
 
-- [ ] **Step 4: Prove obsolete named types are gone from active application/E2E code**
+- [ ] **Step 4: Update the repository cache-debugging documentation**
+
+In `CLAUDE.md`'s Manual Cache Clearing section, replace:
+
+```js
+localStorage.removeItem('simfiles_cache');
+localStorage.removeItem('simfiles_cache_timestamp');
+```
+
+with:
+
+```js
+localStorage.removeItem('simfiles_cache_v2');
+localStorage.removeItem('simfiles_cache_timestamp_v2');
+localStorage.removeItem('dtx_linkage_cache_v2');
+```
+
+Keep `simFileService.clearCache()` and unrelated `song_templates` guidance intact.
+
+`AGENTS.md` follows `CLAUDE.md`; do not duplicate the same documentation elsewhere.
+
+- [ ] **Step 5: Re-run the named-type gate across every active package**
 
 ```bash
 rg -n "LegacySimfile|SimfileWithDtx\b" \
@@ -873,9 +1007,27 @@ rg -n "LegacySimfile|SimfileWithDtx\b" \
   packages/e2e-desktop
 ```
 
-Expected: no active source/test matches for `LegacySimfile` or `SimfileWithDtx`. Historical docs outside these active package paths do not need rewriting.
+Expected: no active source/test matches. Historical docs outside these active package paths do not need rewriting.
 
-- [ ] **Step 5: Prove compatibility snake_case simfile properties no longer leak into application/E2E code**
+This is a **load-bearing acceptance gate**, not cleanup hygiene.
+
+- [ ] **Step 6: Run a syntax-oriented snake_case application-model gate**
+
+Use syntax patterns that catch property access/object keys rather than every prose mention:
+
+```bash
+rg -n "\.(display_id|is_published|dtx_files|google_drive_file_id|download_url|preview_url|video_preview_url|publish_date|created_at|updated_at|user_id)\b|\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|preview_url|video_preview_url|publish_date|created_at|updated_at|user_id)\s*:" \
+  packages/common/src/lib/components \
+  packages/dtx-web/src \
+  packages/dtx-desktop/src/renderer/src \
+  packages/e2e-desktop
+```
+
+Expected: no current-model property/object-key usage.
+
+The `formatLevelDisplay` parameter was renamed in Task 2 specifically so it does not create a false positive here.
+
+- [ ] **Step 7: Run the broad informational snake_case grep and classify the known documentation references**
 
 ```bash
 rg -n "\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|preview_url|video_preview_url|publish_date|created_at|updated_at|user_id)\b" \
@@ -885,26 +1037,25 @@ rg -n "\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|pr
   packages/e2e-desktop
 ```
 
-Fix active current-model matches by using `SimfileModel`; do not add aliases.
+Known acceptable prose references include:
 
-Expected intentional exceptions must be evaluated by ownership rather than blindly renamed:
+- `packages/dtx-desktop/src/renderer/src/lib/scoreMatching.ts` comments describing the real server/D1 `dtx_files.level` column.
+- `packages/dtx-web/src/routes/preview/[id]/+page.svelte` comments explaining duplicate D1 `dtx_files` rows.
 
-- D1/server persistence is outside the shared-UI search and remains snake_case.
-- `packages/common/src/lib/types/supabase.types.ts` remains for auth typing.
-- desktop E2E may contain snake_case only when asserting a true native/server persistence wire shape unrelated to the linkage `SimfileModel`; linkage cache seeds must be camelCase.
-- Rust identifiers may be idiomatic snake_case internally, but JSON crossing to the renderer is camelCase.
+Any other match must be classified by boundary ownership. Do not mechanically rename true persistence/native-wire documentation merely to make the broad grep empty.
 
-- [ ] **Step 6: Prove old cache keys are not active or seeded**
+- [ ] **Step 8: Prove exact v1 cache keys are no longer active or seeded**
 
 ```bash
-rg -n "\b(simfiles_cache|simfiles_cache_timestamp|dtx_linkage_cache)\b" \
+rg -n "['\"](simfiles_cache|simfiles_cache_timestamp|dtx_linkage_cache)['\"]" \
   packages/dtx-desktop/src/renderer/src \
-  packages/e2e-desktop
+  packages/e2e-desktop \
+  CLAUDE.md
 ```
 
-Expected: no active exact v1 key usages. `*_v2` matches are allowed.
+Expected: no exact v1-key usage. `*_v2` keys are expected.
 
-- [ ] **Step 7: Reconfirm retained Supabase auth type is live**
+- [ ] **Step 9: Reconfirm retained Supabase auth typing is live**
 
 ```bash
 rg -n "SupabaseClient<Database>|createServerClient<Database>|type \{ Database \}" packages/dtx-web packages/common
@@ -912,7 +1063,7 @@ rg -n "SupabaseClient<Database>|createServerClient<Database>|type \{ Database \}
 
 Expected live consumers in `packages/dtx-web/src/app.d.ts` and `packages/dtx-web/src/hooks.server.ts`. Leave `Database` and `gen-types` in place.
 
-- [ ] **Step 8: Run affected package checks**
+- [ ] **Step 10: Run affected package checks with honest coverage claims**
 
 ```bash
 cd packages/common && bun run test && bun run check
@@ -923,34 +1074,55 @@ cd ../..
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Run `bun run e2e` from `packages/e2e-desktop` when the native E2E environment is available.
+Interpretation:
 
-Expected: all HPA-614-focused tests changed above pass. Record unrelated pre-existing failures separately rather than weakening the migration.
+- Common/web checks type-check their configured source.
+- Desktop `bun run typecheck` checks production renderer source only; it does not type-check test files and runs with `strict: false`.
+- Desktop test-file legacy imports are proven by the load-bearing `rg` gate, not by `svelte-check`.
+- `e2e-desktop` `bun run check` statically checks the changed E2E TypeScript helpers/scripts.
 
-- [ ] **Step 9: Review scope and diff hygiene**
+Expected: all HPA-614-focused tests/checks pass.
+
+- [ ] **Step 11: Require the non-draft desktop E2E CI gate**
+
+Confirm the implementation PR is non-draft and the **Desktop E2E Test / Tauri Integration Test** workflow ran for its final head commit.
+
+Do not merge HPA-614 implementation without that job because Tasks 3–4 are the native/renderer seam that unit suites can independently pass while disagreeing.
+
+- [ ] **Step 12: Review scope and diff hygiene**
 
 ```bash
 git diff --check
 git status --short
 git diff --stat main...HEAD
-git diff main...HEAD -- packages/common packages/dtx-web packages/dtx-desktop packages/e2e-desktop
+git diff main...HEAD -- \
+  packages/common \
+  packages/dtx-web \
+  packages/dtx-desktop \
+  packages/e2e-desktop \
+  CLAUDE.md
 ```
 
 Verify:
 
-- no D1 or GraphQL schema change;
+- no D1/GraphQL schema change;
 - no runtime schema/codegen framework;
-- no compatibility alias for snake_case fields;
+- no compatibility alias/reader;
+- no renderer import from `@dtx/common/server`;
 - no unrelated UI refactor;
-- no deletion of the live Supabase auth `Database` type;
-- `ChartDetail` still uses the existing `dayjs` date fallback;
-- general simfile update payloads are explicit picks and native strips `googleDriveFileId` inline;
-- cache changes are only the three explicit v2 keys plus matching E2E seed updates.
+- no deletion of live `Database` auth typing;
+- `ChartDetail` still uses the existing `dayjs` local-date fallback;
+- `publishDate` / `createdAt` / `updatedAt` remain required model fields;
+- desktop list GraphQL selects both timestamps;
+- score `CloudSong.id` remains string;
+- general simfile updates are explicit picks and native strips only `googleDriveFileId`;
+- cache changes are exactly the three v2 keys plus matching E2E/docs updates;
+- Rust/Vitest both consume the shared `simfile_model.json` fixture.
 
-- [ ] **Step 10: Commit only if cleanup produced changes**
+- [ ] **Step 13: Commit cleanup if it produced changes**
 
 ```bash
-git add packages/common packages/dtx-web packages/dtx-desktop packages/e2e-desktop
+git add packages/common packages/dtx-web packages/dtx-desktop packages/e2e-desktop CLAUDE.md
 git commit -m "refactor: remove legacy simfile compatibility residue"
 ```
 
@@ -960,14 +1132,21 @@ Do not create an empty commit.
 
 ## Expected End State
 
-- `@dtx/common` exposes `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types are server-only.
+- `@dtx/common` exposes `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for full application use; D1 row/aggregate types are server-only.
+- `SimfileModel.publishDate`, `createdAt`, and `updatedAt` are required strings matching the non-null GraphQL schema.
+- Desktop `LIST_SIMFILES_QUERY` selects `createdAt` / `updatedAt` so a full native model never uses omission-as-null.
 - `ChartDetail` accepts `Partial<SimfileModel>`, has no D1 import, and retains its current `dayjs` publish-date fallback.
-- Web GraphQL code adapts generated results directly into camelCase `SimfileModel`; `LegacySimfile` and the chart-page cast are gone.
-- Desktop Rust emits camelCase current-model JSON. The general update mapper is gone, while `update_simfile_record_impl` still removes `googleDriveFileId` inline before `UpdateSimfileInput`.
-- Desktop stores/services/components — including auto-linking, `App.svelte`, `CommandPalette`, and workspace fixtures — use `SimfileModel`.
-- Desktop simfile/linkage caches use only the three v2 keys; both desktop-E2E linkage seeds use `dtx_linkage_cache_v2` with camelCase current-model data and no new common-package dependency.
-- `SimfileWithDtx` is deleted only after consumers migrate; no renderer imports persistence types from `@dtx/common/server`.
-- Score-link persistence remains a small string-id map with explicit conversion at that boundary.
-- `PreviewSimfile` remains a purpose-specific web projection.
-- `Database` / `gen-types` remain because auth still uses them.
-- HPA-615 can generate Tauri TypeScript bindings against one stable renderer-facing model instead of encoding a legacy compatibility contract.
+- Web GraphQL code adapts generated results directly into `SimfileModel`; `LegacySimfile` and the chart-page cast are gone.
+- Desktop Rust emits camelCase full-model JSON and no longer maps current fields through snake_case compatibility names.
+- General native updates remove only `googleDriveFileId`; renderer update objects are explicit picks.
+- Desktop stores/services/components, auto-linking, `App.svelte`, `CommandPalette`, and workspace fixtures use `SimfileModel`.
+- Score-page `CloudSong` stays a purpose-specific string-id projection with camelCase `isPublished`; score links remain `Record<string, string>`.
+- `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2` are the only active renderer simfile/linkage keys.
+- Both desktop-E2E linkage seeds use `dtx_linkage_cache_v2` with current-model camelCase data.
+- `CLAUDE.md` documents the active v2 cache keys.
+- Rust API tests and desktop Vitest consume one shared `src-tauri/tests/fixtures/simfile_model.json` behavioral fixture.
+- Desktop production typecheck is not overstated; excluded test-type cleanup is proven with load-bearing repository greps.
+- `SimfileWithDtx` is deleted only after all consumers migrate; no renderer code imports persistence types from `@dtx/common/server`.
+- `PreviewSimfile`, `Database`, and `gen-types` remain because they still have current owners/consumers.
+- Tasks 3 and 4 ship in one implementation PR, and that PR is non-draft before the required desktop-E2E CI gate.
+- HPA-615 can generate Tauri TypeScript bindings against one stable renderer-facing model instead of encoding a compatibility contract.

--- a/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace Supabase/REST-era simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, and the desktop renderer while keeping D1 snake_case types server-only.
+**Goal:** Replace Supabase/REST-era simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, desktop renderer code, and desktop E2E linkage fixtures while keeping D1 snake_case types server-only.
 
-**Architecture:** `@dtx/common` owns the neutral application model. Web generated GraphQL results and desktop Rust GraphQL results each normalize once at their real transport boundary. Shared/web/desktop application code consumes that model directly. Existing renderer caches are invalidated by versioned keys instead of migrated.
+**Architecture:** `@dtx/common` owns the neutral application model. Web generated GraphQL results and desktop Rust GraphQL results each normalize once at their real transport boundary. Application code consumes that model directly. Renderer caches are invalidated by versioned keys, and desktop E2E seeds use the same current key/shape.
 
-**Tech Stack:** TypeScript, Svelte 5, Vitest, generated GraphQL types, Rust/Tauri, `serde_json`, Bun workspaces.
+**Tech Stack:** TypeScript, Svelte 5, Vitest, generated GraphQL types, Rust/Tauri, `serde_json`, Bun workspaces, WebdriverIO desktop E2E.
 
 ## Global Constraints
 
@@ -18,7 +18,11 @@
 - Do not extract `api.rs` or `SongDetails.svelte`; that is HPA-616.
 - Keep `Database` in `packages/common/src/lib/types/supabase.types.ts`, its existing export, and root `gen-types`: current web auth still consumes `SupabaseClient<Database>` / `createServerClient<Database>`.
 - Invalidate renderer caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read or adapt the old keys.
-- This is a breaking internal migration. Do not retain `LegacySimfile`, `SimfileWithDtx`, snake_case renderer properties, or deprecated aliases.
+- Desktop E2E linkage seeds must use `dtx_linkage_cache_v2` and camelCase current-model data.
+- This is a breaking internal migration. Do not retain `LegacySimfile`, `SimfileWithDtx`, snake_case renderer properties, or deprecated aliases after final cleanup.
+- Do not remove old `@dtx/common` application-barrel D1/compatibility exports until all web/desktop consumers have migrated; never redirect renderer code to `@dtx/common/server` as an intermediate fix.
+- Preserve `ChartDetail`'s current `dayjs().format('YYYY-MM-DD')` publish-date fallback while renaming fields.
+- General simfile updates must never send `googleDriveFileId`; Drive binding remains owned by the dedicated Drive mutation.
 
 ---
 
@@ -27,11 +31,12 @@
 **Files:**
 - Create: `packages/common/src/lib/types/simfile.ts`
 - Modify: `packages/common/src/lib/index.ts`
-- Modify: `packages/common/src/lib/server.ts`
-- Modify: `packages/common/src/lib/types/d1.types.ts`
-- Modify: `packages/common/src/lib/types/d1.types.test.ts`
 - Modify: `packages/common/src/lib/components/ChartDetail.svelte`
 - Modify: `packages/common/src/lib/components/ChartDetail.test.ts`
+
+**Interfaces:**
+- Produces: `SimfileModel`, `SimfileDtxFile`, `SimfileAssetFile` exported from the main `@dtx/common` barrel.
+- Keeps temporarily: existing D1/compatibility exports, including `SimfileWithDtx`, until Task 5.
 
 - [ ] **Step 1: Make `ChartDetail` tests describe the new contract first**
 
@@ -55,7 +60,7 @@ const mockSimfile = {
 };
 ```
 
-Rename the DTX-list fixtures/assertions from `dtx_files` to `dtxFiles`.
+Rename DTX-list fixtures/assertions from `dtx_files` to `dtxFiles`.
 
 - [ ] **Step 2: Run the focused test and confirm the old component contract fails**
 
@@ -104,27 +109,19 @@ export interface SimfileModel {
 }
 ```
 
-Keep `SimfileDtxFile.id` optional because not every GraphQL list projection requests a chart id. Do not add `simfileId` / `simfile_id` to this application model.
+Keep `SimfileDtxFile.id` optional because not every web projection currently requests chart ids. Do not add `simfileId` / `simfile_id` to this application model.
 
-- [ ] **Step 4: Make the browser-facing common barrel expose the application model instead of D1 rows**
+- [ ] **Step 4: Export the new model without removing old application-barrel exports yet**
 
-Add:
+Add to `packages/common/src/lib/index.ts`:
 
 ```ts
 export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
 ```
 
-Remove the main-barrel exports of D1 simfile/profile row types and the two D1 simfile aggregates. Those remain available from `@dtx/common/server` while the API still owns them.
+Do **not** remove `SimfileWithDtx`, `SimfileWithDtxFiles`, D1 row types, or `toSimfileWithDtx` from the main barrel in this task. Current web/desktop consumers and `constants.test.ts` still rely on them; removal belongs in Task 5 after the consumer migration.
 
-Leave `Database` exported because web auth still uses it.
-
-- [ ] **Step 5: Delete only the obsolete desktop-compatible D1 shape**
-
-Delete `SimfileWithDtx` from `d1.types.ts` and remove tests that exist only for that shape.
-
-Keep `SimfileWithDtxFiles` and `toSimfileWithDtx` server-side because `dtx-api` still consumes them. Update `packages/common/src/lib/server.ts` only to stop exporting the deleted `SimfileWithDtx` symbol.
-
-- [ ] **Step 6: Migrate `ChartDetail` mechanically to camelCase**
+- [ ] **Step 5: Migrate `ChartDetail` mechanically to camelCase**
 
 Use:
 
@@ -137,40 +134,37 @@ interface Props {
 }
 ```
 
-Then replace only the compatibility field reads:
+Rename the existing bindings/reads:
 
 ```ts
 displayId = $bindable(simfile?.displayId ?? 0);
-publishDate = $bindable(simfile?.publishDate ?? new Date().toISOString().split('T')[0]);
+publishDate = $bindable(simfile?.publishDate ?? dayjs().format('YYYY-MM-DD'));
 isPublished = $bindable(simfile?.isPublished ?? true);
 downloadUrl = $bindable(simfile?.downloadUrl ?? '');
 videoPreviewUrl = $bindable(simfile?.videoPreviewUrl ?? '');
 let dtxFiles = $derived(simfile?.dtxFiles ?? []);
 ```
 
-Do not redesign the component or change its existing camelCase save-event contract.
+Keep the existing `dayjs` import and fallback. Do not replace it with `new Date().toISOString()` in this migration.
 
-- [ ] **Step 7: Verify common**
+- [ ] **Step 6: Verify common without removing live barrel exports**
 
 ```bash
 cd packages/common
-bun vitest run src/lib/components/ChartDetail.test.ts src/lib/types/d1.types.test.ts
+bun vitest run src/lib/components/ChartDetail.test.ts src/lib/constants.test.ts
 bun run check
 ```
 
-Expected: PASS.
+Expected: PASS. `constants.test.ts` must still pass because the old barrel exports remain until Task 5.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add packages/common/src/lib/types/simfile.ts \
   packages/common/src/lib/index.ts \
-  packages/common/src/lib/server.ts \
-  packages/common/src/lib/types/d1.types.ts \
-  packages/common/src/lib/types/d1.types.test.ts \
   packages/common/src/lib/components/ChartDetail.svelte \
   packages/common/src/lib/components/ChartDetail.test.ts
-git commit -m "refactor(common): define current simfile model"
+git commit -m "refactor(common): add current simfile model"
 ```
 
 ---
@@ -191,9 +185,13 @@ git commit -m "refactor(common): define current simfile model"
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts`
 
+**Interfaces:**
+- Consumes: `SimfileModel`, `SimfileDtxFile` from Task 1.
+- Produces: `toSimfileModel()` as the single web GraphQL→application adapter.
+
 - [ ] **Step 1: Change API adapter tests to the new public shape**
 
-In `chart.test.ts`, replace snake_case result assertions with camelCase assertions. Cover nullable metadata and nested levels, for example:
+In `chart.test.ts`, replace snake_case result assertions with camelCase assertions and cover nullable metadata/nested levels:
 
 ```ts
 expect(result).toMatchObject({
@@ -206,7 +204,7 @@ expect(result).toMatchObject({
 });
 ```
 
-Update list tests to assert `hasUploadedFiles` and Drive-binding tests to expect:
+Update list tests to assert `hasUploadedFiles`. Update Drive-binding expectations to:
 
 ```ts
 {
@@ -216,21 +214,24 @@ Update list tests to assert `hasUploadedFiles` and Drive-binding tests to expect
 }
 ```
 
-Keep the existing invalid numeric-id coverage.
+Keep the existing invalid numeric-id test.
 
 - [ ] **Step 2: Change chart-list fixtures/helper expectations before implementation**
 
-`ChartList.test.ts` already owns both component and `ChartList.helpers` coverage. Migrate `mockListedChart` and helper assertions to:
+`ChartList.test.ts` owns both component and `ChartList.helpers` coverage. Migrate `mockListedChart` and helper assertions to camelCase:
 
 ```ts
-{
+const mockListedChart = {
 	id: 1,
+	title: 'Test Song 1',
+	artist: 'Test Artist 1',
+	bpm: 120,
 	isPublished: true,
 	hasUploadedFiles: true,
 	downloadUrl: 'https://example.com/download1',
 	displayId: 1,
 	dtxFiles: [{ level: 3, label: 'BSC' }]
-}
+};
 ```
 
 Run:
@@ -250,9 +251,7 @@ In `chart.ts` import:
 import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 ```
 
-Delete `LegacySimfile`. Rename/refocus `adaptSimfile` to `toSimfileModel` and return `SimfileModel`.
-
-Keep the existing numeric-id parsing behavior and map current GraphQL names directly:
+Delete `LegacySimfile`. Rename/refocus `adaptSimfile` to `toSimfileModel` and return `SimfileModel`:
 
 ```ts
 const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
@@ -280,7 +279,7 @@ const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
 });
 ```
 
-Do not add a validation framework; this is the same explicit adapter the file already has, minus the legacy renaming.
+Use the existing numeric-id error behavior; do not add runtime validation machinery.
 
 Make `listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. Make `updateSimfileDriveFile` return camelCase `{ id, googleDriveFileId, downloadUrl }`.
 
@@ -298,7 +297,7 @@ export type ChartNavigationItem = {
 
 Update `canBulkSelect`, `isPreviewable`, and `chartTitleHref` accordingly.
 
-In `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte`, use `SimfileModel` and replace only current-model properties such as:
+In `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte`, use `SimfileModel` and replace only current-model property names:
 
 - `is_published` → `isPublished`
 - `has_uploaded_files` → `hasUploadedFiles`
@@ -308,9 +307,9 @@ In `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte`, 
 
 Do not alter layout or behavior.
 
-- [ ] **Step 5: Remove the last web test dependency on D1 row types**
+- [ ] **Step 5: Remove web test dependency on D1 row types**
 
-In `packages/dtx-web/src/lib/utils.test.ts`, replace `DtxFileRow[]` fixtures with `SimfileDtxFile[]` (or the function's existing structural `{ level }[]` type) and remove `simfile_id` from fixtures.
+In `packages/dtx-web/src/lib/utils.test.ts`, replace `DtxFileRow[]` fixtures with `SimfileDtxFile[]` (or the helper's structural `{ level }[]` type) and remove `simfile_id` from fixtures.
 
 - [ ] **Step 6: Migrate the chart-detail page and delete its cast**
 
@@ -329,7 +328,7 @@ Delete the `LegacySimfile` import and render:
 
 without `as import('@dtx/common').SimfileWithDtxFiles`.
 
-Update page-level field reads and `chart-detail-page.test.ts` fixtures to camelCase while preserving existing load/save/error behavior.
+Update page-level fields and `chart-detail-page.test.ts` fixtures to camelCase while preserving load/save/error behavior.
 
 - [ ] **Step 7: Verify web**
 
@@ -373,9 +372,13 @@ git commit -m "refactor(web): consume current simfile model"
 - Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
 
+**Interfaces:**
+- Produces: camelCase current-model JSON from `simfile_model_from_graphql`.
+- Preserves: general-update exclusion of `googleDriveFileId`.
+
 - [ ] **Step 1: Rewrite native API assertions to require camelCase output**
 
-Update existing fetch/create/update/search API tests so the renderer-facing JSON is the same current model shape, for example:
+Update fetch/create/update/search API tests so renderer-facing simfile JSON uses the current model, for example:
 
 ```json
 {
@@ -396,7 +399,7 @@ Update existing fetch/create/update/search API tests so the renderer-facing JSON
 
 Update cloud-search expectations from `is_published` to `isPublished` and make search ids numeric.
 
-Add/update the update-command test so renderer input is already current/GraphQL-shaped:
+Change the update-command request fixture to already use camelCase input names:
 
 ```json
 {
@@ -408,7 +411,7 @@ Add/update the update-command test so renderer input is already current/GraphQL-
 }
 ```
 
-and assert the GraphQL request receives those names unchanged.
+Keep `update_input_excludes_drive_file_id_from_general_simfile_updates` conceptually: after the mapper is removed, rewrite it against the new narrow omission helper/path so it still proves `googleDriveFileId` cannot reach `UpdateSimfileInput`.
 
 - [ ] **Step 2: Confirm the old native contract fails**
 
@@ -416,44 +419,62 @@ and assert the GraphQL request receives those names unchanged.
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Expected: FAIL because native mapping still emits snake_case and update input still uses `update_input_from_renderer`.
+Expected: FAIL because native mapping still emits snake_case and update input still uses the old general mapper.
 
 - [ ] **Step 3: Replace the renderer compatibility mapper**
 
 Rename `renderer_simfile_from_graphql` to `simfile_model_from_graphql`.
 
-Keep `number_id` validation, but emit current JSON keys (`displayId`, `userId`, `googleDriveFileId`, `isPublished`, `downloadUrl`, `previewUrl`, `videoPreviewUrl`, `publishDate`, `createdAt`, `updatedAt`, `dtxFiles`).
+Keep `number_id` validation, but emit current JSON keys: `displayId`, `userId`, `googleDriveFileId`, `isPublished`, `downloadUrl`, `previewUrl`, `videoPreviewUrl`, `publishDate`, `createdAt`, `updatedAt`, `dtxFiles`.
 
-Nested `dtxFiles` contain `id` when supplied plus `label` / `level`. Delete the positional id fallback that existed only for old cached renderer records.
+Nested `dtxFiles` contain a real `id` when supplied plus `label` / `level`. Delete the positional id fallback that existed for older cached renderer records.
 
-Use this mapper in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
+Use the mapper in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
 
-- [ ] **Step 4: Delete the renderer→GraphQL snake_case round trip**
+- [ ] **Step 4: Remove the general update mapper but preserve Drive ownership**
 
-Delete `update_input_from_renderer` and change:
+Delete `update_input_from_renderer`; the renderer no longer sends snake_case.
 
-```rust
-"input": update_input_from_renderer(update_data),
-```
-
-to:
+Before sending `update_data` to GraphQL, remove only `googleDriveFileId` from a JSON object. Keep non-object behavior explicit:
 
 ```rust
-"input": update_data,
+fn general_simfile_update_input(update_data: Value) -> Value {
+    let Value::Object(mut object) = update_data else {
+        return update_data;
+    };
+    object.remove("googleDriveFileId");
+    Value::Object(object)
+}
 ```
 
-The renderer now sends current GraphQL input names. Do not replace the deleted function with a new allowlist/mapper in this ticket.
+Then use:
 
-- [ ] **Step 5: Make cloud search use the current projection names and numeric ids**
+```rust
+"input": general_simfile_update_input(update_data),
+```
 
-Because `number_id` is fallible, keep the collection fallible rather than hiding an invalid id:
+Do not reintroduce a generic field mapper/allowlist here. The renderer will construct explicit update payloads in Task 4, so this helper exists only to preserve the Drive-id ownership invariant at the native boundary.
+
+Rewrite the existing Drive-id test to assert:
+
+```rust
+let mapped = general_simfile_update_input(json!({
+    "title": "Song",
+    "googleDriveFileId": "drive-file-42"
+}));
+assert_eq!(mapped, json!({ "title": "Song" }));
+```
+
+- [ ] **Step 5: Make cloud search use current projection names and numeric ids**
+
+Keep invalid ids fallible:
 
 ```rust
 let rows = songs
     .iter()
     .map(|song| -> Result<Value> {
         Ok(json!({
-            "id": number_id(&song["id"] )?,
+            "id": number_id(&song["id"])?,
             "title": song["title"],
             "artist": song["artist"],
             "bpm": song["bpm"],
@@ -463,16 +484,12 @@ let rows = songs
     .collect::<Result<Vec<_>>>()?;
 ```
 
-Keep the implementation idiomatic if the exact surrounding iterator shape differs; the invariant is numeric validated ids and camelCase output, not this exact formatting.
-
 - [ ] **Step 6: Verify Rust formatting and API tests**
 
 ```bash
 cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml -- --check
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
-
-If formatting fails, run `cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml` and rerun both commands.
 
 Expected: PASS.
 
@@ -486,18 +503,23 @@ git commit -m "refactor(desktop): emit current simfile model from native API"
 
 ---
 
-## Task 4: Migrate desktop renderer state, consumers, and caches
+## Task 4: Migrate every desktop renderer consumer and cache seed
 
-**Files:**
+**Files — services/stores/app:**
 - Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/services/linkageCacheService.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/services/linkageCacheService.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/linkingService.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/linkingService.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/stores/simFileStore.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/stores/simFileStore.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/stores/workspaceStore.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/stores/workspaceStore.test.ts`
-- Modify: `packages/dtx-desktop/src/renderer/src/lib/scoreTypes.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/App.svelte`
+- Modify as fixtures require: `packages/dtx-desktop/src/renderer/src/App.test.ts`
+
+**Files — renderer components:**
 - Modify: `packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte`
@@ -506,9 +528,25 @@ git commit -m "refactor(desktop): emit current simfile model from native API"
 - Modify: `packages/dtx-desktop/src/renderer/src/components/SimFileList.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.test.ts`
-- Modify as required by the shared `CloudSong` id/name change: `packages/dtx-desktop/src/renderer/src/components/ScoreSongCard.svelte`, `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`, `packages/dtx-desktop/src/renderer/src/components/Scores.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/Workspace.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.test.ts`
 
-- [ ] **Step 1: Make cache tests prove stale shapes are ignored**
+**Files — score projection:**
+- Modify: `packages/dtx-desktop/src/renderer/src/lib/scoreTypes.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/ScoreSongCard.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/components/Scores.test.ts`
+
+**Files — desktop E2E current-cache seeds:**
+- Modify: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
+- Modify: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
+
+**Interfaces:**
+- Consumes: `SimfileModel` and camelCase native JSON from Tasks 1/3.
+- Keeps separate: score-link `Record<string, string>` persistence.
+
+- [ ] **Step 1: Make renderer cache tests prove stale shapes are ignored**
 
 In `simFileService.test.ts`, migrate fixtures to camelCase and assert only these keys are read/written:
 
@@ -517,7 +555,7 @@ In `simFileService.test.ts`, migrate fixtures to camelCase and assert only these
 'simfiles_cache_timestamp_v2'
 ```
 
-Add a test where old data exists only under `simfiles_cache`; verify the service still calls `desktopHost.fetchUserSimfiles()`.
+Add a test where valid-looking old data exists only under `simfiles_cache`; verify `desktopHost.fetchUserSimfiles()` is still called.
 
 In `linkageCacheService.test.ts`, migrate `sampleSimfile` to `SimfileModel`, expect `dtx_linkage_cache_v2`, and add the equivalent old-key-ignore assertion.
 
@@ -530,7 +568,7 @@ bun vitest run \
   src/renderer/src/services/linkageCacheService.test.ts
 ```
 
-Expected: FAIL because the implementation still uses v1 keys and `SimfileWithDtx`.
+Expected: FAIL because implementation still uses v1 keys and `SimfileWithDtx`.
 
 - [ ] **Step 2: Version caches without migration machinery**
 
@@ -543,7 +581,7 @@ const CACHE_KEY = 'simfiles_cache_v2';
 const CACHE_TIMESTAMP_KEY = 'simfiles_cache_timestamp_v2';
 ```
 
-Change service/cache result types from `SimfileWithDtx` to `SimfileModel`.
+Change service/cache result types to `SimfileModel`.
 
 In `linkageCacheService.ts`:
 
@@ -552,13 +590,21 @@ import type { SimfileModel } from '@dtx/common';
 const LINKAGE_CACHE_KEY = 'dtx_linkage_cache_v2';
 ```
 
-Change `cloudSongData` / `saveLinkage` to `SimfileModel`. Do not read, delete, or transform `dtx_linkage_cache`; leaving an unreachable old entry is cheaper than adding migration behavior.
+Change `cloudSongData` / `saveLinkage` to `SimfileModel`. Do not read, delete, or transform `dtx_linkage_cache`.
 
-- [ ] **Step 3: Migrate renderer stores to `SimfileModel`**
+- [ ] **Step 3: Migrate stores, auto-link service, app, command palette, and workspace fixtures**
 
-Replace `SimfileWithDtx` annotations in `simFileStore.ts` with `SimfileModel`.
+Replace `SimfileWithDtx` with `SimfileModel` in:
 
-In `workspaceStore.ts`, use `SimfileModel` for linked/selected cloud simfiles and update Drive metadata directly in camelCase:
+- `simFileStore.ts`
+- `workspaceStore.ts`
+- `linkingService.ts`
+- `App.svelte` (`triggerAutoLinking(remoteSimFiles: SimfileModel[])`)
+- `CommandPalette.svelte` (`FlatResult` cloud variant)
+
+Update their tests/fixtures, including `linkingService.test.ts`, `CommandPalette.test.ts`, `Workspace.test.ts`, and `App.test.ts` if its current mocks/fixtures encode the old shape.
+
+In `workspaceStore.ts`, update Drive metadata with camelCase:
 
 ```ts
 const driveUpdates: Partial<SimfileModel> = {};
@@ -566,11 +612,11 @@ if (fields.googleDriveFileId) driveUpdates.googleDriveFileId = fields.googleDriv
 if (fields.downloadUrl) driveUpdates.downloadUrl = fields.downloadUrl;
 ```
 
-Update the existing store fixtures/tests mechanically.
+Do not alter linking heuristics, store ownership, command-palette behavior, or workspace UI behavior.
 
 - [ ] **Step 4: Migrate score-page cloud projections without changing persisted link format**
 
-In `scoreTypes.ts` reuse the current model names:
+In `scoreTypes.ts`:
 
 ```ts
 import type { SimfileModel } from '@dtx/common';
@@ -586,37 +632,34 @@ export interface FetchCloudSongResult<T = SimfileModel> {
 
 Delete the old snake_case `CloudSongData` interface.
 
-`CloudSong.id` is now numeric, but `savedLinks` intentionally remains `Record<string, string>` because it is a small persisted score-link map, not a simfile DTO. Keep that boundary explicit in `Scores.svelte`:
+`CloudSong.id` is numeric, but `savedLinks` intentionally stays `Record<string, string>`. Keep conversions explicit in `Scores.svelte`:
 
 ```ts
-// Comparing a restored numeric model id to persisted string ids
 String(existing.id) === cloudId
-
-// Persisting a selected/restored current-model id
 savedLinks = { ...savedLinks, [songKey(songRow)]: String(song.id) };
 ```
 
 Also:
 
-- construct placeholder/restored `CloudSong` ids with `Number(cloudId)` after the saved id has already been validated by a successful cloud fetch, or reuse the numeric `cloudSongData.id` when available;
-- pass `String(song.id)` to native calls only where that command still takes the persisted string id;
-- make `excludeIdsFor()` push `String(existing.id)`;
-- in `CloudSongAutocomplete.svelte`, compare exclusions with `String(song.id)`;
-- rename `is_published` → `isPublished` in score-page fixtures/results.
+```ts
+const persistedId = String(song.id);
+```
 
-Do not introduce a second legacy `CloudSong` contract just to keep ids as strings.
+Use `persistedId` only for score-link storage/native calls that still take string ids. Use numeric `song.id` inside current-model application state.
 
-- [ ] **Step 5: Migrate read-only desktop cloud components**
+Update `excludeIdsFor()` to push `String(existing.id)`. In `CloudSongAutocomplete.svelte`, compare exclusions with `String(song.id)`. Rename `is_published` → `isPublished` in score fixtures/results.
 
-In `CloudSongDetail.svelte` and `SimFileList.svelte` use `SimfileModel` and mechanically rename:
+- [ ] **Step 5: Migrate read-only cloud components**
+
+Use `SimfileModel` in `CloudSongDetail.svelte` and `SimFileList.svelte`. Mechanically rename:
 
 - `dtx_files` → `dtxFiles`
 - `publish_date` → `publishDate`
 - `is_published` → `isPublished`
 
-Update existing tests. No markup redesign.
+Update their existing tests. No markup redesign.
 
-- [ ] **Step 6: Migrate `SongDetails` and delete renderer compatibility normalization**
+- [ ] **Step 6: Migrate `SongDetails` and keep update payloads explicit**
 
 Use:
 
@@ -626,7 +669,7 @@ import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 
 Change create/update/fetch result types to `SimfileModel` / `Partial<SimfileModel>`.
 
-Delete `normalizeSimfile`; native now returns the current model. Keep only a minimal IPC object/id guard until HPA-615 generates contracts—do not add Zod or a schema layer.
+Delete `normalizeSimfile`; native already returns the current model. Keep only the existing minimal IPC object/id guard until HPA-615 generates contracts.
 
 Link current native data directly:
 
@@ -639,11 +682,9 @@ if (result.success && result.cloudSongData && isSimfileModel(result.cloudSongDat
 }
 ```
 
-Build local fallback DTX files as `SimfileDtxFile[]` without `simfile_id`.
+Build fallback levels as `SimfileDtxFile[]` without `simfile_id`. Build the `ChartDetail` fallback as `Partial<SimfileModel>` with camelCase fields.
 
-Build the `ChartDetail` fallback as `Partial<SimfileModel>` using `publishDate`, `displayId`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, and `dtxFiles`.
-
-Send update payloads to Rust with current GraphQL names:
+General update payloads must be explicit picks, never `{ ...simfile }`:
 
 ```ts
 const updateData: Record<string, unknown> = {
@@ -653,68 +694,210 @@ const updateData: Record<string, unknown> = {
 	videoPreviewUrl: String(event.detail.videoPreviewUrl)
 };
 if (!isDriveBound) updateData.downloadUrl = String(event.detail.downloadUrl);
+if (parsedLocalData.bpm) updateData.bpm = parsedLocalData.bpm;
+if (parsedLocalData.artist) updateData.artist = parsedLocalData.artist;
+if (song.songTitle || song.name) updateData.title = song.songTitle || song.name;
 ```
 
-Change linked-record reads such as `google_drive_file_id` / `download_url` to `googleDriveFileId` / `downloadUrl`.
+Determine Drive ownership from `targetSong.linkedSimFile?.googleDriveFileId`. Do not add `googleDriveFileId`, `dtxFiles`, `id`, `files`, or other `SimfileModel` fields to the general update payload.
 
-Preserve existing stale-selection, concurrency, linking, save, and Drive-upload behavior tests.
+Preserve stale-selection, concurrency, linking, save, and Drive-upload tests.
 
-- [ ] **Step 7: Verify desktop renderer**
+- [ ] **Step 7: Update desktop E2E linkage-cache seeds to the current key/shape**
+
+In `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`, change the helper shape and seed key:
+
+```ts
+const linkedSimfile = (...): SimfileModel => ({
+	id: Number(simfileId),
+	title: rendererTitle,
+	artist: 'Integration Test',
+	bpm: 120,
+	isPublished: false,
+	publishDate: '2026-07-25',
+	displayId: Number(simfileId),
+	downloadUrl,
+	googleDriveFileId,
+	previewUrl: null,
+	videoPreviewUrl: null,
+	userId: null,
+	createdAt: null,
+	updatedAt: null,
+	dtxFiles: []
+});
+```
+
+Seed:
+
+```ts
+localStorage.setItem('dtx_linkage_cache_v2', JSON.stringify({
+	[songPath]: {
+		linkedSimFileId: String(cloudSong.id),
+		linkedAt: '2026-07-25T00:00:00.000Z',
+		cloudSongData: cloudSong
+	}
+}));
+```
+
+Apply the same key/field migration in `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`. Do not add a fallback seed under `dtx_linkage_cache`.
+
+- [ ] **Step 8: Verify desktop renderer consumer coverage**
 
 ```bash
 cd packages/dtx-desktop
 bun vitest run \
   src/renderer/src/services/simFileService.test.ts \
   src/renderer/src/services/linkageCacheService.test.ts \
+  src/renderer/src/services/linkingService.test.ts \
   src/renderer/src/stores/simFileStore.test.ts \
   src/renderer/src/stores/workspaceStore.test.ts \
   src/renderer/src/components/SongDetails.test.ts \
   src/renderer/src/components/CloudSongDetail.test.ts \
   src/renderer/src/components/SimFileList.test.ts \
   src/renderer/src/components/CloudSongAutocomplete.test.ts \
+  src/renderer/src/components/Workspace.test.ts \
+  src/renderer/src/components/shell/CommandPalette.test.ts \
   src/renderer/src/components/Scores.test.ts
 bun run typecheck
 ```
 
-Expected: PASS.
-
-- [ ] **Step 8: Commit**
+If `App.test.ts` contains a migrated fixture or assertion, include it in the focused run:
 
 ```bash
-git add packages/dtx-desktop/src/renderer/src
+bun vitest run src/renderer/src/App.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Validate the affected Drive E2E setup path**
+
+Run the existing desktop E2E command(s) that own these two helpers in the repository's normal E2E environment. At minimum, the Drive upload flow must reach linked Song Details using the new cache seed; the crash-recovery script must restore the same linked song after reload.
+
+Use the existing package scripts rather than introducing a new runner:
+
+```bash
+cd packages/e2e-desktop
+bun run e2e
+```
+
+If the full desktop E2E environment is unavailable locally, run the repository's existing typecheck/build validation for `packages/e2e-desktop` and record the environment limitation in the implementation PR; do not add compatibility code to make the old seed work.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/dtx-desktop/src/renderer/src \
+  packages/e2e-desktop/specs/google-drive-upload.e2e.ts \
+  packages/e2e-desktop/scripts/google-drive-crash-recovery.ts
 git commit -m "refactor(desktop): consume current simfile model"
 ```
 
 ---
 
-## Task 5: Remove compatibility residue and verify the full seam
+## Task 5: Remove compatibility residue only after every consumer has migrated
 
-- [ ] **Step 1: Prove obsolete named types are gone from active source**
+**Files:**
+- Modify: `packages/common/src/lib/index.ts`
+- Modify: `packages/common/src/lib/server.ts`
+- Modify: `packages/common/src/lib/types/d1.types.ts`
+- Modify: `packages/common/src/lib/types/d1.types.test.ts`
+- Modify: `packages/common/src/lib/constants.test.ts`
+- Modify only if final grep finds a missed active consumer: files under `packages/dtx-web`, `packages/dtx-desktop`, or `packages/e2e-desktop`
 
-```bash
-rg -n "LegacySimfile|SimfileWithDtx\b" packages/common packages/dtx-web packages/dtx-desktop
+**Interfaces:**
+- Deletes: `SimfileWithDtx` and application-barrel D1/compatibility exports after consumers are gone.
+- Keeps: `SimfileWithDtxFiles`, D1 rows/helpers under `@dtx/common/server`; `Database` auth type.
+
+- [ ] **Step 1: Delete `SimfileWithDtx` now that renderer consumers are gone**
+
+Remove `SimfileWithDtx` from `packages/common/src/lib/types/d1.types.ts` and its `@dtx/common/server` export.
+
+Keep `SimfileWithDtxFiles` and `toSimfileWithDtx` server-side because `dtx-api` still consumes them.
+
+- [ ] **Step 2: Remove D1/compatibility exports from the main application barrel**
+
+In `packages/common/src/lib/index.ts`, keep:
+
+```ts
+export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
 ```
 
-Expected: no active source/test matches. Historical docs do not need rewriting.
+Remove main-barrel exports of persistence/application-compatibility symbols such as `SimfileRow`, `SimfileInsert`, `SimfileUpdate`, `DtxFileRow`, `DtxFileInsert`, `UserProfileRow`, `UserProfileInsert`, `UserProfileUpdate`, `SimfileWithDtxFiles`, `SimfileWithDtx`, and `toSimfileWithDtx`.
 
-- [ ] **Step 2: Prove snake_case simfile properties no longer leak into shared/web/renderer application code**
+Do not remove those persistence types/helpers from `@dtx/common/server` except the deleted `SimfileWithDtx` compatibility shape.
+
+- [ ] **Step 3: Update barrel tests with the cleanup**
+
+In `packages/common/src/lib/constants.test.ts`, remove the main-barrel import/assertion for `toSimfileWithDtx` but keep the server-barrel assertion:
+
+```ts
+import {
+	DTXFile as ServerDTXFile,
+	SimFile as ServerSimFile,
+	VALID_DTX_FILE_EXTENSIONS as ServerExtensions,
+	toSimfileWithDtx as ServerToSimfile
+} from './server';
+```
+
+Keep:
+
+```ts
+expect(ServerToSimfile).toBeDefined();
+```
+
+Update `d1.types.test.ts` only for deleted `SimfileWithDtx` compatibility coverage; keep D1 conversion coverage.
+
+Run:
+
+```bash
+cd packages/common
+bun vitest run src/lib/constants.test.ts src/lib/types/d1.types.test.ts
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Prove obsolete named types are gone from active application/E2E code**
+
+```bash
+rg -n "LegacySimfile|SimfileWithDtx\b" \
+  packages/common \
+  packages/dtx-web \
+  packages/dtx-desktop \
+  packages/e2e-desktop
+```
+
+Expected: no active source/test matches for `LegacySimfile` or `SimfileWithDtx`. Historical docs outside these active package paths do not need rewriting.
+
+- [ ] **Step 5: Prove compatibility snake_case simfile properties no longer leak into application/E2E code**
 
 ```bash
 rg -n "\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|preview_url|video_preview_url|publish_date|created_at|updated_at|user_id)\b" \
   packages/common/src/lib/components \
   packages/dtx-web/src \
-  packages/dtx-desktop/src/renderer/src
+  packages/dtx-desktop/src/renderer/src \
+  packages/e2e-desktop
 ```
 
-Fix active application-model matches by using `SimfileModel`; do not add aliases.
+Fix active current-model matches by using `SimfileModel`; do not add aliases.
 
-Expected intentional boundaries:
+Expected intentional exceptions must be evaluated by ownership rather than blindly renamed:
 
-- D1/server code is outside the shared-UI search and remains snake_case.
-- `packages/common/src/lib/types/supabase.types.ts` is intentionally retained for auth typing.
+- D1/server persistence is outside the shared-UI search and remains snake_case.
+- `packages/common/src/lib/types/supabase.types.ts` remains for auth typing.
+- desktop E2E may contain snake_case only when asserting a true native/server persistence wire shape unrelated to the linkage `SimfileModel`; linkage cache seeds must be camelCase.
 - Rust identifiers may be idiomatic snake_case internally, but JSON crossing to the renderer is camelCase.
 
-- [ ] **Step 3: Reconfirm the retained Supabase auth type is live**
+- [ ] **Step 6: Prove old cache keys are not active or seeded**
+
+```bash
+rg -n "\b(simfiles_cache|simfiles_cache_timestamp|dtx_linkage_cache)\b" \
+  packages/dtx-desktop/src/renderer/src \
+  packages/e2e-desktop
+```
+
+Expected: no active exact v1 key usages. `*_v2` matches are allowed.
+
+- [ ] **Step 7: Reconfirm retained Supabase auth type is live**
 
 ```bash
 rg -n "SupabaseClient<Database>|createServerClient<Database>|type \{ Database \}" packages/dtx-web packages/common
@@ -722,7 +905,7 @@ rg -n "SupabaseClient<Database>|createServerClient<Database>|type \{ Database \}
 
 Expected live consumers in `packages/dtx-web/src/app.d.ts` and `packages/dtx-web/src/hooks.server.ts`. Leave `Database` and `gen-types` in place.
 
-- [ ] **Step 4: Run affected package checks**
+- [ ] **Step 8: Run affected package checks**
 
 ```bash
 cd packages/common && bun run test && bun run check
@@ -732,15 +915,17 @@ cd ../..
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Expected: PASS. If a repo-wide suite exposes an unrelated pre-existing failure, record it separately; every HPA-614-focused test changed above must still pass.
+Then validate `packages/e2e-desktop` with its existing test/typecheck/E2E path available in the implementation environment.
 
-- [ ] **Step 5: Review scope and diff hygiene**
+Expected: all HPA-614-focused tests changed above pass. Record unrelated pre-existing failures separately rather than weakening the migration.
+
+- [ ] **Step 9: Review scope and diff hygiene**
 
 ```bash
 git diff --check
 git status --short
 git diff --stat main...HEAD
-git diff main...HEAD -- packages/common packages/dtx-web packages/dtx-desktop
+git diff main...HEAD -- packages/common packages/dtx-web packages/dtx-desktop packages/e2e-desktop
 ```
 
 Verify:
@@ -750,12 +935,14 @@ Verify:
 - no compatibility alias for snake_case fields;
 - no unrelated UI refactor;
 - no deletion of the live Supabase auth `Database` type;
-- cache changes are only the three explicit v2 keys.
+- `ChartDetail` still uses the existing `dayjs` date fallback;
+- general simfile update payloads are explicit picks and native strips `googleDriveFileId`;
+- cache changes are only the three explicit v2 keys plus matching E2E seed updates.
 
-- [ ] **Step 6: Commit only if cleanup produced changes**
+- [ ] **Step 10: Commit only if cleanup produced changes**
 
 ```bash
-git add packages/common packages/dtx-web packages/dtx-desktop
+git add packages/common packages/dtx-web packages/dtx-desktop packages/e2e-desktop
 git commit -m "refactor: remove legacy simfile compatibility residue"
 ```
 
@@ -765,12 +952,14 @@ Do not create an empty commit.
 
 ## Expected End State
 
-- `@dtx/common` exposes `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types remain server-only.
-- `ChartDetail` accepts `Partial<SimfileModel>` and has no D1 import.
+- `@dtx/common` exposes `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types are server-only.
+- `ChartDetail` accepts `Partial<SimfileModel>`, has no D1 import, and retains its current `dayjs` publish-date fallback.
 - Web GraphQL code adapts generated results directly into camelCase `SimfileModel`; `LegacySimfile` and the chart-page cast are gone.
-- Desktop Rust emits camelCase current-model JSON and accepts camelCase update input without `update_input_from_renderer`.
-- Desktop stores/services/components use `SimfileModel`; `SimfileWithDtx` and `normalizeSimfile` are gone.
-- Desktop simfile/linkage caches use only the three v2 keys; old shapes are ignored.
-- Score-link persistence remains a small string-id map with explicit conversion at that persistence boundary; it does not force the current simfile model back to string ids.
+- Desktop Rust emits camelCase current-model JSON. The general update mapper is gone, but a narrow native omission still prevents `googleDriveFileId` from entering `UpdateSimfileInput`.
+- Desktop stores/services/components — including auto-linking, `App.svelte`, `CommandPalette`, and workspace fixtures — use `SimfileModel`.
+- Desktop simfile/linkage caches use only the three v2 keys; both desktop-E2E linkage seeds use `dtx_linkage_cache_v2` with camelCase current-model data.
+- `SimfileWithDtx` is deleted only after consumers migrate; no renderer imports persistence types from `@dtx/common/server`.
+- Score-link persistence remains a small string-id map with explicit conversion at that boundary.
+- `PreviewSimfile` remains a purpose-specific web projection.
 - `Database` / `gen-types` remain because auth still uses them.
 - HPA-615 can generate Tauri TypeScript bindings against one stable renderer-facing model instead of encoding a legacy compatibility contract.

--- a/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
@@ -2,22 +2,22 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the Supabase/REST-era simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, and the desktop renderer while keeping D1 snake_case types server-only.
+**Goal:** Replace Supabase/REST-era simfile compatibility shapes with one camelCase `SimfileModel` across shared UI, web, and the desktop renderer while keeping D1 snake_case types server-only.
 
-**Architecture:** `@dtx/common` owns the neutral application model. Web generated GraphQL responses and desktop Rust GraphQL responses each normalize once at their transport boundary. Shared/web/desktop application code consumes the neutral model directly. Old localStorage simfile shapes are invalidated by versioned cache keys rather than migrated.
+**Architecture:** `@dtx/common` owns the neutral application model. Web generated GraphQL results and desktop Rust GraphQL results each normalize once at their real transport boundary. Shared/web/desktop application code consumes that model directly. Existing renderer caches are invalidated by versioned keys instead of migrated.
 
-**Tech Stack:** TypeScript, Svelte 5, Vitest, GraphQL Codegen types, Rust/Tauri, serde_json, Bun workspaces.
+**Tech Stack:** TypeScript, Svelte 5, Vitest, generated GraphQL types, Rust/Tauri, `serde_json`, Bun workspaces.
 
 ## Global Constraints
 
 - Keep D1/Drizzle row types and snake_case fields in server persistence code; do not move them into the application model.
-- Use exactly one shared application model: `SimfileModel` plus its nested `SimfileDtxFile` / `SimfileAssetFile` value types.
-- Do not add a DTO/mapper framework, runtime schema library, repository layer, cache migration framework, or compatibility aliases.
+- Use one shared application model: `SimfileModel` plus `SimfileDtxFile` / `SimfileAssetFile` nested value types.
+- Do not add a generic DTO/mapper layer, runtime schema library, repository abstraction, cache migration framework, or compatibility aliases.
 - Do not change the D1 schema or GraphQL schema.
-- Do not add production `ts-rs` or generated Tauri contracts; that is HPA-615.
-- Do not extract `api.rs` / `SongDetails`; that is HPA-616.
-- Keep `Database` in `packages/common/src/lib/types/supabase.types.ts`, its main-barrel export, and root `gen-types`: current web auth code still consumes `SupabaseClient<Database>`.
-- Version caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read or adapt the old keys.
+- Do not add production Rust→TypeScript generation; that is HPA-615.
+- Do not extract `api.rs` or `SongDetails.svelte`; that is HPA-616.
+- Keep `Database` in `packages/common/src/lib/types/supabase.types.ts`, its existing export, and root `gen-types`: current web auth still consumes `SupabaseClient<Database>` / `createServerClient<Database>`.
+- Invalidate renderer caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read or adapt the old keys.
 - This is a breaking internal migration. Do not retain `LegacySimfile`, `SimfileWithDtx`, snake_case renderer properties, or deprecated aliases.
 
 ---
@@ -27,14 +27,15 @@
 **Files:**
 - Create: `packages/common/src/lib/types/simfile.ts`
 - Modify: `packages/common/src/lib/index.ts`
+- Modify: `packages/common/src/lib/server.ts`
 - Modify: `packages/common/src/lib/types/d1.types.ts`
 - Modify: `packages/common/src/lib/types/d1.types.test.ts`
 - Modify: `packages/common/src/lib/components/ChartDetail.svelte`
 - Modify: `packages/common/src/lib/components/ChartDetail.test.ts`
 
-- [ ] **Step 1: Make the `ChartDetail` test describe the new contract first**
+- [ ] **Step 1: Make `ChartDetail` tests describe the new contract first**
 
-Change `mockSimfile` in `ChartDetail.test.ts` to camelCase and remove the D1-only `simfile_id` field:
+Change `mockSimfile` in `ChartDetail.test.ts` to camelCase and remove D1-only `simfile_id`:
 
 ```ts
 const mockSimfile = {
@@ -54,22 +55,20 @@ const mockSimfile = {
 };
 ```
 
-Rename the DTX-list assertions from `dtx_files` to `dtxFiles`.
+Rename the DTX-list fixtures/assertions from `dtx_files` to `dtxFiles`.
 
 - [ ] **Step 2: Run the focused test and confirm the old component contract fails**
-
-Run:
 
 ```bash
 cd packages/common
 bun vitest run src/lib/components/ChartDetail.test.ts
 ```
 
-Expected: FAIL because `ChartDetail` still reads `display_id`, `is_published`, `download_url`, `publish_date`, `video_preview_url`, and `dtx_files`.
+Expected: FAIL because `ChartDetail` still reads snake_case simfile fields.
 
-- [ ] **Step 3: Add the shared current model**
+- [ ] **Step 3: Add the current shared model**
 
-Create `packages/common/src/lib/types/simfile.ts` with:
+Create `packages/common/src/lib/types/simfile.ts`:
 
 ```ts
 export interface SimfileDtxFile {
@@ -105,31 +104,29 @@ export interface SimfileModel {
 }
 ```
 
-`id` on nested DTX files is optional because list projections do not require it. Do not add `simfileId`/`simfile_id` to this UI model.
+Keep `SimfileDtxFile.id` optional because not every GraphQL list projection requests a chart id. Do not add `simfileId` / `simfile_id` to this application model.
 
-- [ ] **Step 4: Make the browser-facing common barrel expose the application model, not D1 rows**
+- [ ] **Step 4: Make the browser-facing common barrel expose the application model instead of D1 rows**
 
-In `packages/common/src/lib/index.ts`:
+Add:
 
 ```ts
 export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
 ```
 
-Remove the main-barrel exports of `SimfileRow`, `SimfileInsert`, `SimfileUpdate`, `DtxFileRow`, `DtxFileInsert`, `UserProfileRow`, `UserProfileInsert`, `UserProfileUpdate`, `SimfileWithDtxFiles`, `SimfileWithDtx`, and `toSimfileWithDtx`.
+Remove the main-barrel exports of D1 simfile/profile row types and the two D1 simfile aggregates. Those remain available from `@dtx/common/server` while the API still owns them.
 
-Leave `Database` exported because web auth still uses it. Leave all persistence exports in `packages/common/src/lib/server.ts` unchanged except for removal of `SimfileWithDtx` after Step 5.
+Leave `Database` exported because web auth still uses it.
 
-- [ ] **Step 5: Delete the desktop-compatible D1 shape**
+- [ ] **Step 5: Delete only the obsolete desktop-compatible D1 shape**
 
-Delete `SimfileWithDtx` from `packages/common/src/lib/types/d1.types.ts` and remove only tests/imports that exist solely to validate that compatibility shape.
+Delete `SimfileWithDtx` from `d1.types.ts` and remove tests that exist only for that shape.
 
-Keep `SimfileWithDtxFiles` and `toSimfileWithDtx` server-side because `dtx-api`/D1 still use them. Do not rename or relocate those server types in HPA-614.
-
-Update `packages/common/src/lib/server.ts` so it no longer exports the deleted `SimfileWithDtx` symbol but still exports current D1/server types.
+Keep `SimfileWithDtxFiles` and `toSimfileWithDtx` server-side because `dtx-api` still consumes them. Update `packages/common/src/lib/server.ts` only to stop exporting the deleted `SimfileWithDtx` symbol.
 
 - [ ] **Step 6: Migrate `ChartDetail` mechanically to camelCase**
 
-Change the prop type to:
+Use:
 
 ```ts
 import type { SimfileModel } from '../types/simfile';
@@ -140,7 +137,7 @@ interface Props {
 }
 ```
 
-Update only the field reads/bind defaults:
+Then replace only the compatibility field reads:
 
 ```ts
 displayId = $bindable(simfile?.displayId ?? 0);
@@ -151,11 +148,9 @@ videoPreviewUrl = $bindable(simfile?.videoPreviewUrl ?? '');
 let dtxFiles = $derived(simfile?.dtxFiles ?? []);
 ```
 
-Do not change the component layout or its existing camelCase save event payload.
+Do not redesign the component or change its existing camelCase save-event contract.
 
-- [ ] **Step 7: Run common verification**
-
-Run:
+- [ ] **Step 7: Verify common**
 
 ```bash
 cd packages/common
@@ -165,7 +160,7 @@ bun run check
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit the shared-model slice**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add packages/common/src/lib/types/simfile.ts \
@@ -186,8 +181,8 @@ git commit -m "refactor(common): define current simfile model"
 - Modify: `packages/dtx-web/src/lib/api/chart.ts`
 - Modify: `packages/dtx-web/src/lib/api/chart.test.ts`
 - Modify: `packages/dtx-web/src/lib/components/ChartList.helpers.ts`
-- Modify: `packages/dtx-web/src/lib/components/ChartList.helpers.test.ts`
 - Modify: `packages/dtx-web/src/lib/components/ChartList.svelte`
+- Modify: `packages/dtx-web/src/lib/components/ChartList.test.ts`
 - Modify: `packages/dtx-web/src/lib/components/ChartListItem.svelte`
 - Modify: `packages/dtx-web/src/lib/components/ChartListItem.test.ts`
 - Modify: `packages/dtx-web/src/lib/components/ChartListTableItem.svelte`
@@ -196,9 +191,9 @@ git commit -m "refactor(common): define current simfile model"
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts`
 
-- [ ] **Step 1: Change the API adapter tests to the new public shape**
+- [ ] **Step 1: Change API adapter tests to the new public shape**
 
-In `chart.test.ts`, replace snake_case output assertions with camelCase assertions. Cover one complete adapter result, including nullable fields and nested DTX files:
+In `chart.test.ts`, replace snake_case result assertions with camelCase assertions. Cover nullable metadata and nested levels, for example:
 
 ```ts
 expect(result).toMatchObject({
@@ -211,7 +206,7 @@ expect(result).toMatchObject({
 });
 ```
 
-Update list tests to assert `hasUploadedFiles`, and Drive-binding tests to expect:
+Update list tests to assert `hasUploadedFiles` and Drive-binding tests to expect:
 
 ```ts
 {
@@ -221,28 +216,35 @@ Update list tests to assert `hasUploadedFiles`, and Drive-binding tests to expec
 }
 ```
 
-Keep the existing invalid numeric-id test.
+Keep the existing invalid numeric-id coverage.
 
-- [ ] **Step 2: Change chart-list helper tests to camelCase before implementation**
+- [ ] **Step 2: Change chart-list fixtures/helper expectations before implementation**
 
-Update helper fixtures and expectations so navigation/selectability uses:
+`ChartList.test.ts` already owns both component and `ChartList.helpers` coverage. Migrate `mockListedChart` and helper assertions to:
 
 ```ts
-{ id: 1, isPublished: true, hasUploadedFiles: true }
+{
+	id: 1,
+	isPublished: true,
+	hasUploadedFiles: true,
+	downloadUrl: 'https://example.com/download1',
+	displayId: 1,
+	dtxFiles: [{ level: 3, label: 'BSC' }]
+}
 ```
 
 Run:
 
 ```bash
 cd packages/dtx-web
-bun vitest run src/lib/api/chart.test.ts src/lib/components/ChartList.helpers.test.ts
+bun vitest run src/lib/api/chart.test.ts src/lib/components/ChartList.test.ts
 ```
 
-Expected: FAIL while the web adapter/helpers still emit/read snake_case.
+Expected: FAIL while the adapter/list code still emits or reads snake_case.
 
-- [ ] **Step 3: Replace `LegacySimfile` with a typed `SimfileModel` adapter**
+- [ ] **Step 3: Replace `LegacySimfile` with one typed GraphQL→model adapter**
 
-In `chart.ts`:
+In `chart.ts` import:
 
 ```ts
 import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
@@ -250,7 +252,7 @@ import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 
 Delete `LegacySimfile`. Rename/refocus `adaptSimfile` to `toSimfileModel` and return `SimfileModel`.
 
-The adapter must use the current field names and stable null defaults:
+Keep the existing numeric-id parsing behavior and map current GraphQL names directly:
 
 ```ts
 const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
@@ -274,19 +276,17 @@ const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
 		level: Number(file.level)
 	})),
 	...(simfile.files == null ? {} : { files: simfile.files }),
-	...(simfile.hasUploadedFiles == null
-		? {}
-		: { hasUploadedFiles: simfile.hasUploadedFiles })
+	...(simfile.hasUploadedFiles == null ? {} : { hasUploadedFiles: simfile.hasUploadedFiles })
 });
 ```
 
-Use the existing numeric-id helper/error behavior rather than adding validation machinery.
+Do not add a validation framework; this is the same explicit adapter the file already has, minus the legacy renaming.
 
-Make `listSimfiles`, `getSimfile`, and `updateSimfile` return this model. Make `updateSimfileDriveFile` return camelCase `{ id, googleDriveFileId, downloadUrl }`.
+Make `listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. Make `updateSimfileDriveFile` return camelCase `{ id, googleDriveFileId, downloadUrl }`.
 
-- [ ] **Step 4: Migrate chart-list helpers and components**
+- [ ] **Step 4: Migrate chart-list helpers/components**
 
-In `ChartList.helpers.ts` rename the narrow navigation fields:
+Change the helper projection to:
 
 ```ts
 export type ChartNavigationItem = {
@@ -296,57 +296,48 @@ export type ChartNavigationItem = {
 };
 ```
 
-Update `canBulkSelect`, `isPreviewable`, and `chartTitleHref` to use `hasUploadedFiles` / `isPublished`.
+Update `canBulkSelect`, `isPreviewable`, and `chartTitleHref` accordingly.
 
-In `ChartList.svelte`, use `SimfileModel[]` directly and change all list state/filter/toggle reads to `isPublished`, `hasUploadedFiles`, `displayId`, and `dtxFiles`.
+In `ChartList.svelte`, `ChartListItem.svelte`, and `ChartListTableItem.svelte`, use `SimfileModel` and replace only current-model properties such as:
 
-In `ChartListItem.svelte` and `ChartListTableItem.svelte`, replace `SimfileWithDtx` with `SimfileModel` and migrate their field reads. In particular:
+- `is_published` → `isPublished`
+- `has_uploaded_files` → `hasUploadedFiles`
+- `display_id` → `displayId`
+- `download_url` → `downloadUrl`
+- `dtx_files` → `dtxFiles`
 
-```svelte
-<DownloadDropdown
-	simfileId={item.id}
-	externalUrl={item.downloadUrl ?? null}
-	hasUploadedFiles={item.hasUploadedFiles}
-/>
-```
+Do not alter layout or behavior.
 
-Do not change UI behavior or styling.
+- [ ] **Step 5: Remove the last web test dependency on D1 row types**
 
-- [ ] **Step 5: Remove the last web D1 test dependency**
+In `packages/dtx-web/src/lib/utils.test.ts`, replace `DtxFileRow[]` fixtures with `SimfileDtxFile[]` (or the function's existing structural `{ level }[]` type) and remove `simfile_id` from fixtures.
 
-In `packages/dtx-web/src/lib/utils.test.ts`, replace `DtxFileRow[]` fixtures with `SimfileDtxFile[]` (or the function's existing minimal `{ level }[]` structural type) and delete `simfile_id` from those fixtures.
+- [ ] **Step 6: Migrate the chart-detail page and delete its cast**
 
-This is necessary so the main `@dtx/common` barrel can stop exposing D1 row types.
-
-- [ ] **Step 6: Migrate the web chart-detail page without a cast**
-
-In `+page.svelte`:
+Use:
 
 ```ts
 import type { SimfileModel } from '@dtx/common';
-
 let simfile: SimfileModel | null = $state(null);
 ```
 
-Delete the `LegacySimfile` import and the cast:
+Delete the `LegacySimfile` import and render:
 
 ```svelte
 <ChartDetail simfile={simfile} ... />
 ```
 
-Change page-level reads from `is_published` and other snake_case names to the current camelCase fields. Keep `files` handling unchanged apart from the new model type.
+without `as import('@dtx/common').SimfileWithDtxFiles`.
 
-Update `chart-detail-page.test.ts` fixtures to camelCase and preserve the current load/save/error behavior assertions.
+Update page-level field reads and `chart-detail-page.test.ts` fixtures to camelCase while preserving existing load/save/error behavior.
 
-- [ ] **Step 7: Run web tests and type check**
-
-Run:
+- [ ] **Step 7: Verify web**
 
 ```bash
 cd packages/dtx-web
 bun vitest run \
   src/lib/api/chart.test.ts \
-  src/lib/components/ChartList.helpers.test.ts \
+  src/lib/components/ChartList.test.ts \
   src/lib/components/ChartListItem.test.ts \
   src/lib/components/ChartListTableItem.test.ts \
   src/lib/utils.test.ts \
@@ -356,14 +347,14 @@ bun run check
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit the web migration**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add packages/dtx-web/src/lib/api/chart.ts \
   packages/dtx-web/src/lib/api/chart.test.ts \
   packages/dtx-web/src/lib/components/ChartList.helpers.ts \
-  packages/dtx-web/src/lib/components/ChartList.helpers.test.ts \
   packages/dtx-web/src/lib/components/ChartList.svelte \
+  packages/dtx-web/src/lib/components/ChartList.test.ts \
   packages/dtx-web/src/lib/components/ChartListItem.svelte \
   packages/dtx-web/src/lib/components/ChartListItem.test.ts \
   packages/dtx-web/src/lib/components/ChartListTableItem.svelte \
@@ -382,9 +373,9 @@ git commit -m "refactor(web): consume current simfile model"
 - Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
 
-- [ ] **Step 1: Rewrite native API assertions to require camelCase renderer output**
+- [ ] **Step 1: Rewrite native API assertions to require camelCase output**
 
-Update the existing `renderer_simfile_from_graphql`/fetch/create/update/search tests in `api_tests.rs` so expected JSON uses:
+Update existing fetch/create/update/search API tests so the renderer-facing JSON is the same current model shape, for example:
 
 ```json
 {
@@ -403,9 +394,9 @@ Update the existing `renderer_simfile_from_graphql`/fetch/create/update/search t
 }
 ```
 
-Update cloud-search expectations from `is_published` to `isPublished`, and make search ids numeric so the renderer does not retain another incompatible id representation.
+Update cloud-search expectations from `is_published` to `isPublished` and make search ids numeric.
 
-Add/update the update-command test so the renderer input is camelCase:
+Add/update the update-command test so renderer input is already current/GraphQL-shaped:
 
 ```json
 {
@@ -417,63 +408,29 @@ Add/update the update-command test so the renderer input is camelCase:
 }
 ```
 
-and the GraphQL mock receives those names unchanged.
+and assert the GraphQL request receives those names unchanged.
 
-- [ ] **Step 2: Run the native API test module and confirm failure**
-
-Run:
+- [ ] **Step 2: Confirm the old native contract fails**
 
 ```bash
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Expected: FAIL because native mapping still emits snake_case and update input still passes through `update_input_from_renderer`.
+Expected: FAIL because native mapping still emits snake_case and update input still uses `update_input_from_renderer`.
 
 - [ ] **Step 3: Replace the renderer compatibility mapper**
 
-Rename:
+Rename `renderer_simfile_from_graphql` to `simfile_model_from_graphql`.
 
-```rust
-renderer_simfile_from_graphql
-```
+Keep `number_id` validation, but emit current JSON keys (`displayId`, `userId`, `googleDriveFileId`, `isPublished`, `downloadUrl`, `previewUrl`, `videoPreviewUrl`, `publishDate`, `createdAt`, `updatedAt`, `dtxFiles`).
 
-to:
+Nested `dtxFiles` contain `id` when supplied plus `label` / `level`. Delete the positional id fallback that existed only for old cached renderer records.
 
-```rust
-simfile_model_from_graphql
-```
+Use this mapper in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
 
-Keep `number_id` validation, but emit current JSON keys:
+- [ ] **Step 4: Delete the renderer→GraphQL snake_case round trip**
 
-```rust
-mapped.insert("id".to_string(), json!(number_id(&simfile["id"])?));
-mapped.insert("displayId".to_string(), simfile["displayId"].clone());
-mapped.insert("userId".to_string(), simfile["userId"].clone());
-mapped.insert(
-    "googleDriveFileId".to_string(),
-    simfile["googleDriveFileId"].clone(),
-);
-mapped.insert("isPublished".to_string(), simfile["isPublished"].clone());
-mapped.insert("downloadUrl".to_string(), simfile["downloadUrl"].clone());
-mapped.insert("previewUrl".to_string(), simfile["previewUrl"].clone());
-mapped.insert(
-    "videoPreviewUrl".to_string(),
-    simfile["videoPreviewUrl"].clone(),
-);
-mapped.insert("publishDate".to_string(), simfile["publishDate"].clone());
-mapped.insert("createdAt".to_string(), simfile["createdAt"].clone());
-mapped.insert("updatedAt".to_string(), simfile["updatedAt"].clone());
-```
-
-Keep `title`, `artist`, and `bpm` unchanged. Emit the nested collection as `dtxFiles` with only `id` when present plus `label`/`level`. Delete the positional id fallback that existed only for old cached renderer records.
-
-Use `simfile_model_from_graphql` in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
-
-- [ ] **Step 4: Delete the renderer-to-GraphQL snake_case round trip**
-
-Delete `update_input_from_renderer`.
-
-Change `update_simfile_record_impl` from:
+Delete `update_input_from_renderer` and change:
 
 ```rust
 "input": update_input_from_renderer(update_data),
@@ -485,38 +442,41 @@ to:
 "input": update_data,
 ```
 
-The renderer will send only current GraphQL input names. Do not introduce an allowlist/mapper here; the GraphQL input remains the validation boundary.
+The renderer now sends current GraphQL input names. Do not replace the deleted function with a new allowlist/mapper in this ticket.
 
-- [ ] **Step 5: Make cloud search use the current projection names**
+- [ ] **Step 5: Make cloud search use the current projection names and numeric ids**
 
-In `search_cloud_songs_impl`, return numeric `id` and camelCase `isPublished`:
+Because `number_id` is fallible, keep the collection fallible rather than hiding an invalid id:
 
 ```rust
-json!({
-    "id": number_id(&song["id"]),
-    "title": song["title"],
-    "artist": song["artist"],
-    "bpm": song["bpm"],
-    "isPublished": song["isPublished"],
-})
+let rows = songs
+    .iter()
+    .map(|song| -> Result<Value> {
+        Ok(json!({
+            "id": number_id(&song["id"] )?,
+            "title": song["title"],
+            "artist": song["artist"],
+            "bpm": song["bpm"],
+            "isPublished": song["isPublished"],
+        }))
+    })
+    .collect::<Result<Vec<_>>>()?;
 ```
 
-If the closure needs fallible id parsing, collect a `Result<Vec<Value>>` rather than falling back to a string or `0`.
+Keep the implementation idiomatic if the exact surrounding iterator shape differs; the invariant is numeric validated ids and camelCase output, not this exact formatting.
 
-- [ ] **Step 6: Run Rust formatting and tests**
-
-Run:
+- [ ] **Step 6: Verify Rust formatting and API tests**
 
 ```bash
 cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml -- --check
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-If `cargo fmt --check` reports formatting changes, run `cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml`, then rerun both commands.
+If formatting fails, run `cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml` and rerun both commands.
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit the native boundary change**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add packages/dtx-desktop/src-tauri/src/api.rs \
@@ -546,20 +506,20 @@ git commit -m "refactor(desktop): emit current simfile model from native API"
 - Modify: `packages/dtx-desktop/src/renderer/src/components/SimFileList.test.ts`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte`
 - Modify: `packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.test.ts`
-- Modify as required by the same `CloudSong` type rename: `packages/dtx-desktop/src/renderer/src/components/ScoreSongCard.svelte`, `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`, and their existing tests.
+- Modify as required by the shared `CloudSong` id/name change: `packages/dtx-desktop/src/renderer/src/components/ScoreSongCard.svelte`, `packages/dtx-desktop/src/renderer/src/components/Scores.svelte`, `packages/dtx-desktop/src/renderer/src/components/Scores.test.ts`
 
-- [ ] **Step 1: Make cache tests prove old shapes are not read**
+- [ ] **Step 1: Make cache tests prove stale shapes are ignored**
 
-In `simFileService.test.ts`, update fixtures to camelCase and assert the service only accesses:
+In `simFileService.test.ts`, migrate fixtures to camelCase and assert only these keys are read/written:
 
 ```ts
 'simfiles_cache_v2'
 'simfiles_cache_timestamp_v2'
 ```
 
-Add a test where the mock returns old data only for `simfiles_cache` and confirm `fetchUserSimfiles` is still called. This proves the old cache is ignored, not adapted.
+Add a test where old data exists only under `simfiles_cache`; verify the service still calls `desktopHost.fetchUserSimfiles()`.
 
-In `linkageCacheService.test.ts`, update `sampleSimfile` to `SimfileModel`, expect writes/removals against `dtx_linkage_cache_v2`, and add the equivalent old-key-ignore test.
+In `linkageCacheService.test.ts`, migrate `sampleSimfile` to `SimfileModel`, expect `dtx_linkage_cache_v2`, and add the equivalent old-key-ignore assertion.
 
 Run:
 
@@ -572,7 +532,7 @@ bun vitest run \
 
 Expected: FAIL because the implementation still uses v1 keys and `SimfileWithDtx`.
 
-- [ ] **Step 2: Version the caches without migration code**
+- [ ] **Step 2: Version caches without migration machinery**
 
 In `simFileService.ts`:
 
@@ -583,55 +543,40 @@ const CACHE_KEY = 'simfiles_cache_v2';
 const CACHE_TIMESTAMP_KEY = 'simfiles_cache_timestamp_v2';
 ```
 
-Change `MainProcessSimFileResult`, `SimFileServiceResult`, `getCachedData`, and `setCachedData` from `SimfileWithDtx` to `SimfileModel`.
+Change service/cache result types from `SimfileWithDtx` to `SimfileModel`.
 
 In `linkageCacheService.ts`:
 
 ```ts
 import type { SimfileModel } from '@dtx/common';
-
 const LINKAGE_CACHE_KEY = 'dtx_linkage_cache_v2';
 ```
 
-Change `cloudSongData` and `saveLinkage` to `SimfileModel`. Do not read, delete, or transform `dtx_linkage_cache`; leaving an unreachable old localStorage entry is cheaper and safer than migration logic.
+Change `cloudSongData` / `saveLinkage` to `SimfileModel`. Do not read, delete, or transform `dtx_linkage_cache`; leaving an unreachable old entry is cheaper than adding migration behavior.
 
-- [ ] **Step 3: Migrate desktop stores to `SimfileModel`**
+- [ ] **Step 3: Migrate renderer stores to `SimfileModel`**
 
-In `simFileStore.ts`, replace every `SimfileWithDtx` annotation with `SimfileModel`.
+Replace `SimfileWithDtx` annotations in `simFileStore.ts` with `SimfileModel`.
 
-In `workspaceStore.ts`:
-
-```ts
-import type { SimfileModel } from '@dtx/common';
-```
-
-Use it for `TreeNode.linkedSimFile`, `selectedCloudSimFile`, `selectCloudSimFile`, and `linkSimFileToFolder`.
-
-Keep `GoogleDriveFields` camelCase and stop translating them back to snake_case:
+In `workspaceStore.ts`, use `SimfileModel` for linked/selected cloud simfiles and update Drive metadata directly in camelCase:
 
 ```ts
 const driveUpdates: Partial<SimfileModel> = {};
-if (fields.googleDriveFileId) {
-	driveUpdates.googleDriveFileId = fields.googleDriveFileId;
-}
-if (fields.downloadUrl) {
-	driveUpdates.downloadUrl = fields.downloadUrl;
-}
+if (fields.googleDriveFileId) driveUpdates.googleDriveFileId = fields.googleDriveFileId;
+if (fields.downloadUrl) driveUpdates.downloadUrl = fields.downloadUrl;
 ```
 
-Update both store test fixture families to camelCase.
+Update the existing store fixtures/tests mechanically.
 
-- [ ] **Step 4: Migrate the desktop score/link projections to the current naming**
+- [ ] **Step 4: Migrate score-page cloud projections without changing persisted link format**
 
-In `scoreTypes.ts`, import `SimfileModel` and make the cloud-search projection reuse the current model keys:
+In `scoreTypes.ts` reuse the current model names:
 
 ```ts
+import type { SimfileModel } from '@dtx/common';
+
 export type CloudSong = Pick<SimfileModel, 'id' | 'title' | 'artist' | 'isPublished'>;
-```
 
-Delete the old `CloudSongData` snake_case interface. Make the fetch envelope default to the full current model:
-
-```ts
 export interface FetchCloudSongResult<T = SimfileModel> {
 	success: boolean;
 	cloudSongData?: T;
@@ -639,40 +584,51 @@ export interface FetchCloudSongResult<T = SimfileModel> {
 }
 ```
 
-Update `CloudSongAutocomplete.svelte` to use the shared `CloudSong` type instead of redeclaring a second interface. Its exclusion check must compare `String(song.id)` with the existing string id list.
+Delete the old snake_case `CloudSongData` interface.
 
-Update `ScoreSongCard.svelte`, `Scores.svelte`, and their tests only where the `CloudSong.id` number / `isPublished` rename requires it. Do not refactor score matching in this ticket.
+`CloudSong.id` is now numeric, but `savedLinks` intentionally remains `Record<string, string>` because it is a small persisted score-link map, not a simfile DTO. Keep that boundary explicit in `Scores.svelte`:
 
-- [ ] **Step 5: Migrate read-only cloud components**
+```ts
+// Comparing a restored numeric model id to persisted string ids
+String(existing.id) === cloudId
 
-In `CloudSongDetail.svelte`:
+// Persisting a selected/restored current-model id
+savedLinks = { ...savedLinks, [songKey(songRow)]: String(song.id) };
+```
 
-- `SimfileWithDtx` -> `SimfileModel`
-- `dtx_files` -> `dtxFiles`
-- `publish_date` -> `publishDate`
-- `is_published` -> `isPublished`
+Also:
 
-In `SimFileList.svelte`:
+- construct placeholder/restored `CloudSong` ids with `Number(cloudId)` after the saved id has already been validated by a successful cloud fetch, or reuse the numeric `cloudSongData.id` when available;
+- pass `String(song.id)` to native calls only where that command still takes the persisted string id;
+- make `excludeIdsFor()` push `String(existing.id)`;
+- in `CloudSongAutocomplete.svelte`, compare exclusions with `String(song.id)`;
+- rename `is_published` → `isPublished` in score-page fixtures/results.
 
-- `publish_date` -> `publishDate`
-- `dtx_files` -> `dtxFiles`
-- `is_published` -> `isPublished`
+Do not introduce a second legacy `CloudSong` contract just to keep ids as strings.
 
-Update their tests mechanically. No markup/layout redesign.
+- [ ] **Step 5: Migrate read-only desktop cloud components**
+
+In `CloudSongDetail.svelte` and `SimFileList.svelte` use `SimfileModel` and mechanically rename:
+
+- `dtx_files` → `dtxFiles`
+- `publish_date` → `publishDate`
+- `is_published` → `isPublished`
+
+Update existing tests. No markup redesign.
 
 - [ ] **Step 6: Migrate `SongDetails` and delete renderer compatibility normalization**
 
-Replace the imports with:
+Use:
 
 ```ts
 import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 ```
 
-Change create/update/fetch result types from `SimfileWithDtx` to `SimfileModel` / `Partial<SimfileModel>`.
+Change create/update/fetch result types to `SimfileModel` / `Partial<SimfileModel>`.
 
-Rename the small IPC guard to `isSimfileModel` and keep it minimal until HPA-615, e.g. validate only the object/id/title shape needed to reject obviously malformed IPC data. Do not add Zod or a schema abstraction.
+Delete `normalizeSimfile`; native now returns the current model. Keep only a minimal IPC object/id guard until HPA-615 generates contracts—do not add Zod or a schema layer.
 
-Delete `normalizeSimfile`. Native now returns the current model, so linking becomes:
+Link current native data directly:
 
 ```ts
 if (result.success && result.cloudSongData && isSimfileModel(result.cloudSongData)) {
@@ -683,18 +639,11 @@ if (result.success && result.cloudSongData && isSimfileModel(result.cloudSongDat
 }
 ```
 
-Build local fallback levels as `SimfileDtxFile[]`:
+Build local fallback DTX files as `SimfileDtxFile[]` without `simfile_id`.
 
-```ts
-const fallbackDtxFiles: SimfileDtxFile[] = parsedLocalData.levels?.map((level) => ({
-	label: level.label || 'Unknown',
-	level: Number(level.level || 0)
-})) ?? [];
-```
+Build the `ChartDetail` fallback as `Partial<SimfileModel>` using `publishDate`, `displayId`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, and `dtxFiles`.
 
-Build `simfileData` as `Partial<SimfileModel>` with `publishDate`, `displayId`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, and `dtxFiles`.
-
-Change the update payload sent to `desktopHost.updateSimfileRecord` to GraphQL/current names:
+Send update payloads to Rust with current GraphQL names:
 
 ```ts
 const updateData: Record<string, unknown> = {
@@ -703,18 +652,14 @@ const updateData: Record<string, unknown> = {
 	isPublished: Boolean(event.detail.isPublished),
 	videoPreviewUrl: String(event.detail.videoPreviewUrl)
 };
-if (!isDriveBound) {
-	updateData.downloadUrl = String(event.detail.downloadUrl);
-}
+if (!isDriveBound) updateData.downloadUrl = String(event.detail.downloadUrl);
 ```
 
-Change all linked-record reads such as `google_drive_file_id` / `download_url` to `googleDriveFileId` / `downloadUrl`.
+Change linked-record reads such as `google_drive_file_id` / `download_url` to `googleDriveFileId` / `downloadUrl`.
 
-Update `SongDetails.test.ts` fixtures/IPC assertions accordingly. Preserve all existing stale-selection, concurrent action, linking, save, and Drive upload behavior tests.
+Preserve existing stale-selection, concurrency, linking, save, and Drive-upload behavior tests.
 
-- [ ] **Step 7: Run desktop renderer tests and type check**
-
-Run:
+- [ ] **Step 7: Verify desktop renderer**
 
 ```bash
 cd packages/dtx-desktop
@@ -727,14 +672,13 @@ bun vitest run \
   src/renderer/src/components/CloudSongDetail.test.ts \
   src/renderer/src/components/SimFileList.test.ts \
   src/renderer/src/components/CloudSongAutocomplete.test.ts \
-  src/renderer/src/components/ScoreSongCard.test.ts \
   src/renderer/src/components/Scores.test.ts
 bun run typecheck
 ```
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit the renderer/cache migration**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add packages/dtx-desktop/src/renderer/src
@@ -745,23 +689,15 @@ git commit -m "refactor(desktop): consume current simfile model"
 
 ## Task 5: Remove compatibility residue and verify the full seam
 
-**Files:**
-- Modify only files surfaced by the explicit searches below if they are active application consumers of the removed compatibility contract.
-- Do **not** edit `packages/common/src/lib/types/supabase.types.ts` or D1/server snake_case code merely because the searches find them.
-
-- [ ] **Step 1: Prove the obsolete named types are gone**
-
-Run from the repo root:
+- [ ] **Step 1: Prove obsolete named types are gone from active source**
 
 ```bash
 rg -n "LegacySimfile|SimfileWithDtx\b" packages/common packages/dtx-web packages/dtx-desktop
 ```
 
-Expected: no matches in source/test code. Historical docs may still mention them and do not need rewriting.
+Expected: no active source/test matches. Historical docs do not need rewriting.
 
-- [ ] **Step 2: Prove snake_case simfile properties no longer leak into app/UI code**
-
-Run:
+- [ ] **Step 2: Prove snake_case simfile properties no longer leak into shared/web/renderer application code**
 
 ```bash
 rg -n "\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|preview_url|video_preview_url|publish_date|created_at|updated_at|user_id)\b" \
@@ -770,27 +706,23 @@ rg -n "\b(display_id|is_published|dtx_files|google_drive_file_id|download_url|pr
   packages/dtx-desktop/src/renderer/src
 ```
 
-Expected application exceptions must be justified narrowly before leaving them. In particular:
+Fix active application-model matches by using `SimfileModel`; do not add aliases.
 
-- D1/server files are outside this search and remain snake_case.
-- `packages/common/src/lib/types/supabase.types.ts` is intentionally retained and is outside shared UI.
-- Native Rust identifiers may remain idiomatic snake_case internally, but JSON keys crossing to the renderer must be camelCase.
+Expected intentional boundaries:
 
-Fix active UI/renderer matches by using `SimfileModel`; do not add aliases.
+- D1/server code is outside the shared-UI search and remains snake_case.
+- `packages/common/src/lib/types/supabase.types.ts` is intentionally retained for auth typing.
+- Rust identifiers may be idiomatic snake_case internally, but JSON crossing to the renderer is camelCase.
 
-- [ ] **Step 3: Confirm the retained Supabase auth type is still genuinely used**
-
-Run:
+- [ ] **Step 3: Reconfirm the retained Supabase auth type is live**
 
 ```bash
 rg -n "SupabaseClient<Database>|createServerClient<Database>|type \{ Database \}" packages/dtx-web packages/common
 ```
 
-Expected: current uses in `packages/dtx-web/src/app.d.ts` and `packages/dtx-web/src/hooks.server.ts`. Leave `Database` and `gen-types` in place.
+Expected live consumers in `packages/dtx-web/src/app.d.ts` and `packages/dtx-web/src/hooks.server.ts`. Leave `Database` and `gen-types` in place.
 
-- [ ] **Step 4: Run all affected checks**
-
-Run:
+- [ ] **Step 4: Run affected package checks**
 
 ```bash
 cd packages/common && bun run test && bun run check
@@ -800,51 +732,45 @@ cd ../..
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Expected: PASS. If the repo-wide test suites expose unrelated pre-existing failures, record those separately and still require every HPA-614-focused test changed above to pass.
+Expected: PASS. If a repo-wide suite exposes an unrelated pre-existing failure, record it separately; every HPA-614-focused test changed above must still pass.
 
-- [ ] **Step 5: Review the diff for scope discipline**
-
-Run:
+- [ ] **Step 5: Review scope and diff hygiene**
 
 ```bash
 git diff --check
 git status --short
 git diff --stat main...HEAD
-git diff main...HEAD -- \
-  packages/common \
-  packages/dtx-web \
-  packages/dtx-desktop
+git diff main...HEAD -- packages/common packages/dtx-web packages/dtx-desktop
 ```
 
 Verify:
 
-- no GraphQL schema/D1 schema changes;
+- no D1 or GraphQL schema change;
 - no runtime schema/codegen framework;
 - no compatibility alias for snake_case fields;
 - no unrelated UI refactor;
 - no deletion of the live Supabase auth `Database` type;
 - cache changes are only the three explicit v2 keys.
 
-- [ ] **Step 6: Commit any final mechanical cleanup**
-
-If Step 1/2 surfaced active compatibility residue and it was fixed:
+- [ ] **Step 6: Commit only if cleanup produced changes**
 
 ```bash
 git add packages/common packages/dtx-web packages/dtx-desktop
 git commit -m "refactor: remove legacy simfile compatibility residue"
 ```
 
-If there were no cleanup edits, do not create an empty commit.
+Do not create an empty commit.
 
 ---
 
 ## Expected End State
 
-- `@dtx/common` main exports `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types remain server-only.
+- `@dtx/common` exposes `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types remain server-only.
 - `ChartDetail` accepts `Partial<SimfileModel>` and has no D1 import.
 - Web GraphQL code adapts generated results directly into camelCase `SimfileModel`; `LegacySimfile` and the chart-page cast are gone.
 - Desktop Rust emits camelCase current-model JSON and accepts camelCase update input without `update_input_from_renderer`.
 - Desktop stores/services/components use `SimfileModel`; `SimfileWithDtx` and `normalizeSimfile` are gone.
-- Desktop cache keys are `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`; old cached shapes are ignored.
-- `Database`/`gen-types` remain because auth still uses them.
-- HPA-615 can now generate Tauri TypeScript bindings against one stable renderer-facing model instead of encoding a legacy compatibility contract.
+- Desktop simfile/linkage caches use only the three v2 keys; old shapes are ignored.
+- Score-link persistence remains a small string-id map with explicit conversion at that persistence boundary; it does not force the current simfile model back to string ids.
+- `Database` / `gen-types` remain because auth still uses them.
+- HPA-615 can generate Tauri TypeScript bindings against one stable renderer-facing model instead of encoding a legacy compatibility contract.

--- a/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md
@@ -18,7 +18,7 @@
 - Do not extract `api.rs` or `SongDetails.svelte`; that is HPA-616.
 - Keep `Database` in `packages/common/src/lib/types/supabase.types.ts`, its existing export, and root `gen-types`: current web auth still consumes `SupabaseClient<Database>` / `createServerClient<Database>`.
 - Invalidate renderer caches by switching to `simfiles_cache_v2`, `simfiles_cache_timestamp_v2`, and `dtx_linkage_cache_v2`. Never read or adapt the old keys.
-- Desktop E2E linkage seeds must use `dtx_linkage_cache_v2` and camelCase current-model data.
+- Desktop E2E linkage seeds must use `dtx_linkage_cache_v2` and camelCase current-model data, without adding an `@dtx/common` dependency to the E2E package.
 - This is a breaking internal migration. Do not retain `LegacySimfile`, `SimfileWithDtx`, snake_case renderer properties, or deprecated aliases after final cleanup.
 - Do not remove old `@dtx/common` application-barrel D1/compatibility exports until all web/desktop consumers have migrated; never redirect renderer code to `@dtx/common/server` as an intermediate fix.
 - Preserve `ChartDetail`'s current `dayjs().format('YYYY-MM-DD')` publish-date fallback while renaming fields.
@@ -411,7 +411,7 @@ Change the update-command request fixture to already use camelCase input names:
 }
 ```
 
-Keep `update_input_excludes_drive_file_id_from_general_simfile_updates` conceptually: after the mapper is removed, rewrite it against the new narrow omission helper/path so it still proves `googleDriveFileId` cannot reach `UpdateSimfileInput`.
+Keep the Drive-id ownership test: after the general mapper is removed, rewrite it against `update_simfile_record_impl`'s one-field omission so it still proves `googleDriveFileId` cannot reach `UpdateSimfileInput`.
 
 - [ ] **Step 2: Confirm the old native contract fails**
 
@@ -431,39 +431,36 @@ Nested `dtxFiles` contain a real `id` when supplied plus `label` / `level`. Dele
 
 Use the mapper in `fetch_user_simfiles_impl`, `fetch_cloud_song_impl`, `update_simfile_record_impl`, and `create_simfile_record_impl`.
 
-- [ ] **Step 4: Remove the general update mapper but preserve Drive ownership**
+- [ ] **Step 4: Remove the general update mapper but preserve Drive ownership inline**
 
 Delete `update_input_from_renderer`; the renderer no longer sends snake_case.
 
-Before sending `update_data` to GraphQL, remove only `googleDriveFileId` from a JSON object. Keep non-object behavior explicit:
+Inside `update_simfile_record_impl`, remove only `googleDriveFileId` before constructing the GraphQL variables:
 
 ```rust
-fn general_simfile_update_input(update_data: Value) -> Value {
-    let Value::Object(mut object) = update_data else {
-        return update_data;
-    };
-    object.remove("googleDriveFileId");
-    Value::Object(object)
-}
+let input = match update_data {
+    Value::Object(mut object) => {
+        object.remove("googleDriveFileId");
+        Value::Object(object)
+    }
+    other => other,
+};
+
+let result = graphql_result_with_url(
+    base_url,
+    token,
+    &graphql_document(UPDATE_SIMFILE_MUTATION),
+    json!({
+        "id": simfile_id.to_string().trim_matches('"'),
+        "input": input,
+    }),
+)
+.await?;
 ```
 
-Then use:
+Do not create a replacement mapper/helper. The renderer constructs explicit update payloads in Task 4; this inline omission exists only to preserve Drive-id ownership at the native boundary.
 
-```rust
-"input": general_simfile_update_input(update_data),
-```
-
-Do not reintroduce a generic field mapper/allowlist here. The renderer will construct explicit update payloads in Task 4, so this helper exists only to preserve the Drive-id ownership invariant at the native boundary.
-
-Rewrite the existing Drive-id test to assert:
-
-```rust
-let mapped = general_simfile_update_input(json!({
-    "title": "Song",
-    "googleDriveFileId": "drive-file-42"
-}));
-assert_eq!(mapped, json!({ "title": "Song" }));
-```
+Update the existing native test to capture/assert the outgoing GraphQL request (or an extracted local input value already inside the test seam) and prove `googleDriveFileId` is absent while normal fields such as `title` remain.
 
 - [ ] **Step 5: Make cloud search use current projection names and numeric ids**
 
@@ -639,13 +636,7 @@ String(existing.id) === cloudId
 savedLinks = { ...savedLinks, [songKey(songRow)]: String(song.id) };
 ```
 
-Also:
-
-```ts
-const persistedId = String(song.id);
-```
-
-Use `persistedId` only for score-link storage/native calls that still take string ids. Use numeric `song.id` inside current-model application state.
+Use string ids only for score-link persistence/native calls that still take the persisted string id. Use numeric `song.id` inside current-model application state.
 
 Update `excludeIdsFor()` to push `String(existing.id)`. In `CloudSongAutocomplete.svelte`, compare exclusions with `String(song.id)`. Rename `is_published` → `isPublished` in score fixtures/results.
 
@@ -705,10 +696,20 @@ Preserve stale-selection, concurrency, linking, save, and Drive-upload tests.
 
 - [ ] **Step 7: Update desktop E2E linkage-cache seeds to the current key/shape**
 
-In `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`, change the helper shape and seed key:
+Do not add `@dtx/common` as an E2E dependency just to type a fixture. Keep the helper structural/inferred, but make its data match `SimfileModel` exactly.
+
+In `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`, change the helper data to:
 
 ```ts
-const linkedSimfile = (...): SimfileModel => ({
+const linkedSimfile = ({
+	downloadUrl,
+	googleDriveFileId,
+	rendererTitle
+}: {
+	downloadUrl: string | null;
+	googleDriveFileId: string | null;
+	rendererTitle: string;
+}) => ({
 	id: Number(simfileId),
 	title: rendererTitle,
 	artist: 'Integration Test',
@@ -771,16 +772,22 @@ Expected: PASS.
 
 - [ ] **Step 9: Validate the affected Drive E2E setup path**
 
-Run the existing desktop E2E command(s) that own these two helpers in the repository's normal E2E environment. At minimum, the Drive upload flow must reach linked Song Details using the new cache seed; the crash-recovery script must restore the same linked song after reload.
-
-Use the existing package scripts rather than introducing a new runner:
+Run the existing desktop E2E command that owns both helpers:
 
 ```bash
 cd packages/e2e-desktop
 bun run e2e
 ```
 
-If the full desktop E2E environment is unavailable locally, run the repository's existing typecheck/build validation for `packages/e2e-desktop` and record the environment limitation in the implementation PR; do not add compatibility code to make the old seed work.
+This runs the normal WDIO flow plus relaunch and Drive crash-recovery scripts. The Drive upload flow must reach linked Song Details using `dtx_linkage_cache_v2`, and crash recovery must restore the same linked song after reload.
+
+If the full native E2E environment is unavailable locally, still run the package's existing TypeScript check:
+
+```bash
+bun run check
+```
+
+Record the environment limitation in the implementation PR; do not add compatibility code to make an old seed work.
 
 - [ ] **Step 10: Commit**
 
@@ -911,11 +918,12 @@ Expected live consumers in `packages/dtx-web/src/app.d.ts` and `packages/dtx-web
 cd packages/common && bun run test && bun run check
 cd ../dtx-web && bun run test && bun run check
 cd ../dtx-desktop && bun run test && bun run typecheck
+cd ../e2e-desktop && bun run check
 cd ../..
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml api_tests
 ```
 
-Then validate `packages/e2e-desktop` with its existing test/typecheck/E2E path available in the implementation environment.
+Run `bun run e2e` from `packages/e2e-desktop` when the native E2E environment is available.
 
 Expected: all HPA-614-focused tests changed above pass. Record unrelated pre-existing failures separately rather than weakening the migration.
 
@@ -936,7 +944,7 @@ Verify:
 - no unrelated UI refactor;
 - no deletion of the live Supabase auth `Database` type;
 - `ChartDetail` still uses the existing `dayjs` date fallback;
-- general simfile update payloads are explicit picks and native strips `googleDriveFileId`;
+- general simfile update payloads are explicit picks and native strips `googleDriveFileId` inline;
 - cache changes are only the three explicit v2 keys plus matching E2E seed updates.
 
 - [ ] **Step 10: Commit only if cleanup produced changes**
@@ -955,9 +963,9 @@ Do not create an empty commit.
 - `@dtx/common` exposes `SimfileModel`, `SimfileDtxFile`, and `SimfileAssetFile` for application use; D1 row/aggregate types are server-only.
 - `ChartDetail` accepts `Partial<SimfileModel>`, has no D1 import, and retains its current `dayjs` publish-date fallback.
 - Web GraphQL code adapts generated results directly into camelCase `SimfileModel`; `LegacySimfile` and the chart-page cast are gone.
-- Desktop Rust emits camelCase current-model JSON. The general update mapper is gone, but a narrow native omission still prevents `googleDriveFileId` from entering `UpdateSimfileInput`.
+- Desktop Rust emits camelCase current-model JSON. The general update mapper is gone, while `update_simfile_record_impl` still removes `googleDriveFileId` inline before `UpdateSimfileInput`.
 - Desktop stores/services/components — including auto-linking, `App.svelte`, `CommandPalette`, and workspace fixtures — use `SimfileModel`.
-- Desktop simfile/linkage caches use only the three v2 keys; both desktop-E2E linkage seeds use `dtx_linkage_cache_v2` with camelCase current-model data.
+- Desktop simfile/linkage caches use only the three v2 keys; both desktop-E2E linkage seeds use `dtx_linkage_cache_v2` with camelCase current-model data and no new common-package dependency.
 - `SimfileWithDtx` is deleted only after consumers migrate; no renderer imports persistence types from `@dtx/common/server`.
 - Score-link persistence remains a small string-id map with explicit conversion at that boundary.
 - `PreviewSimfile` remains a purpose-specific web projection.

--- a/docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md
+++ b/docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md
@@ -1,0 +1,254 @@
+# HPA-614 Current Simfile Model Design
+
+## Summary
+
+Replace the Supabase/REST-era simfile compatibility shapes that still leak through shared UI, web, and desktop code with one current camelCase `SimfileModel` owned by `@dtx/common`.
+
+D1 row types remain snake_case at the server persistence boundary. The web GraphQL client and the desktop Rust GraphQL boundary each perform one explicit conversion into the current model. Shared components, web application code, desktop renderer stores/services, and local caches use only the current model.
+
+This is an intentional breaking internal migration. There is no compatibility reader for old renderer payloads or localStorage entries.
+
+Linear: HPA-614
+
+## Why this is the next slice
+
+HPA-614 is currently unblocked and is the dependency root for HPA-615, HPA-616, and HPA-617. Finishing the model boundary first gives the generated Tauri contract work in HPA-615 one stable renderer-facing contract to generate toward, and avoids extracting/refactoring compatibility code in HPA-616/617 that is about to be deleted.
+
+## Current problem
+
+The same simfile currently has several overlapping representations:
+
+- `SimfileRow` / `DtxFileRow`: D1 persistence rows with snake_case fields and SQLite boolean representation.
+- `SimfileWithDtxFiles`: a server/API-facing D1-derived aggregate.
+- `SimfileWithDtx`: a desktop-compatible shape explicitly modeled after the old Supabase contract.
+- `LegacySimfile`: a web-only GraphQL adapter that converts current GraphQL camelCase fields back into snake_case.
+- Rust `renderer_simfile_from_graphql`: another adapter that converts current GraphQL camelCase fields back into the same old renderer snake_case contract.
+- Shared `ChartDetail.svelte`: imports the D1-derived type and therefore requires snake_case fields.
+
+This creates avoidable round trips. For example, GraphQL returns `isPublished`, web maps it to `is_published`, and shared UI reads `is_published`. Desktop does the same in Rust, then maps `display_id` back to `displayId` before sending an update to GraphQL.
+
+The web chart-detail page also has to cast its `LegacySimfile` into `SimfileWithDtxFiles` to satisfy `ChartDetail`, which is evidence that the shared boundary is not describing the actual application model.
+
+## Approaches considered
+
+### A. Introduce only `ChartDetailModel`
+
+Change `ChartDetail` to accept a small camelCase view model while leaving `LegacySimfile`, `SimfileWithDtx`, desktop caches, and native renderer payloads unchanged.
+
+This is the smallest immediate diff, but it adds another adapter without removing the obsolete contracts. It would leave HPA-615 and HPA-616 working around the same migration residue. Rejected.
+
+### B. One shared current model with explicit edge adapters
+
+Add one neutral `SimfileModel` in `@dtx/common`, use it throughout shared/web/desktop application code, and keep translation only where data crosses a real boundary:
+
+- D1 persistence stays snake_case on the server.
+- Web generated GraphQL results are normalized once in `packages/dtx-web/src/lib/api/chart.ts`.
+- Desktop GraphQL results are normalized once in Rust before crossing Tauri IPC.
+- Desktop renderer update payloads use camelCase directly.
+- Old localStorage cache keys are replaced with versioned keys.
+
+This removes compatibility shapes without adding a mapper framework or pulling HPA-615 forward. **Chosen.**
+
+### C. Generate the Tauri contracts in this ticket
+
+Replace Rust `serde_json::Value` command envelopes and the renderer's handwritten result types at the same time.
+
+That is the eventual direction, but it is HPA-615's scope and would combine two independently reviewable migrations. It also makes this ticket depend on production `ts-rs`/codegen machinery before the renderer contract is stable. Rejected.
+
+## Current model
+
+Create `packages/common/src/lib/types/simfile.ts`:
+
+```ts
+export interface SimfileDtxFile {
+	id?: number;
+	label: string;
+	level: number;
+}
+
+export interface SimfileAssetFile {
+	key: string;
+	size: number;
+	uploaded: string;
+}
+
+export interface SimfileModel {
+	id: number;
+	title: string;
+	artist: string;
+	bpm: number;
+	displayId: number | null;
+	userId: string | null;
+	googleDriveFileId: string | null;
+	isPublished: boolean;
+	downloadUrl: string | null;
+	previewUrl: string | null;
+	videoPreviewUrl: string | null;
+	publishDate: string | null;
+	createdAt: string | null;
+	updatedAt: string | null;
+	dtxFiles: SimfileDtxFile[];
+	files?: SimfileAssetFile[];
+	hasUploadedFiles?: boolean;
+}
+```
+
+`SimfileDtxFile.id` stays optional because list/detail projections do not all need or currently request the chart id. Code that uploads scores already has a narrower requirement for real chart ids and must continue to enforce it at that feature boundary.
+
+Nullable metadata uses `null`, not empty-string sentinels. The transport adapters are responsible for converting omitted projection fields to `null` or `[]` so application consumers see a stable shape.
+
+`ChartDetail` accepts `Partial<SimfileModel> | null` because the desktop also uses it to render an unlinked local song before a cloud simfile id and remote metadata exist. This remains one named application model; `Partial` only represents an incomplete local draft, not a second compatibility contract.
+
+## Boundary ownership
+
+### D1 / API server
+
+`SimfileRow`, `DtxFileRow`, `SimfileWithDtxFiles`, and D1 conversion helpers remain in the server/D1 area for now. They may stay exported from `@dtx/common/server` until HPA-617 moves API-only infrastructure into `dtx-api`.
+
+They stop being exported from the main `@dtx/common` browser/application barrel. Shared UI and renderer code must not import them.
+
+Delete `SimfileWithDtx` after its renderer consumers move; its sole purpose is the old desktop-compatible contract.
+
+No D1 migration or GraphQL schema change is required.
+
+### Web GraphQL boundary
+
+Replace `LegacySimfile` and `adaptSimfile` with a single `toSimfileModel` adapter in `packages/dtx-web/src/lib/api/chart.ts`.
+
+The adapter:
+
+- converts the GraphQL `ID` string to a finite numeric `id` exactly as today;
+- preserves GraphQL camelCase names instead of converting back to snake_case;
+- converts absent nullable projection fields to `null`;
+- maps `dtxFiles` to `dtxFiles` without inventing D1-only fields;
+- preserves optional `files` and `hasUploadedFiles` for detail/list consumers.
+
+`listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. `updateSimfileDriveFile` returns `{ id, googleDriveFileId, downloadUrl }` rather than another snake_case mini-contract.
+
+Web chart list/detail components and helpers move mechanically from names such as `is_published`, `display_id`, `download_url`, `dtx_files`, and `has_uploaded_files` to the camelCase model.
+
+### Shared ChartDetail
+
+`ChartDetail.svelte` imports only `SimfileModel` from the neutral shared type module. Its props and internal bindings use:
+
+- `displayId`
+- `publishDate`
+- `isPublished`
+- `downloadUrl`
+- `videoPreviewUrl`
+- `dtxFiles`
+
+The component's emitted save event already uses camelCase names, so this removes the current impedance mismatch instead of changing its outward event contract.
+
+### Desktop native boundary
+
+Keep `serde_json::Value` command plumbing until HPA-615, but stop using it to preserve an obsolete renderer schema.
+
+Rename/refocus `renderer_simfile_from_graphql` to `simfile_model_from_graphql`. It should:
+
+- keep the current numeric-id validation;
+- return the same camelCase fields as `SimfileModel`;
+- normalize nested `dtxFiles` without `simfile_id`;
+- stop synthesizing compatibility-only fields for old cached records.
+
+`update_simfile_record_impl` sends the renderer's camelCase update object directly as the GraphQL input. Delete `update_input_from_renderer`; the renderer no longer sends `display_id`, `publish_date`, `is_published`, `download_url`, or `video_preview_url`.
+
+`search_cloud_songs_impl` also returns `isPublished` so the search result does not retain a separate snake_case mini-contract.
+
+### Desktop renderer
+
+Migrate the renderer's cloud-simfile ownership to `SimfileModel`:
+
+- `simFileStore`
+- `simFileService`
+- `workspaceStore`
+- `linkageCacheService`
+- `SongDetails`
+- `CloudSongDetail`
+- `SimFileList`
+- `CloudSongAutocomplete`
+- directly affected tests/services
+
+Delete `normalizeSimfile` and the old positional/cache compatibility comments once all current native responses already match `SimfileModel`.
+
+Local draft data assembled in `SongDetails` should use camelCase and `Partial<SimfileModel>` directly. Update payloads to Rust use the GraphQL-style input names (`displayId`, `publishDate`, `isPublished`, `downloadUrl`, `videoPreviewUrl`) so native no longer has to translate them.
+
+## Cache invalidation
+
+Do not parse or migrate the previous cached simfile shape.
+
+Change the renderer cache keys to:
+
+- `simfiles_cache_v2`
+- `simfiles_cache_timestamp_v2`
+- `dtx_linkage_cache_v2`
+
+The old keys are simply no longer read. A user with stale data gets a normal refetch/relink-cache rebuild through existing behavior. No cache-version registry or migration framework is added.
+
+Tests must prove that current reads/writes use only the `*_v2` keys.
+
+## Supabase auth type and `gen-types`
+
+HPA-614's cleanup clause is conditional on the type having no current consumer. That condition is not met on current `main`:
+
+- `packages/dtx-web/src/app.d.ts` uses `SupabaseClient<Database>`.
+- `packages/dtx-web/src/hooks.server.ts` creates `createServerClient<Database>`.
+
+Therefore this ticket does **not** delete `packages/common/src/lib/types/supabase.types.ts`, the `Database` export, or the root `gen-types` script. They are type-only auth plumbing, not the application simfile contract. Removing or replacing them belongs with later migration cleanup once their consumers are changed deliberately.
+
+## Error and compatibility behavior
+
+- Invalid top-level GraphQL simfile ids continue to fail immediately rather than leaking `NaN` into application state.
+- Existing corrupt-cache handling remains: parse failures clear the current cache and refetch.
+- Old cache entries are unsupported by design and ignored through the key version bump.
+- No aliases, deprecated snake_case properties, proxy accessors, runtime schema library, or generic mapper abstraction are introduced.
+- No backwards compatibility is provided for old internal renderer payloads.
+
+## Testing strategy
+
+### Common
+
+- Add direct type/model fixtures using camelCase.
+- Update `ChartDetail.test.ts` to render camelCase fields and `dtxFiles`.
+- Keep D1 conversion tests under the server/persistence boundary.
+
+### Web
+
+- Update `chart.test.ts` to assert the GraphQL adapter returns camelCase `SimfileModel`, nullable fields, nested levels, assets, and numeric-id validation.
+- Update chart-list helper/component tests to assert `isPublished` / `hasUploadedFiles` behavior.
+- Update the chart-detail page test to prove no cast/legacy type is required.
+
+### Desktop renderer
+
+- Update store/service/component fixtures to `SimfileModel`.
+- Add/adjust cache tests for the new `*_v2` keys and confirm old keys are ignored.
+- Preserve action concurrency, stale-selection, Drive upload, and link behavior while changing field names only.
+
+### Rust
+
+- Update API tests to assert camelCase output from `simfile_model_from_graphql` and cloud search.
+- Update create/fetch/update tests to assert Tauri envelopes contain the current model.
+- Add an update test proving camelCase renderer input is sent to GraphQL unchanged.
+
+## Non-goals
+
+- No GraphQL schema or D1 schema changes.
+- No database migration.
+- No production TypeScript generation from Rust; that remains HPA-615.
+- No extraction of `api.rs` or `SongDetails`; that remains HPA-616.
+- No broad `@dtx/common/server` ownership cleanup; that remains HPA-617.
+- No UI redesign or behavioral change.
+- No generic DTO, mapper, repository, DI, validation, or cache-migration framework.
+
+## Completion criteria
+
+HPA-614 is complete when:
+
+1. `SimfileModel` is the only simfile application model imported by shared UI, web application code, and desktop renderer code.
+2. `ChartDetail` no longer imports D1 types and reads only camelCase fields.
+3. `LegacySimfile` and `SimfileWithDtx` are deleted.
+4. The web detail-page cast is deleted.
+5. Rust no longer converts current GraphQL payloads into the old snake_case renderer shape, and renderer updates no longer require `update_input_from_renderer`.
+6. Browser/application code contains no compatibility-only snake_case simfile fields; snake_case remains confined to D1/server persistence code and the separately retained Supabase auth `Database` type definition.
+7. Desktop simfile/linkage caches use the new versioned keys and do not read old entries.
+8. Common, web, desktop renderer, and Rust API tests/type checks covering this seam pass.

--- a/docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md
+++ b/docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md
@@ -22,14 +22,13 @@ The same simfile currently has several overlapping representations:
 - `SimfileWithDtxFiles`: a server/API-facing D1-derived aggregate.
 - `SimfileWithDtx`: a desktop-compatible shape explicitly modeled after the old Supabase contract.
 - `LegacySimfile`: a web-only GraphQL adapter that converts current GraphQL camelCase fields back into snake_case.
-- Rust `renderer_simfile_from_graphql`: another adapter that converts current GraphQL camelCase fields back into the same old renderer snake_case contract.
-- Shared `ChartDetail.svelte`: imports the D1-derived type and therefore requires snake_case fields.
-- Desktop renderer stores/services and utility consumers still import `SimfileWithDtx`, including `simFileStore`, `workspaceStore`, `simFileService`, `linkageCacheService`, `linkingService`, `App.svelte`, `SongDetails`, `CloudSongDetail`, `SimFileList`, and `CommandPalette`.
-- Desktop E2E helpers seed the old linkage-cache key with the old snake_case shape, so a cache-key bump without updating them would make Drive tests open an unlinked song.
+- Rust `renderer_simfile_from_graphql`: another adapter that converts current GraphQL camelCase fields back into the old renderer contract.
+- Shared `ChartDetail.svelte`: consumes that compatibility shape rather than a neutral application model.
+- Desktop caches and E2E linkage seeds persist the same obsolete snake_case renderer shape.
 
-This creates avoidable round trips. GraphQL returns `isPublished`, web maps it to `is_published`, and shared UI reads `is_published`. Desktop does the same in Rust, then maps `display_id` back to `displayId` before sending an update to GraphQL.
+This creates avoidable round trips. GraphQL returns `isPublished`, web maps it to `is_published`, and shared UI reads `is_published`. Desktop does the same in Rust, then maps `display_id` back to `displayId` before an update is sent to GraphQL.
 
-The web chart-detail page also casts its `LegacySimfile` into `SimfileWithDtxFiles` to satisfy `ChartDetail`, which is evidence that the shared boundary does not describe the application model.
+The web chart-detail page also casts one representation into another to satisfy `ChartDetail`, which is direct evidence that the shared boundary is not describing the actual application model.
 
 ## Approaches considered
 
@@ -37,7 +36,7 @@ The web chart-detail page also casts its `LegacySimfile` into `SimfileWithDtxFil
 
 Change `ChartDetail` to accept a small camelCase view model while leaving `LegacySimfile`, `SimfileWithDtx`, desktop caches, and native renderer payloads unchanged.
 
-This is the smallest immediate diff, but it adds another adapter without removing the obsolete contracts. It would leave HPA-615 and HPA-616 working around the same migration residue. Rejected.
+This is the smallest immediate diff, but it adds another adapter without removing the obsolete contracts. HPA-615 and HPA-616 would still inherit the same migration residue. Rejected.
 
 ### B. One shared current model with explicit edge adapters
 
@@ -46,17 +45,17 @@ Add one neutral `SimfileModel` in `@dtx/common`, use it throughout shared/web/de
 - D1 persistence stays snake_case on the server.
 - Web generated GraphQL results are normalized once in `packages/dtx-web/src/lib/api/chart.ts`.
 - Desktop GraphQL results are normalized once in Rust before crossing Tauri IPC.
-- Desktop renderer update payloads use explicit camelCase GraphQL input fields.
+- Desktop renderer update payloads use GraphQL/current-model names directly.
 - Old localStorage cache keys are replaced with versioned keys.
-- Desktop E2E cache seeds move to the same versioned key and camelCase shape as the renderer.
+- Desktop E2E linkage seeds use the same current cache key and current-model field names.
 
 This removes compatibility shapes without adding a mapper framework or pulling HPA-615 forward. **Chosen.**
 
 ### C. Generate the Tauri contracts in this ticket
 
-Replace Rust `serde_json::Value` command envelopes and the renderer's handwritten result types at the same time.
+Replace Rust `serde_json::Value` command envelopes and renderer handwritten result types at the same time.
 
-That is the eventual direction, but it is HPA-615's scope and would combine two independently reviewable migrations. It also makes this ticket depend on production Rust-to-TypeScript generation before the renderer contract is stable. Rejected.
+That is the eventual direction, but it is HPA-615 scope and combines two independently reviewable migrations. Rejected.
 
 ## Current model
 
@@ -87,43 +86,36 @@ export interface SimfileModel {
 	downloadUrl: string | null;
 	previewUrl: string | null;
 	videoPreviewUrl: string | null;
-	publishDate: string | null;
-	createdAt: string | null;
-	updatedAt: string | null;
+	publishDate: string;
+	createdAt: string;
+	updatedAt: string;
 	dtxFiles: SimfileDtxFile[];
 	files?: SimfileAssetFile[];
 	hasUploadedFiles?: boolean;
 }
 ```
 
-`SimfileDtxFile.id` stays optional because the web `SimfileFull`/list projections do not all request chart ids, while desktop already does. Code that uploads scores has a narrower requirement for real chart ids and continues to enforce it at that feature boundary.
+The nullability follows the current GraphQL schema rather than transport omissions:
 
-Nullable metadata uses `null`, not empty-string sentinels. Transport adapters convert omitted projection fields to `null` or `[]` so application consumers see a stable shape.
+- `publishDate`, `createdAt`, `updatedAt`, and `isPublished` are non-null GraphQL fields.
+- The web `SimfileFull` fragment already selects all three timestamps.
+- The desktop full fragment already selects all three timestamps.
+- The desktop list query currently omits only `createdAt` / `updatedAt`; HPA-614 adds those two selections so a full `SimfileModel` has one timestamp convention instead of treating "not requested" as `null`.
+- `files` / `hasUploadedFiles` remain optional because they are genuinely projection-specific extras rather than required base simfile metadata.
 
-`ChartDetail` accepts `Partial<SimfileModel> | null` because the desktop also renders an unlinked local song before a cloud simfile id and remote metadata exist. `Partial` represents an incomplete local draft, not a second compatibility contract.
+`SimfileDtxFile.id` remains optional because the web `SimfileFull` projection does not request it and the shared detail/list UI does not require it. Score upload chart ids come through dedicated score/chart boundaries rather than relying on this optional UI value.
 
-## Migration ordering
-
-The application model is introduced before the old application-barrel exports are removed.
-
-Task ordering must avoid a workspace-wide transient compile break:
-
-1. add/export `SimfileModel` and migrate `ChartDetail` while the old D1/compatibility exports remain temporarily available;
-2. migrate web and native transport boundaries;
-3. migrate every renderer and desktop-E2E consumer;
-4. only then delete `SimfileWithDtx`, remove D1/compatibility exports from the main `@dtx/common` barrel, and update barrel tests.
-
-Renderer code must never be "fixed" by importing persistence types from `@dtx/common/server`.
+`ChartDetail` accepts `Partial<SimfileModel> | null` because desktop also uses it to render an unlinked local draft before remote metadata exists. This is the existing behavior with `Partial<SimfileWithDtx>`, not a new compatibility representation.
 
 ## Boundary ownership
 
 ### D1 / API server
 
-`SimfileRow`, `DtxFileRow`, `SimfileWithDtxFiles`, and D1 conversion helpers remain in the server/D1 area. They may stay exported from `@dtx/common/server` until HPA-617 moves API-only infrastructure into `dtx-api`.
+`SimfileRow`, `DtxFileRow`, `SimfileWithDtxFiles`, and D1 conversion helpers remain in the server/D1 area. They may stay exported from `@dtx/common/server` until HPA-617 moves API-only infrastructure deliberately.
 
-They stop being exported from the main `@dtx/common` application barrel only after all application consumers have migrated. `packages/common/src/lib/constants.test.ts` is updated in that final cleanup step because it currently asserts `toSimfileWithDtx` on the main barrel.
+Delete `SimfileWithDtx` only after every renderer/application consumer has moved. Its purpose is the old desktop-compatible contract.
 
-Delete `SimfileWithDtx` after its renderer consumers move; its sole purpose is the old desktop-compatible contract.
+The main browser/application barrel temporarily keeps its existing D1/compatibility exports while Tasks 1–4 migrate consumers. Task 5 removes those exports only after the load-bearing repository grep proves no application consumer remains. Renderer code must never be redirected to `@dtx/common/server` as an intermediate fix.
 
 No D1 migration or GraphQL schema change is required.
 
@@ -133,25 +125,21 @@ Replace `LegacySimfile` and `adaptSimfile` with one `toSimfileModel` adapter in 
 
 The adapter:
 
-- converts GraphQL `ID` strings to finite numeric ids exactly as today;
-- preserves GraphQL camelCase names instead of converting back to snake_case;
-- converts absent nullable projection fields to `null`;
+- converts GraphQL `ID` to the numeric application id exactly as today;
+- preserves current camelCase names instead of converting back to snake_case;
+- preserves schema nullability (`publishDate` / timestamps remain required strings);
 - maps `dtxFiles` without inventing D1-only fields;
-- preserves optional `files` and `hasUploadedFiles` for detail/list consumers.
+- preserves optional `files` and `hasUploadedFiles` projection data.
 
-`listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. `updateSimfileDriveFile` returns `{ id, googleDriveFileId, downloadUrl }` rather than another snake_case mini-contract.
+`listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. `updateSimfileDriveFile` returns `{ id, googleDriveFileId, downloadUrl }`.
 
-Web chart list/detail components and helpers move mechanically from names such as `is_published`, `display_id`, `download_url`, `dtx_files`, and `has_uploaded_files` to the camelCase model.
+`PreviewSimfile` stays separate. Its query deliberately carries `fileUrl` nullability that should not be added to the base application model.
 
-`PreviewSimfile` stays separate. It is a purpose-specific preview projection, not an old compatibility shape.
+### Shared `ChartDetail`
 
-### Shared ChartDetail
+`ChartDetail.svelte` imports only `SimfileModel`. Its bindings use `displayId`, `publishDate`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, and `dtxFiles`.
 
-`ChartDetail.svelte` imports only `SimfileModel` from the neutral shared type module. Its props and internal bindings use camelCase fields.
-
-The component's emitted save event already uses camelCase names, so this removes the impedance mismatch instead of changing its event contract.
-
-The migration does not change unrelated behavior. In particular, keep the existing `dayjs().format('YYYY-MM-DD')` fallback for `publishDate`; do not replace it with `new Date().toISOString()` during the field rename.
+The existing `dayjs().format('YYYY-MM-DD')` local-draft fallback stays unchanged. Replacing it with an ISO-UTC expression would be an unrelated timezone-sensitive behavior change.
 
 ### Desktop native boundary
 
@@ -159,24 +147,38 @@ Keep `serde_json::Value` command plumbing until HPA-615, but stop using it to pr
 
 Rename/refocus `renderer_simfile_from_graphql` to `simfile_model_from_graphql`. It should:
 
-- keep current numeric-id validation;
+- keep numeric-id validation for full simfiles;
 - return the same camelCase fields as `SimfileModel`;
 - normalize nested `dtxFiles` without `simfile_id`;
-- stop synthesizing compatibility-only fields for old cached records.
+- stop synthesizing positional chart ids for old cached records;
+- include `createdAt` / `updatedAt` in `LIST_SIMFILES_QUERY` so full model timestamps are always present.
 
-Delete the general snake_case-to-camelCase `update_input_from_renderer` mapper once the renderer sends camelCase update payloads, but preserve its real ownership rule: general simfile updates must not carry `googleDriveFileId`.
+General simfile updates need one native ownership rule even after the snake_case mapper disappears: `googleDriveFileId` is owned by the dedicated Drive mutation and must never enter `UpdateSimfileInput`. `update_simfile_record_impl` therefore removes only `googleDriveFileId` inline before issuing the GraphQL mutation. It does not replace `update_input_from_renderer` with another generic mapper or allowlist.
 
-`update_simfile_record_impl` therefore performs only the narrow Drive-id omission before sending the object to `UpdateSimfileInput`. It does not become a generic mapper or accept a spread `SimfileModel` as an update payload.
+Renderer update payloads are explicit picks, never `{ ...simfile }`.
 
-Renderer update objects are explicit picks of fields owned by `UpdateSimfileInput`, for example `displayId`, `publishDate`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, `bpm`, `artist`, and `title`. They are never built as `{ ...simfile }`.
+### Desktop score projection
 
-Keep/update the native test that proves `googleDriveFileId` is excluded from the general update mutation.
+The score page keeps its narrow `CloudSong` projection separate from the full current model, just as `PreviewSimfile` remains separate on web.
 
-`search_cloud_songs_impl` returns `isPublished` so search results do not retain a separate snake_case mini-contract.
+Keep:
+
+```ts
+interface CloudSong {
+	id: string;
+	title: string;
+	artist: string;
+	isPublished: boolean;
+}
+```
+
+Only `is_published` becomes `isPublished`. Keeping `id` as a string matches the persisted `Record<string, string>` score-link map and `desktopHost.fetchCloudSongCharts(cloudSongId: string)`, avoiding conversions that do not advance HPA-614.
+
+A full `fetch_cloud_song` result used by `SongDetails` still becomes `SimfileModel` with numeric `id`; the score-page search/link projection is a smaller purpose-specific boundary.
 
 ### Desktop renderer
 
-Migrate all current `SimfileWithDtx` consumers to `SimfileModel`, including:
+Migrate all full-cloud-simfile consumers to `SimfileModel`, including:
 
 - `simFileStore`
 - `simFileService`
@@ -184,29 +186,32 @@ Migrate all current `SimfileWithDtx` consumers to `SimfileModel`, including:
 - `linkageCacheService`
 - `linkingService`
 - `App.svelte`
+- `CommandPalette.svelte`
 - `SongDetails`
 - `CloudSongDetail`
 - `SimFileList`
-- `CommandPalette`
-- score-page cloud projections that currently reuse the old contract
-- directly affected tests such as `linkingService.test.ts`, `CommandPalette.test.ts`, and `Workspace.test.ts`
+- directly affected tests/fixtures
 
-Delete `normalizeSimfile` and old positional/cache compatibility comments once native responses already match `SimfileModel`.
+Delete `normalizeSimfile` and old positional/cache compatibility comments once current native responses already match `SimfileModel`.
 
-Local draft data assembled in `SongDetails` uses camelCase and `Partial<SimfileModel>` directly. Update payloads to Rust are explicit camelCase GraphQL-input picks, not application-model spreads.
+Local draft data assembled in `SongDetails` uses camelCase and `Partial<SimfileModel>`. Update payloads are explicit camelCase picks and continue to omit Drive-owned metadata.
 
-The persisted score-link map remains `Record<string, string>`. It is a separate persistence boundary and keeps explicit numeric↔string conversion rather than forcing `SimfileModel.id` back to a string.
+## Cross-language contract fixture
 
-### Desktop E2E fixtures
+The weakest seam today is that Rust and renderer tests hand-write the expected simfile shape independently. Both can drift while still passing their own suites.
 
-Two desktop-E2E helpers currently seed `dtx_linkage_cache` with the old snake_case cloud-song shape:
+HPA-614 adds one repository fixture:
 
-- `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
-- `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
+`packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json`
 
-Both must seed `dtx_linkage_cache_v2` and a camelCase `SimfileModel`-compatible `cloudSongData`, including `isPublished`, `publishDate`, `displayId`, `downloadUrl`, `googleDriveFileId`, `previewUrl`, `videoPreviewUrl`, and `dtxFiles`.
+It contains one complete base `SimfileModel` payload with required fields and nested `dtxFiles`.
 
-This is part of the migration, not compatibility support. Without it, the renderer correctly ignores the old key and the Drive E2E setup no longer links the song.
+- Rust API tests deserialize the fixture and assert `simfile_model_from_graphql` produces it exactly.
+- A desktop Vitest service/cache test reads the same JSON and uses it as native mock output, proving the renderer behavior consumes the same field names.
+
+This is a behavioral cross-language fixture, not a generated type system. Desktop Vitest files are excluded from `tsconfig.web.json`, so this fixture must not be described as TypeScript compile-time enforcement. No `resolveJsonModule` setting is required: the Vitest test can read the JSON with Node `fs`/`URL` rather than changing production TypeScript config for a test-only import.
+
+HPA-615 remains responsible for generated Rust→TypeScript contracts.
 
 ## Cache invalidation
 
@@ -218,83 +223,113 @@ Change renderer cache keys to:
 - `simfiles_cache_timestamp_v2`
 - `dtx_linkage_cache_v2`
 
-The old keys are no longer read. A user with stale data gets a normal refetch/relink-cache rebuild through existing behavior. No cache-version registry or migration framework is added.
+Old keys are simply no longer read. Desktop E2E helpers that seed linkage state must use `dtx_linkage_cache_v2` and the same camelCase current-model shape; otherwise they silently stop opening a linked song after the key bump.
 
-Tests prove current reads/writes use only the `*_v2` keys and desktop-E2E seeds use the same current key/shape.
+No cache-version registry or migration framework is added.
+
+Update `CLAUDE.md` cache-clearing instructions in the same migration so the repository documentation points at the active v2 keys.
+
+## Verification reality
+
+Desktop verification has three distinct layers and the plan must not conflate them:
+
+1. `bun run typecheck` / `svelte-check --tsconfig ./tsconfig.web.json` checks production renderer source, but the config has `strict: false` and explicitly excludes `*.test.ts` / `*.spec.ts`.
+2. Vitest executes renderer tests but does not type-check their TypeScript annotations.
+3. Repository `rg` gates are therefore load-bearing for proving `LegacySimfile` / `SimfileWithDtx` type-only imports and snake_case test fixtures are actually gone.
+
+Desktop E2E is the only full native→renderer seam proof. The workflow skips draft pull requests. Tasks 3 and 4 must land in the same implementation PR, and that PR must be marked ready for review after both tasks are complete so the desktop-E2E workflow runs before merge. A temporary broken state between commits is acceptable inside that one PR; splitting the boundary and consumer migrations across mergeable PRs is not.
+
+The current planning PR may remain draft because it changes docs only. The non-draft requirement applies to the later implementation PR.
+
+## Grep policy
+
+Completion checks should detect actual compatibility syntax rather than treating every historical word in a comment as a bug.
+
+`packages/dtx-web/src/lib/utils.ts` currently has an application helper parameter named `dtx_files`; HPA-614 renames that parameter to `dtxFiles`.
+
+Two existing documentation comments intentionally refer to the real D1 `dtx_files` column and may remain:
+
+- `packages/dtx-desktop/src/renderer/src/lib/scoreMatching.ts`
+- `packages/dtx-web/src/routes/preview/[id]/+page.svelte`
+
+The load-bearing grep therefore checks property/object-key syntax for snake_case application fields and separately performs a broad informational grep whose only allowed active matches are true persistence/documentation references such as those two files.
 
 ## Supabase auth type and `gen-types`
 
-HPA-614's cleanup clause is conditional on the type having no current consumer. That condition is not met on current `main`:
+HPA-614's cleanup clause is conditional on the type having no current consumer. That condition is not met:
 
 - `packages/dtx-web/src/app.d.ts` uses `SupabaseClient<Database>`.
 - `packages/dtx-web/src/hooks.server.ts` creates `createServerClient<Database>`.
 
-Therefore this ticket does **not** delete `packages/common/src/lib/types/supabase.types.ts`, the `Database` export, or the root `gen-types` script. They are type-only auth plumbing, not the application simfile contract.
+Therefore HPA-614 does **not** delete `packages/common/src/lib/types/supabase.types.ts`, the `Database` export, or root `gen-types`.
 
 ## Error and compatibility behavior
 
-- Invalid top-level GraphQL simfile ids continue to fail immediately rather than leaking `NaN` into application state.
-- Existing corrupt-cache handling remains: parse failures clear the current cache and refetch.
-- Old cache entries are unsupported and ignored through the key version bump.
-- General simfile updates cannot send `googleDriveFileId`; Drive binding remains owned by its dedicated mutation.
+- Invalid full GraphQL simfile ids continue to fail immediately rather than leaking `NaN` into application state.
+- Existing corrupt-cache handling remains for malformed current entries.
+- Old cache entries are unsupported by design and ignored through the key version bump.
 - No aliases, deprecated snake_case properties, proxy accessors, runtime schema library, or generic mapper abstraction are introduced.
 - No backwards compatibility is provided for old internal renderer payloads.
+- General updates cannot mutate `googleDriveFileId`.
 
 ## Testing strategy
 
 ### Common
 
-- Add camelCase model fixtures.
-- Update `ChartDetail.test.ts` to render camelCase fields and `dtxFiles` while retaining existing date-default behavior.
-- Keep D1 conversion tests under the persistence boundary.
-- Update `constants.test.ts` only when final application-barrel cleanup happens.
+- Add the camelCase model.
+- Update `ChartDetail.test.ts` while retaining its current date fallback behavior.
+- Keep legacy application-barrel exports until Task 5 so intermediate commits remain compile-safe.
 
 ### Web
 
-- Update `chart.test.ts` to assert the GraphQL adapter returns camelCase `SimfileModel`, nullable fields, nested levels, assets, and numeric-id validation.
-- Update chart-list helper/component tests to assert `isPublished` / `hasUploadedFiles` behavior.
-- Update the chart-detail page test to prove no cast/legacy type is required.
-
-### Desktop renderer
-
-- Update store/service/component fixtures to `SimfileModel`.
-- Add/adjust cache tests for `*_v2` keys and confirm old keys are ignored.
-- Run the direct consumer suites, including `linkingService.test.ts`, `CommandPalette.test.ts`, `Workspace.test.ts`, stores/services, `SongDetails`, list/detail, autocomplete, and scores.
-- Preserve action concurrency, stale-selection, auto-link, Drive upload, and score-link behavior while changing field names only.
-
-### Desktop E2E
-
-- Change both linkage-cache seed helpers to `dtx_linkage_cache_v2` + camelCase model data.
-- Keep the existing Google Drive upload/crash-recovery flows as regression coverage for restored linkage.
+- Update `chart.test.ts` to assert `toSimfileModel` returns required timestamps, nullable metadata, nested levels, assets, and numeric-id validation.
+- Update chart-list/component tests to camelCase.
+- Rename the application `formatLevelDisplay(dtx_files)` parameter to `dtxFiles`.
+- Update chart-detail page tests and delete the cast.
 
 ### Rust
 
-- Update API tests to assert camelCase output from `simfile_model_from_graphql` and cloud search.
-- Update create/fetch/update tests to assert Tauri envelopes contain the current model.
-- Add an update test proving camelCase renderer input reaches GraphQL unchanged except for the deliberate `googleDriveFileId` omission.
-- Preserve the Drive-id ownership test when removing the general mapper.
+- Add `createdAt` / `updatedAt` to `LIST_SIMFILES_QUERY`.
+- Assert full mapper output equals the shared `simfile_model.json` fixture.
+- Keep the Drive-id exclusion test at the real outgoing update request seam.
+- Keep score search ids as strings; rename only `isPublished` in that narrow projection.
+
+### Desktop renderer
+
+- Feed the same shared fixture into a Vitest native-mock/cache path.
+- Update every full simfile fixture to camelCase.
+- Add/adjust v2 cache tests and prove v1 keys are ignored.
+- Run focused tests plus production renderer typecheck, while explicitly relying on grep gates for excluded test files.
+
+### Desktop E2E
+
+- Update both linkage-cache seed helpers to v2/camelCase.
+- Run `packages/e2e-desktop` checks locally when available.
+- Mark the implementation PR ready and require the desktop-E2E CI job before merge.
 
 ## Non-goals
 
 - No GraphQL schema or D1 schema changes.
 - No database migration.
-- No production TypeScript generation from Rust; that remains HPA-615.
-- No extraction of `api.rs` or `SongDetails`; that remains HPA-616.
-- No broad `@dtx/common/server` ownership cleanup; that remains HPA-617.
-- No UI redesign or behavioral change.
+- No production TypeScript generation from Rust; HPA-615 owns that.
+- No extraction of `api.rs` or `SongDetails`; HPA-616 owns that.
+- No broad `@dtx/common/server` ownership cleanup; HPA-617 owns that.
+- No UI redesign or unrelated date behavior change.
 - No generic DTO, mapper, repository, DI, validation, or cache-migration framework.
 
 ## Completion criteria
 
 HPA-614 is complete when:
 
-1. `SimfileModel` is the only simfile application model imported by shared UI, web application code, desktop renderer code, and current desktop-E2E linkage fixtures.
-2. `ChartDetail` no longer imports D1 types, reads only camelCase fields, and keeps its existing date-default behavior.
-3. `LegacySimfile` and `SimfileWithDtx` are deleted after all consumers migrate.
-4. D1/compatibility exports are removed from the main `@dtx/common` application barrel only in final cleanup; `@dtx/common/server` keeps persistence ownership.
+1. `SimfileModel` is the authoritative full simfile application model imported by shared UI, web application code, and desktop renderer code.
+2. `publishDate`, `createdAt`, and `updatedAt` are required strings in that model, and all full-model native projections select them.
+3. `ChartDetail` no longer imports D1 types and retains its current local-date fallback.
+4. `LegacySimfile` and `SimfileWithDtx` are deleted after all consumers migrate.
 5. The web detail-page cast is deleted.
-6. Rust no longer converts current GraphQL payloads into the old snake_case renderer shape, and general renderer updates no longer require `update_input_from_renderer` while still excluding `googleDriveFileId`.
-7. Browser/application code contains no compatibility-only snake_case simfile fields; snake_case remains confined to D1/server persistence code and the separately retained Supabase auth `Database` type definition.
-8. Desktop simfile/linkage caches and desktop-E2E linkage seeds use the new versioned keys and do not read/seed old entries.
-9. The score-link `Record<string, string>` and `PreviewSimfile` remain purpose-specific boundaries rather than being folded into `SimfileModel`.
-10. Common, web, desktop renderer, Rust API, and affected desktop-E2E validation covering this seam pass.
+6. Rust no longer emits the old snake_case renderer simfile shape; general updates still strip `googleDriveFileId` before GraphQL.
+7. Desktop score `CloudSong` remains a narrow string-id projection with `isPublished` camelCase.
+8. Desktop simfile/linkage caches and both desktop-E2E linkage seeds use the v2 keys/current model.
+9. `CLAUDE.md` documents the v2 cache keys.
+10. Rust and Vitest consume the same `simfile_model.json` behavioral fixture.
+11. Load-bearing greps prove no active `LegacySimfile` / `SimfileWithDtx` imports or snake_case application object/property usage remain, including excluded test files and `packages/e2e-desktop`.
+12. Common, web, desktop renderer, Rust API, `e2e-desktop` static checks, and the non-draft desktop-E2E CI gate pass for the implementation PR.

--- a/docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md
+++ b/docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md
@@ -2,9 +2,9 @@
 
 ## Summary
 
-Replace the Supabase/REST-era simfile compatibility shapes that still leak through shared UI, web, and desktop code with one current camelCase `SimfileModel` owned by `@dtx/common`.
+Replace the Supabase/REST-era simfile compatibility shapes that still leak through shared UI, web, desktop renderer code, and desktop test fixtures with one current camelCase `SimfileModel` owned by `@dtx/common`.
 
-D1 row types remain snake_case at the server persistence boundary. The web GraphQL client and the desktop Rust GraphQL boundary each perform one explicit conversion into the current model. Shared components, web application code, desktop renderer stores/services, and local caches use only the current model.
+D1 row types remain snake_case at the server persistence boundary. The web GraphQL client and desktop Rust GraphQL boundary each perform one explicit conversion into the current model. Shared components, web application code, desktop renderer stores/services/components, and renderer caches use the current model.
 
 This is an intentional breaking internal migration. There is no compatibility reader for old renderer payloads or localStorage entries.
 
@@ -12,7 +12,7 @@ Linear: HPA-614
 
 ## Why this is the next slice
 
-HPA-614 is currently unblocked and is the dependency root for HPA-615, HPA-616, and HPA-617. Finishing the model boundary first gives the generated Tauri contract work in HPA-615 one stable renderer-facing contract to generate toward, and avoids extracting/refactoring compatibility code in HPA-616/617 that is about to be deleted.
+HPA-614 is unblocked and is the dependency root for HPA-615, HPA-616, and HPA-617. Finishing the model boundary first gives HPA-615 one stable renderer-facing contract to generate toward and avoids extracting compatibility code in HPA-616/617 that is about to be deleted.
 
 ## Current problem
 
@@ -24,10 +24,12 @@ The same simfile currently has several overlapping representations:
 - `LegacySimfile`: a web-only GraphQL adapter that converts current GraphQL camelCase fields back into snake_case.
 - Rust `renderer_simfile_from_graphql`: another adapter that converts current GraphQL camelCase fields back into the same old renderer snake_case contract.
 - Shared `ChartDetail.svelte`: imports the D1-derived type and therefore requires snake_case fields.
+- Desktop renderer stores/services and utility consumers still import `SimfileWithDtx`, including `simFileStore`, `workspaceStore`, `simFileService`, `linkageCacheService`, `linkingService`, `App.svelte`, `SongDetails`, `CloudSongDetail`, `SimFileList`, and `CommandPalette`.
+- Desktop E2E helpers seed the old linkage-cache key with the old snake_case shape, so a cache-key bump without updating them would make Drive tests open an unlinked song.
 
-This creates avoidable round trips. For example, GraphQL returns `isPublished`, web maps it to `is_published`, and shared UI reads `is_published`. Desktop does the same in Rust, then maps `display_id` back to `displayId` before sending an update to GraphQL.
+This creates avoidable round trips. GraphQL returns `isPublished`, web maps it to `is_published`, and shared UI reads `is_published`. Desktop does the same in Rust, then maps `display_id` back to `displayId` before sending an update to GraphQL.
 
-The web chart-detail page also has to cast its `LegacySimfile` into `SimfileWithDtxFiles` to satisfy `ChartDetail`, which is evidence that the shared boundary is not describing the actual application model.
+The web chart-detail page also casts its `LegacySimfile` into `SimfileWithDtxFiles` to satisfy `ChartDetail`, which is evidence that the shared boundary does not describe the application model.
 
 ## Approaches considered
 
@@ -44,8 +46,9 @@ Add one neutral `SimfileModel` in `@dtx/common`, use it throughout shared/web/de
 - D1 persistence stays snake_case on the server.
 - Web generated GraphQL results are normalized once in `packages/dtx-web/src/lib/api/chart.ts`.
 - Desktop GraphQL results are normalized once in Rust before crossing Tauri IPC.
-- Desktop renderer update payloads use camelCase directly.
+- Desktop renderer update payloads use explicit camelCase GraphQL input fields.
 - Old localStorage cache keys are replaced with versioned keys.
+- Desktop E2E cache seeds move to the same versioned key and camelCase shape as the renderer.
 
 This removes compatibility shapes without adding a mapper framework or pulling HPA-615 forward. **Chosen.**
 
@@ -53,7 +56,7 @@ This removes compatibility shapes without adding a mapper framework or pulling H
 
 Replace Rust `serde_json::Value` command envelopes and the renderer's handwritten result types at the same time.
 
-That is the eventual direction, but it is HPA-615's scope and would combine two independently reviewable migrations. It also makes this ticket depend on production `ts-rs`/codegen machinery before the renderer contract is stable. Rejected.
+That is the eventual direction, but it is HPA-615's scope and would combine two independently reviewable migrations. It also makes this ticket depend on production Rust-to-TypeScript generation before the renderer contract is stable. Rejected.
 
 ## Current model
 
@@ -93,19 +96,32 @@ export interface SimfileModel {
 }
 ```
 
-`SimfileDtxFile.id` stays optional because list/detail projections do not all need or currently request the chart id. Code that uploads scores already has a narrower requirement for real chart ids and must continue to enforce it at that feature boundary.
+`SimfileDtxFile.id` stays optional because the web `SimfileFull`/list projections do not all request chart ids, while desktop already does. Code that uploads scores has a narrower requirement for real chart ids and continues to enforce it at that feature boundary.
 
-Nullable metadata uses `null`, not empty-string sentinels. The transport adapters are responsible for converting omitted projection fields to `null` or `[]` so application consumers see a stable shape.
+Nullable metadata uses `null`, not empty-string sentinels. Transport adapters convert omitted projection fields to `null` or `[]` so application consumers see a stable shape.
 
-`ChartDetail` accepts `Partial<SimfileModel> | null` because the desktop also uses it to render an unlinked local song before a cloud simfile id and remote metadata exist. This remains one named application model; `Partial` only represents an incomplete local draft, not a second compatibility contract.
+`ChartDetail` accepts `Partial<SimfileModel> | null` because the desktop also renders an unlinked local song before a cloud simfile id and remote metadata exist. `Partial` represents an incomplete local draft, not a second compatibility contract.
+
+## Migration ordering
+
+The application model is introduced before the old application-barrel exports are removed.
+
+Task ordering must avoid a workspace-wide transient compile break:
+
+1. add/export `SimfileModel` and migrate `ChartDetail` while the old D1/compatibility exports remain temporarily available;
+2. migrate web and native transport boundaries;
+3. migrate every renderer and desktop-E2E consumer;
+4. only then delete `SimfileWithDtx`, remove D1/compatibility exports from the main `@dtx/common` barrel, and update barrel tests.
+
+Renderer code must never be "fixed" by importing persistence types from `@dtx/common/server`.
 
 ## Boundary ownership
 
 ### D1 / API server
 
-`SimfileRow`, `DtxFileRow`, `SimfileWithDtxFiles`, and D1 conversion helpers remain in the server/D1 area for now. They may stay exported from `@dtx/common/server` until HPA-617 moves API-only infrastructure into `dtx-api`.
+`SimfileRow`, `DtxFileRow`, `SimfileWithDtxFiles`, and D1 conversion helpers remain in the server/D1 area. They may stay exported from `@dtx/common/server` until HPA-617 moves API-only infrastructure into `dtx-api`.
 
-They stop being exported from the main `@dtx/common` browser/application barrel. Shared UI and renderer code must not import them.
+They stop being exported from the main `@dtx/common` application barrel only after all application consumers have migrated. `packages/common/src/lib/constants.test.ts` is updated in that final cleanup step because it currently asserts `toSimfileWithDtx` on the main barrel.
 
 Delete `SimfileWithDtx` after its renderer consumers move; its sole purpose is the old desktop-compatible contract.
 
@@ -113,32 +129,29 @@ No D1 migration or GraphQL schema change is required.
 
 ### Web GraphQL boundary
 
-Replace `LegacySimfile` and `adaptSimfile` with a single `toSimfileModel` adapter in `packages/dtx-web/src/lib/api/chart.ts`.
+Replace `LegacySimfile` and `adaptSimfile` with one `toSimfileModel` adapter in `packages/dtx-web/src/lib/api/chart.ts`.
 
 The adapter:
 
-- converts the GraphQL `ID` string to a finite numeric `id` exactly as today;
+- converts GraphQL `ID` strings to finite numeric ids exactly as today;
 - preserves GraphQL camelCase names instead of converting back to snake_case;
 - converts absent nullable projection fields to `null`;
-- maps `dtxFiles` to `dtxFiles` without inventing D1-only fields;
+- maps `dtxFiles` without inventing D1-only fields;
 - preserves optional `files` and `hasUploadedFiles` for detail/list consumers.
 
 `listSimfiles`, `getSimfile`, and `updateSimfile` return `SimfileModel`. `updateSimfileDriveFile` returns `{ id, googleDriveFileId, downloadUrl }` rather than another snake_case mini-contract.
 
 Web chart list/detail components and helpers move mechanically from names such as `is_published`, `display_id`, `download_url`, `dtx_files`, and `has_uploaded_files` to the camelCase model.
 
+`PreviewSimfile` stays separate. It is a purpose-specific preview projection, not an old compatibility shape.
+
 ### Shared ChartDetail
 
-`ChartDetail.svelte` imports only `SimfileModel` from the neutral shared type module. Its props and internal bindings use:
+`ChartDetail.svelte` imports only `SimfileModel` from the neutral shared type module. Its props and internal bindings use camelCase fields.
 
-- `displayId`
-- `publishDate`
-- `isPublished`
-- `downloadUrl`
-- `videoPreviewUrl`
-- `dtxFiles`
+The component's emitted save event already uses camelCase names, so this removes the impedance mismatch instead of changing its event contract.
 
-The component's emitted save event already uses camelCase names, so this removes the current impedance mismatch instead of changing its outward event contract.
+The migration does not change unrelated behavior. In particular, keep the existing `dayjs().format('YYYY-MM-DD')` fallback for `publishDate`; do not replace it with `new Date().toISOString()` during the field rename.
 
 ### Desktop native boundary
 
@@ -146,46 +159,68 @@ Keep `serde_json::Value` command plumbing until HPA-615, but stop using it to pr
 
 Rename/refocus `renderer_simfile_from_graphql` to `simfile_model_from_graphql`. It should:
 
-- keep the current numeric-id validation;
+- keep current numeric-id validation;
 - return the same camelCase fields as `SimfileModel`;
 - normalize nested `dtxFiles` without `simfile_id`;
 - stop synthesizing compatibility-only fields for old cached records.
 
-`update_simfile_record_impl` sends the renderer's camelCase update object directly as the GraphQL input. Delete `update_input_from_renderer`; the renderer no longer sends `display_id`, `publish_date`, `is_published`, `download_url`, or `video_preview_url`.
+Delete the general snake_case-to-camelCase `update_input_from_renderer` mapper once the renderer sends camelCase update payloads, but preserve its real ownership rule: general simfile updates must not carry `googleDriveFileId`.
 
-`search_cloud_songs_impl` also returns `isPublished` so the search result does not retain a separate snake_case mini-contract.
+`update_simfile_record_impl` therefore performs only the narrow Drive-id omission before sending the object to `UpdateSimfileInput`. It does not become a generic mapper or accept a spread `SimfileModel` as an update payload.
+
+Renderer update objects are explicit picks of fields owned by `UpdateSimfileInput`, for example `displayId`, `publishDate`, `isPublished`, `downloadUrl`, `videoPreviewUrl`, `bpm`, `artist`, and `title`. They are never built as `{ ...simfile }`.
+
+Keep/update the native test that proves `googleDriveFileId` is excluded from the general update mutation.
+
+`search_cloud_songs_impl` returns `isPublished` so search results do not retain a separate snake_case mini-contract.
 
 ### Desktop renderer
 
-Migrate the renderer's cloud-simfile ownership to `SimfileModel`:
+Migrate all current `SimfileWithDtx` consumers to `SimfileModel`, including:
 
 - `simFileStore`
 - `simFileService`
 - `workspaceStore`
 - `linkageCacheService`
+- `linkingService`
+- `App.svelte`
 - `SongDetails`
 - `CloudSongDetail`
 - `SimFileList`
-- `CloudSongAutocomplete`
-- directly affected tests/services
+- `CommandPalette`
+- score-page cloud projections that currently reuse the old contract
+- directly affected tests such as `linkingService.test.ts`, `CommandPalette.test.ts`, and `Workspace.test.ts`
 
-Delete `normalizeSimfile` and the old positional/cache compatibility comments once all current native responses already match `SimfileModel`.
+Delete `normalizeSimfile` and old positional/cache compatibility comments once native responses already match `SimfileModel`.
 
-Local draft data assembled in `SongDetails` should use camelCase and `Partial<SimfileModel>` directly. Update payloads to Rust use the GraphQL-style input names (`displayId`, `publishDate`, `isPublished`, `downloadUrl`, `videoPreviewUrl`) so native no longer has to translate them.
+Local draft data assembled in `SongDetails` uses camelCase and `Partial<SimfileModel>` directly. Update payloads to Rust are explicit camelCase GraphQL-input picks, not application-model spreads.
+
+The persisted score-link map remains `Record<string, string>`. It is a separate persistence boundary and keeps explicit numeric↔string conversion rather than forcing `SimfileModel.id` back to a string.
+
+### Desktop E2E fixtures
+
+Two desktop-E2E helpers currently seed `dtx_linkage_cache` with the old snake_case cloud-song shape:
+
+- `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
+- `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
+
+Both must seed `dtx_linkage_cache_v2` and a camelCase `SimfileModel`-compatible `cloudSongData`, including `isPublished`, `publishDate`, `displayId`, `downloadUrl`, `googleDriveFileId`, `previewUrl`, `videoPreviewUrl`, and `dtxFiles`.
+
+This is part of the migration, not compatibility support. Without it, the renderer correctly ignores the old key and the Drive E2E setup no longer links the song.
 
 ## Cache invalidation
 
-Do not parse or migrate the previous cached simfile shape.
+Do not parse or migrate previous cached simfile shapes.
 
-Change the renderer cache keys to:
+Change renderer cache keys to:
 
 - `simfiles_cache_v2`
 - `simfiles_cache_timestamp_v2`
 - `dtx_linkage_cache_v2`
 
-The old keys are simply no longer read. A user with stale data gets a normal refetch/relink-cache rebuild through existing behavior. No cache-version registry or migration framework is added.
+The old keys are no longer read. A user with stale data gets a normal refetch/relink-cache rebuild through existing behavior. No cache-version registry or migration framework is added.
 
-Tests must prove that current reads/writes use only the `*_v2` keys.
+Tests prove current reads/writes use only the `*_v2` keys and desktop-E2E seeds use the same current key/shape.
 
 ## Supabase auth type and `gen-types`
 
@@ -194,13 +229,14 @@ HPA-614's cleanup clause is conditional on the type having no current consumer. 
 - `packages/dtx-web/src/app.d.ts` uses `SupabaseClient<Database>`.
 - `packages/dtx-web/src/hooks.server.ts` creates `createServerClient<Database>`.
 
-Therefore this ticket does **not** delete `packages/common/src/lib/types/supabase.types.ts`, the `Database` export, or the root `gen-types` script. They are type-only auth plumbing, not the application simfile contract. Removing or replacing them belongs with later migration cleanup once their consumers are changed deliberately.
+Therefore this ticket does **not** delete `packages/common/src/lib/types/supabase.types.ts`, the `Database` export, or the root `gen-types` script. They are type-only auth plumbing, not the application simfile contract.
 
 ## Error and compatibility behavior
 
 - Invalid top-level GraphQL simfile ids continue to fail immediately rather than leaking `NaN` into application state.
 - Existing corrupt-cache handling remains: parse failures clear the current cache and refetch.
-- Old cache entries are unsupported by design and ignored through the key version bump.
+- Old cache entries are unsupported and ignored through the key version bump.
+- General simfile updates cannot send `googleDriveFileId`; Drive binding remains owned by its dedicated mutation.
 - No aliases, deprecated snake_case properties, proxy accessors, runtime schema library, or generic mapper abstraction are introduced.
 - No backwards compatibility is provided for old internal renderer payloads.
 
@@ -208,9 +244,10 @@ Therefore this ticket does **not** delete `packages/common/src/lib/types/supabas
 
 ### Common
 
-- Add direct type/model fixtures using camelCase.
-- Update `ChartDetail.test.ts` to render camelCase fields and `dtxFiles`.
-- Keep D1 conversion tests under the server/persistence boundary.
+- Add camelCase model fixtures.
+- Update `ChartDetail.test.ts` to render camelCase fields and `dtxFiles` while retaining existing date-default behavior.
+- Keep D1 conversion tests under the persistence boundary.
+- Update `constants.test.ts` only when final application-barrel cleanup happens.
 
 ### Web
 
@@ -221,14 +258,21 @@ Therefore this ticket does **not** delete `packages/common/src/lib/types/supabas
 ### Desktop renderer
 
 - Update store/service/component fixtures to `SimfileModel`.
-- Add/adjust cache tests for the new `*_v2` keys and confirm old keys are ignored.
-- Preserve action concurrency, stale-selection, Drive upload, and link behavior while changing field names only.
+- Add/adjust cache tests for `*_v2` keys and confirm old keys are ignored.
+- Run the direct consumer suites, including `linkingService.test.ts`, `CommandPalette.test.ts`, `Workspace.test.ts`, stores/services, `SongDetails`, list/detail, autocomplete, and scores.
+- Preserve action concurrency, stale-selection, auto-link, Drive upload, and score-link behavior while changing field names only.
+
+### Desktop E2E
+
+- Change both linkage-cache seed helpers to `dtx_linkage_cache_v2` + camelCase model data.
+- Keep the existing Google Drive upload/crash-recovery flows as regression coverage for restored linkage.
 
 ### Rust
 
 - Update API tests to assert camelCase output from `simfile_model_from_graphql` and cloud search.
 - Update create/fetch/update tests to assert Tauri envelopes contain the current model.
-- Add an update test proving camelCase renderer input is sent to GraphQL unchanged.
+- Add an update test proving camelCase renderer input reaches GraphQL unchanged except for the deliberate `googleDriveFileId` omission.
+- Preserve the Drive-id ownership test when removing the general mapper.
 
 ## Non-goals
 
@@ -244,11 +288,13 @@ Therefore this ticket does **not** delete `packages/common/src/lib/types/supabas
 
 HPA-614 is complete when:
 
-1. `SimfileModel` is the only simfile application model imported by shared UI, web application code, and desktop renderer code.
-2. `ChartDetail` no longer imports D1 types and reads only camelCase fields.
-3. `LegacySimfile` and `SimfileWithDtx` are deleted.
-4. The web detail-page cast is deleted.
-5. Rust no longer converts current GraphQL payloads into the old snake_case renderer shape, and renderer updates no longer require `update_input_from_renderer`.
-6. Browser/application code contains no compatibility-only snake_case simfile fields; snake_case remains confined to D1/server persistence code and the separately retained Supabase auth `Database` type definition.
-7. Desktop simfile/linkage caches use the new versioned keys and do not read old entries.
-8. Common, web, desktop renderer, and Rust API tests/type checks covering this seam pass.
+1. `SimfileModel` is the only simfile application model imported by shared UI, web application code, desktop renderer code, and current desktop-E2E linkage fixtures.
+2. `ChartDetail` no longer imports D1 types, reads only camelCase fields, and keeps its existing date-default behavior.
+3. `LegacySimfile` and `SimfileWithDtx` are deleted after all consumers migrate.
+4. D1/compatibility exports are removed from the main `@dtx/common` application barrel only in final cleanup; `@dtx/common/server` keeps persistence ownership.
+5. The web detail-page cast is deleted.
+6. Rust no longer converts current GraphQL payloads into the old snake_case renderer shape, and general renderer updates no longer require `update_input_from_renderer` while still excluding `googleDriveFileId`.
+7. Browser/application code contains no compatibility-only snake_case simfile fields; snake_case remains confined to D1/server persistence code and the separately retained Supabase auth `Database` type definition.
+8. Desktop simfile/linkage caches and desktop-E2E linkage seeds use the new versioned keys and do not read/seed old entries.
+9. The score-link `Record<string, string>` and `PreviewSimfile` remain purpose-specific boundaries rather than being folded into `SimfileModel`.
+10. Common, web, desktop renderer, Rust API, and affected desktop-E2E validation covering this seam pass.

--- a/packages/common/src/lib/components/ChartDetail.svelte
+++ b/packages/common/src/lib/components/ChartDetail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
-	import type { SimfileWithDtx } from '../types/d1.types';
+	import type { SimfileModel } from '../types/simfile';
 	import { formatLevel } from '../utils/level';
 	import { createEventDispatcher } from 'svelte';
 	import dayjs from 'dayjs';
@@ -8,7 +8,7 @@
 	import IconCheck from '@lucide/svelte/icons/check';
 
 	interface Props {
-		simfile?: Partial<SimfileWithDtx> | null;
+		simfile?: Partial<SimfileModel> | null;
 		preview?: import('svelte').Snippet;
 		folder_upload?: import('svelte').Snippet;
 		asset_files?: import('svelte').Snippet;
@@ -43,22 +43,22 @@
 		showPublishingControls = true,
 		showPublishedToggle = true,
 		saveButtonText = 'Update',
-		displayId = $bindable(simfile?.display_id ?? 0),
-		publishDate = $bindable(simfile?.publish_date ?? dayjs().format('YYYY-MM-DD')),
-		isPublished = $bindable(simfile?.is_published ?? true),
-		downloadUrl = $bindable(simfile?.download_url ?? ''),
-		videoPreviewUrl = $bindable(simfile?.video_preview_url ?? '')
+		displayId = $bindable(simfile?.displayId ?? 0),
+		publishDate = $bindable(simfile?.publishDate ?? dayjs().format('YYYY-MM-DD')),
+		isPublished = $bindable(simfile?.isPublished ?? true),
+		downloadUrl = $bindable(simfile?.downloadUrl ?? ''),
+		videoPreviewUrl = $bindable(simfile?.videoPreviewUrl ?? '')
 	}: Props = $props();
 
-	let dtxFiles = $derived(simfile?.dtx_files || []);
+	let dtxFiles = $derived(simfile?.dtxFiles ?? []);
 
 	$effect(() => {
 		if (!simfile) return;
-		displayId = simfile.display_id ?? 0;
-		publishDate = simfile.publish_date ?? dayjs().format('YYYY-MM-DD');
-		isPublished = simfile.is_published ?? true;
-		downloadUrl = simfile.download_url ?? '';
-		videoPreviewUrl = simfile.video_preview_url ?? '';
+		displayId = simfile.displayId ?? 0;
+		publishDate = simfile.publishDate ?? dayjs().format('YYYY-MM-DD');
+		isPublished = simfile.isPublished ?? true;
+		downloadUrl = simfile.downloadUrl ?? '';
+		videoPreviewUrl = simfile.videoPreviewUrl ?? '';
 	});
 
 	// Derived values for display

--- a/packages/common/src/lib/components/ChartDetail.test.ts
+++ b/packages/common/src/lib/components/ChartDetail.test.ts
@@ -20,14 +20,16 @@ const mockSimfile = {
 	title: 'Test Song',
 	artist: 'Test Artist',
 	bpm: 140,
-	is_published: true,
-	display_id: 1,
-	download_url: 'https://example.com/download',
-	publish_date: '2024-01-01',
-	video_preview_url: null,
-	dtx_files: [
-		{ id: 1, label: 'BASIC', level: 30, simfile_id: 1 },
-		{ id: 2, label: 'ADVANCED', level: 60, simfile_id: 1 }
+	isPublished: true,
+	displayId: 1,
+	downloadUrl: 'https://example.com/download',
+	publishDate: '2024-01-01',
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-02T00:00:00Z',
+	videoPreviewUrl: null,
+	dtxFiles: [
+		{ id: 1, label: 'BASIC', level: 30 },
+		{ id: 2, label: 'ADVANCED', level: 60 }
 	]
 };
 
@@ -63,15 +65,15 @@ describe('ChartDetail', () => {
 		expect(screen.queryByText('Published:')).not.toBeInTheDocument();
 	});
 
-	it('renders DTX file list when dtx_files present', () => {
+	it('renders DTX file list when dtxFiles present', () => {
 		render(ChartDetail, { props: { simfile: mockSimfile } });
 		expect(screen.getByText('BASIC')).toBeInTheDocument();
 		expect(screen.getByText('ADVANCED')).toBeInTheDocument();
 	});
 
-	it('renders with empty dtx_files array shows no DTX entries', () => {
+	it('renders with empty dtxFiles array shows no DTX entries', () => {
 		render(ChartDetail, {
-			props: { simfile: { ...mockSimfile, dtx_files: [] } }
+			props: { simfile: { ...mockSimfile, dtxFiles: [] } }
 		});
 		expect(screen.queryByText('BASIC')).not.toBeInTheDocument();
 		expect(screen.queryByText('ADVANCED')).not.toBeInTheDocument();

--- a/packages/common/src/lib/constants.test.ts
+++ b/packages/common/src/lib/constants.test.ts
@@ -19,8 +19,7 @@ import {
 	normalizePosition,
 	VALID_DTX_FILE_EXTENSIONS,
 	setFileProvider,
-	getFileProvider,
-	toSimfileWithDtx
+	getFileProvider
 } from './index';
 import {
 	DTXFile as ServerDTXFile,
@@ -158,7 +157,6 @@ describe('package barrel exports', () => {
 		expect(VALID_DTX_FILE_EXTENSIONS).toBeDefined();
 		expect(setFileProvider).toBeDefined();
 		expect(getFileProvider).toBeDefined();
-		expect(toSimfileWithDtx).toBeDefined();
 	});
 
 	it('server.ts exports all expected symbols', () => {

--- a/packages/common/src/lib/index.ts
+++ b/packages/common/src/lib/index.ts
@@ -17,22 +17,7 @@ export { VALID_DTX_FILE_EXTENSIONS, isValidDtxFileExtension, isValidDtxFile } fr
 // Export Supabase types (for backward compatibility with auth)
 export type { Database } from './types/supabase.types';
 
-// Export D1 types
-export type {
-	SimfileRow,
-	SimfileInsert,
-	SimfileUpdate,
-	DtxFileRow,
-	DtxFileInsert,
-	UserProfileRow,
-	UserProfileInsert,
-	UserProfileUpdate,
-	SimfileWithDtxFiles,
-	SimfileWithDtx
-} from './types/d1.types';
-export { toSimfileWithDtx } from './types/d1.types';
-
-// Export current simfile model (replaces compatibility shapes in Task 5)
+// Export current simfile model (D1 row types stay server-only under '@dtx/common/server')
 export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
 
 // Game classes are exported in './game' to avoid SSR issues with Phaser

--- a/packages/common/src/lib/index.ts
+++ b/packages/common/src/lib/index.ts
@@ -32,6 +32,9 @@ export type {
 } from './types/d1.types';
 export { toSimfileWithDtx } from './types/d1.types';
 
+// Export current simfile model (replaces compatibility shapes in Task 5)
+export type { SimfileModel, SimfileDtxFile, SimfileAssetFile } from './types/simfile';
+
 // Game classes are exported in './game' to avoid SSR issues with Phaser
 // Import from '@dtx/common/game' instead of '@dtx/common' for game classes
 

--- a/packages/common/src/lib/server.ts
+++ b/packages/common/src/lib/server.ts
@@ -24,7 +24,6 @@ export type {
 	UserProfileInsert,
 	UserProfileUpdate,
 	SimfileWithDtxFiles,
-	SimfileWithDtx,
 	ChartScoreRow,
 	ScoreRow,
 	ScoreInsert

--- a/packages/common/src/lib/types/d1.types.ts
+++ b/packages/common/src/lib/types/d1.types.ts
@@ -132,20 +132,6 @@ export interface SimfileWithDtxFiles extends Omit<
 	dtx_files: { id?: number; level: number; label: string }[];
 }
 
-/** Simfile with joined dtx_files — desktop-compatible shape matching old Supabase type */
-export interface SimfileWithDtx extends Omit<
-	SimfileRow,
-	'is_published' | 'publish_date' | 'created_at' | 'updated_at' | 'user_id' | 'video_preview_url'
-> {
-	is_published: boolean;
-	publish_date?: string;
-	created_at?: string;
-	updated_at?: string;
-	user_id?: string;
-	video_preview_url?: string | null;
-	dtx_files: Partial<DtxFileRow>[];
-}
-
 /** Convert a raw D1 simfile row (integer booleans) to the API-facing shape */
 export const toSimfileWithDtx = (
 	row: Omit<SimfileRow, 'user_id' | 'google_drive_file_id'> & {

--- a/packages/common/src/lib/types/simfile.ts
+++ b/packages/common/src/lib/types/simfile.ts
@@ -1,0 +1,31 @@
+export interface SimfileDtxFile {
+	id?: number;
+	label: string;
+	level: number;
+}
+
+export interface SimfileAssetFile {
+	key: string;
+	size: number;
+	uploaded: string;
+}
+
+export interface SimfileModel {
+	id: number;
+	title: string;
+	artist: string;
+	bpm: number;
+	displayId: number | null;
+	userId: string | null;
+	googleDriveFileId: string | null;
+	isPublished: boolean;
+	downloadUrl: string | null;
+	previewUrl: string | null;
+	videoPreviewUrl: string | null;
+	publishDate: string;
+	createdAt: string;
+	updatedAt: string;
+	dtxFiles: SimfileDtxFile[];
+	files?: SimfileAssetFile[];
+	hasUploadedFiles?: boolean;
+}

--- a/packages/dtx-desktop/src-tauri/src/api.rs
+++ b/packages/dtx-desktop/src-tauri/src/api.rs
@@ -399,14 +399,17 @@ pub fn simfile_model_from_graphql(simfile: &Value) -> Result<Value> {
             files
                 .iter()
                 .map(|file| {
-                    json!({
-                        "id": file["id"],
-                        "level": file["level"],
-                        "label": file["label"],
-                    })
+                    let mut entry = Map::new();
+                    if let Some(id) = file.get("id").filter(|id| !id.is_null()) {
+                        entry.insert("id".to_string(), json!(number_id(id)?));
+                    }
+                    entry.insert("level".to_string(), file["level"].clone());
+                    entry.insert("label".to_string(), file["label"].clone());
+                    Ok(Value::Object(entry))
                 })
-                .collect::<Vec<_>>()
+                .collect::<Result<Vec<_>>>()
         })
+        .transpose()?
         .unwrap_or_default();
     mapped.insert("dtxFiles".to_string(), Value::Array(dtx_files));
 

--- a/packages/dtx-desktop/src-tauri/src/api.rs
+++ b/packages/dtx-desktop/src-tauri/src/api.rs
@@ -52,6 +52,8 @@ query ListSimfiles($scope: SimfileScope!, $search: String, $page: Int, $pageSize
       previewUrl
       videoPreviewUrl
       publishDate
+      createdAt
+      updatedAt
       dtxFiles {
         id
         level
@@ -367,28 +369,28 @@ fn number_id(value: &Value) -> Result<i64> {
     )))
 }
 
-pub fn renderer_simfile_from_graphql(simfile: &Value) -> Result<Value> {
+pub fn simfile_model_from_graphql(simfile: &Value) -> Result<Value> {
     let mut mapped = Map::new();
     mapped.insert("id".to_string(), json!(number_id(&simfile["id"])?));
+    mapped.insert("displayId".to_string(), simfile["displayId"].clone());
     mapped.insert("title".to_string(), simfile["title"].clone());
     mapped.insert("artist".to_string(), simfile["artist"].clone());
     mapped.insert("bpm".to_string(), simfile["bpm"].clone());
-    mapped.insert("user_id".to_string(), simfile["userId"].clone());
+    mapped.insert("userId".to_string(), simfile["userId"].clone());
     mapped.insert(
-        "google_drive_file_id".to_string(),
+        "googleDriveFileId".to_string(),
         simfile["googleDriveFileId"].clone(),
     );
-    mapped.insert("is_published".to_string(), simfile["isPublished"].clone());
-    mapped.insert("display_id".to_string(), simfile["displayId"].clone());
-    mapped.insert("download_url".to_string(), simfile["downloadUrl"].clone());
-    mapped.insert("preview_url".to_string(), simfile["previewUrl"].clone());
+    mapped.insert("isPublished".to_string(), simfile["isPublished"].clone());
+    mapped.insert("downloadUrl".to_string(), simfile["downloadUrl"].clone());
+    mapped.insert("previewUrl".to_string(), simfile["previewUrl"].clone());
     mapped.insert(
-        "video_preview_url".to_string(),
+        "videoPreviewUrl".to_string(),
         simfile["videoPreviewUrl"].clone(),
     );
-    mapped.insert("publish_date".to_string(), simfile["publishDate"].clone());
-    mapped.insert("created_at".to_string(), simfile["createdAt"].clone());
-    mapped.insert("updated_at".to_string(), simfile["updatedAt"].clone());
+    mapped.insert("publishDate".to_string(), simfile["publishDate"].clone());
+    mapped.insert("createdAt".to_string(), simfile["createdAt"].clone());
+    mapped.insert("updatedAt".to_string(), simfile["updatedAt"].clone());
 
     let dtx_files = simfile
         .get("dtxFiles")
@@ -396,23 +398,9 @@ pub fn renderer_simfile_from_graphql(simfile: &Value) -> Result<Value> {
         .map(|files| {
             files
                 .iter()
-                .enumerate()
-                .map(|(index, file)| {
-                    // Pass through the real GraphQL `dtxFiles.id` (the D1
-                    // dtx_files primary key, also the chart id used by
-                    // `uploadScores`). Fall back to a positional id only when
-                    // the field is absent — older cached records from before
-                    // the fragment requested `id` may lack it, and the
-                    // renderer's `normalizeSimfile` has its own `?? index + 1`
-                    // fallback for the same reason. The positional fallback is
-                    // display-only and must never flow into an upload payload.
-                    let id = file
-                        .get("id")
-                        .filter(|v| !v.is_null())
-                        .cloned()
-                        .unwrap_or_else(|| json!(index + 1));
+                .map(|file| {
                     json!({
-                        "id": id,
+                        "id": file["id"],
                         "level": file["level"],
                         "label": file["label"],
                     })
@@ -420,31 +408,9 @@ pub fn renderer_simfile_from_graphql(simfile: &Value) -> Result<Value> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    mapped.insert("dtx_files".to_string(), Value::Array(dtx_files));
+    mapped.insert("dtxFiles".to_string(), Value::Array(dtx_files));
 
     Ok(Value::Object(mapped))
-}
-
-pub fn update_input_from_renderer(update_data: Value) -> Value {
-    let Some(object) = update_data.as_object() else {
-        return update_data;
-    };
-
-    let mut mapped = Map::new();
-    for (key, value) in object {
-        let mapped_key = match key.as_str() {
-            "display_id" => "displayId",
-            "publish_date" => "publishDate",
-            "is_published" => "isPublished",
-            "download_url" => "downloadUrl",
-            "video_preview_url" => "videoPreviewUrl",
-            "preview_url" => "previewUrl",
-            "google_drive_file_id" | "googleDriveFileId" => continue,
-            _ => key,
-        };
-        mapped.insert(mapped_key.to_string(), value.clone());
-    }
-    Value::Object(mapped)
 }
 
 fn owner_drive_simfile_from_graphql(
@@ -1002,7 +968,7 @@ pub(crate) async fn fetch_user_simfiles_impl(base_url: &str, token: &str) -> Res
             .cloned()
             .unwrap_or_default();
         for simfile in page_data {
-            all_data.push(renderer_simfile_from_graphql(&simfile)?);
+            all_data.push(simfile_model_from_graphql(&simfile)?);
         }
 
         let count = simfiles.get("count").and_then(Value::as_i64).unwrap_or(0);
@@ -1077,7 +1043,7 @@ pub(crate) async fn search_cloud_songs_impl(
                         "title": song["title"],
                         "artist": song["artist"],
                         "bpm": song["bpm"],
-                        "is_published": song["isPublished"],
+                        "isPublished": song["isPublished"],
                     })
                 })
                 .collect::<Vec<_>>()
@@ -1121,7 +1087,7 @@ pub(crate) async fn fetch_cloud_song_impl(
 
     Ok(json!({
         "success": true,
-        "cloudSongData": renderer_simfile_from_graphql(simfile)?,
+        "cloudSongData": simfile_model_from_graphql(simfile)?,
     }))
 }
 
@@ -1299,13 +1265,22 @@ pub(crate) async fn update_simfile_record_impl(
     simfile_id: Value,
     update_data: Value,
 ) -> Result<Value> {
+    let input = match update_data {
+        Value::Object(mut object) => {
+            // A Drive binding is owner-only state with its own mutation;
+            // `UpdateSimfileInput` deliberately does not own this field.
+            object.remove("googleDriveFileId");
+            Value::Object(object)
+        }
+        other => other,
+    };
     let result = graphql_result_with_url(
         base_url,
         token,
         &graphql_document(UPDATE_SIMFILE_MUTATION),
         json!({
             "id": simfile_id.to_string().trim_matches('"'),
-            "input": update_input_from_renderer(update_data),
+            "input": input,
         }),
     )
     .await?;
@@ -1316,7 +1291,7 @@ pub(crate) async fn update_simfile_record_impl(
 
     Ok(json!({
         "success": true,
-        "data": renderer_simfile_from_graphql(&data["updateSimfile"])?,
+        "data": simfile_model_from_graphql(&data["updateSimfile"])?,
     }))
 }
 
@@ -1389,7 +1364,7 @@ pub(crate) async fn create_simfile_record_impl(
     let mut response = json!({
         "success": true,
         "simfileId": simfile_id,
-        "data": renderer_simfile_from_graphql(simfile)?,
+        "data": simfile_model_from_graphql(simfile)?,
     });
     if !warnings.is_empty() {
         response["warnings"] = json!(warnings);

--- a/packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
+++ b/packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
@@ -118,7 +118,7 @@ fn simfile_model_from_graphql_matches_renderer_fixture() {
         "publishDate": "2026-08-15",
         "createdAt": "2026-08-15T00:00:00Z",
         "updatedAt": "2026-08-15T00:00:01Z",
-        "dtxFiles": [{ "id": 99, "label": "EXT", "level": 85 }]
+        "dtxFiles": [{ "id": "99", "label": "EXT", "level": 85 }]
     });
 
     let mapped = simfile_model_from_graphql(&graphql_value).expect("mapped");

--- a/packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
+++ b/packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
@@ -99,91 +99,90 @@ fn api_base_url_rejects_empty_value() {
 }
 
 #[test]
-fn renderer_simfile_maps_graphql_camel_case_to_snake_case() {
-    let mapped = renderer_simfile_from_graphql(&gql_simfile()).expect("mapped");
+fn simfile_model_from_graphql_matches_renderer_fixture() {
+    let expected: Value =
+        serde_json::from_str(include_str!("../../tests/fixtures/simfile_model.json"))
+            .expect("fixture parses");
+    let graphql_value = json!({
+        "id": "42",
+        "displayId": 7,
+        "title": "Fixture Song",
+        "artist": "Fixture Artist",
+        "bpm": 123.5,
+        "userId": "user-1",
+        "googleDriveFileId": null,
+        "isPublished": true,
+        "downloadUrl": "https://example.test/chart.zip",
+        "previewUrl": null,
+        "videoPreviewUrl": null,
+        "publishDate": "2026-08-15",
+        "createdAt": "2026-08-15T00:00:00Z",
+        "updatedAt": "2026-08-15T00:00:01Z",
+        "dtxFiles": [{ "id": 99, "label": "EXT", "level": 85 }]
+    });
 
-    assert_eq!(mapped["id"], 42);
-    assert_eq!(mapped["display_id"], 7);
-    assert_eq!(mapped["user_id"], "user-1");
-    assert_eq!(mapped["google_drive_file_id"], "drive-file-42");
-    assert_eq!(mapped["is_published"], true);
-    assert_eq!(mapped["download_url"], "https://files/song.zip");
-    assert_eq!(mapped["preview_url"], "https://files/preview.jpg");
-    assert_eq!(mapped["video_preview_url"], Value::Null);
-    assert_eq!(mapped["publish_date"], "2024-01-01");
-    assert_eq!(mapped["created_at"], "2024-01-02");
-    assert_eq!(mapped["updated_at"], "2024-01-03");
-    assert_eq!(mapped["dtx_files"][0]["id"], "101");
-    assert_eq!(mapped["dtx_files"][0]["label"], "EXT");
+    let mapped = simfile_model_from_graphql(&graphql_value).expect("mapped");
+
+    assert_eq!(mapped, expected);
 }
 
 #[test]
-fn renderer_simfile_falls_back_to_positional_id_when_graphql_id_absent() {
-    // Older cached records (from before the fragment requested `id`) may lack
-    // the field. The positional fallback keeps display working, but must never
-    // flow into an upload payload — upload chart ids come from
-    // `fetch_cloud_song_charts`, which always requests `id`.
-    let mut simfile = gql_simfile();
-    simfile["dtxFiles"] = json!([{ "level": 5.5, "label": "BSC" }]);
-    let mapped = renderer_simfile_from_graphql(&simfile).expect("mapped");
-    assert_eq!(mapped["dtx_files"][0]["id"], 1);
-    assert_eq!(mapped["dtx_files"][0]["label"], "BSC");
-}
-
-#[test]
-fn list_simfiles_query_requests_persisted_catalog_urls() {
+fn list_simfiles_query_requests_persisted_catalog_urls_and_timestamps() {
     // The list feeds auto-linking, which caches linked simfiles via
-    // `renderer_simfile_from_graphql`. Those cached records later populate
+    // `simfile_model_from_graphql`. Those cached records later populate
     // the metadata editor, so the persisted URL fields must be present in
     // the list response — otherwise opening and saving an auto-linked song
-    // overwrites the real URLs with empty strings.
+    // overwrites the real URLs with empty strings. Timestamps are part of
+    // the current simfile model and must not be optional.
     assert!(LIST_SIMFILES_QUERY.contains("downloadUrl"));
     assert!(LIST_SIMFILES_QUERY.contains("previewUrl"));
     assert!(LIST_SIMFILES_QUERY.contains("videoPreviewUrl"));
+    assert!(LIST_SIMFILES_QUERY.contains("publishDate"));
+    assert!(LIST_SIMFILES_QUERY.contains("createdAt"));
+    assert!(LIST_SIMFILES_QUERY.contains("updatedAt"));
     assert!(LIST_SIMFILES_QUERY.contains("dtxFiles"));
     // Still a curated field set (not the full fragment) to keep the
     // payload lean.
     assert!(!LIST_SIMFILES_QUERY.contains("...SimfileFull"));
 }
 
-#[test]
-fn update_input_maps_renderer_snake_case_to_graphql_camel_case() {
-    let mapped = update_input_from_renderer(json!({
-        "display_id": 3,
-        "publish_date": "2024-01-01",
-        "is_published": true,
-        "download_url": "https://files/song.zip",
-        "video_preview_url": "https://video",
-        "preview_url": "https://files/preview.jpg",
-        "title": "Song"
-    }));
-
-    assert_eq!(
-        mapped,
-        json!({
-            "displayId": 3,
-            "publishDate": "2024-01-01",
-            "isPublished": true,
-            "downloadUrl": "https://files/song.zip",
-            "videoPreviewUrl": "https://video",
-            "previewUrl": "https://files/preview.jpg",
-            "title": "Song"
-        })
-    );
-}
-
-#[test]
-fn update_input_excludes_drive_file_id_from_general_simfile_updates() {
+#[tokio::test]
+async fn update_simfile_record_impl_excludes_google_drive_file_id_from_outgoing_input() {
     // A Drive binding is owner-only state with its own mutation. If this
     // filtering is removed, a renderer form value can accidentally reintroduce
     // it to UpdateSimfileInput, which deliberately does not own that field.
-    let mapped = update_input_from_renderer(json!({
-        "title": "Song",
-        "google_drive_file_id": "drive-file-42",
-        "googleDriveFileId": "drive-file-42"
-    }));
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({
+            "variables": {
+                "id": "42",
+                "input": { "title": "Updated" }
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "updateSimfile": gql_simfile() }
+        })))
+        .mount(&server)
+        .await;
 
-    assert_eq!(mapped, json!({ "title": "Song" }));
+    let result = update_simfile_record_impl(
+        &server.uri(),
+        "token-1",
+        json!(42),
+        json!({ "title": "Updated", "googleDriveFileId": "drive-file-42" }),
+    )
+    .await
+    .expect("result");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["data"]["title"], "Song");
+
+    let requests = server.received_requests().await.expect("received request");
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("GraphQL JSON body");
+    let input = &body["variables"]["input"];
+    assert_eq!(input["title"], "Updated");
+    assert!(input.get("googleDriveFileId").is_none());
 }
 
 #[tokio::test]
@@ -854,16 +853,6 @@ fn create_input_from_renderer_defaults_missing_fields_and_nulls_levels() {
     assert_eq!(input["dtxFiles"], Value::Null);
 }
 
-#[test]
-fn update_input_from_renderer_returns_non_object_input_unchanged() {
-    assert_eq!(
-        update_input_from_renderer(json!([1, 2, 3])),
-        json!([1, 2, 3])
-    );
-    assert_eq!(update_input_from_renderer(json!("plain")), json!("plain"));
-    assert_eq!(update_input_from_renderer(json!(42)), json!(42));
-}
-
 #[tokio::test]
 async fn run_graphql_value_extracts_error_field_on_non_success_status() {
     let server = MockServer::start().await;
@@ -1366,7 +1355,7 @@ async fn search_cloud_songs_impl_returns_mapped_rows() {
     assert_eq!(result["data"].as_array().unwrap().len(), 1);
     assert_eq!(result["data"][0]["id"], 1);
     assert_eq!(result["data"][0]["title"], "Song");
-    assert_eq!(result["data"][0]["is_published"], true);
+    assert_eq!(result["data"][0]["isPublished"], true);
 }
 
 #[tokio::test]
@@ -1426,6 +1415,8 @@ async fn fetch_cloud_song_impl_returns_cloud_song_data_when_found() {
     assert_eq!(result["success"], true);
     assert_eq!(result["cloudSongData"]["id"], 42);
     assert_eq!(result["cloudSongData"]["title"], "Song");
+    assert_eq!(result["cloudSongData"]["isPublished"], true);
+    assert_eq!(result["cloudSongData"]["createdAt"], "2024-01-02");
 }
 
 #[tokio::test]
@@ -1470,6 +1461,7 @@ async fn update_simfile_record_impl_returns_updated_simfile() {
     assert_eq!(result["success"], true);
     assert_eq!(result["data"]["id"], 42);
     assert_eq!(result["data"]["title"], "Song");
+    assert_eq!(result["data"]["isPublished"], true);
 }
 
 #[tokio::test]
@@ -1601,6 +1593,7 @@ async fn create_simfile_record_impl_creates_without_previews_when_no_song_path()
     assert_eq!(result["success"], true);
     assert_eq!(result["simfileId"], "42");
     assert_eq!(result["data"]["id"], 42);
+    assert_eq!(result["data"]["isPublished"], true);
     assert!(result.get("warnings").is_none());
 }
 

--- a/packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json
+++ b/packages/dtx-desktop/src-tauri/tests/fixtures/simfile_model.json
@@ -1,0 +1,17 @@
+{
+	"id": 42,
+	"displayId": 7,
+	"title": "Fixture Song",
+	"artist": "Fixture Artist",
+	"bpm": 123.5,
+	"userId": "user-1",
+	"googleDriveFileId": null,
+	"isPublished": true,
+	"downloadUrl": "https://example.test/chart.zip",
+	"previewUrl": null,
+	"videoPreviewUrl": null,
+	"publishDate": "2026-08-15",
+	"createdAt": "2026-08-15T00:00:00Z",
+	"updatedAt": "2026-08-15T00:00:01Z",
+	"dtxFiles": [{ "id": 99, "label": "EXT", "level": 85 }]
+}

--- a/packages/dtx-desktop/src/renderer/src/App.svelte
+++ b/packages/dtx-desktop/src/renderer/src/App.svelte
@@ -17,7 +17,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { _ } from 'svelte-i18n';
 	import type { Session } from '@supabase/supabase-js';
-	import type { SimfileWithDtx } from '@dtx/common';
+	import type { SimfileModel } from '@dtx/common';
 
 	type MagicLinkResult = {
 		success: boolean;
@@ -206,7 +206,7 @@
 	}
 
 	// Function to trigger automatic linking between remote simFiles and local folders
-	function triggerAutoLinking(remoteSimFiles: SimfileWithDtx[]) {
+	function triggerAutoLinking(remoteSimFiles: SimfileModel[]) {
 		// Get current workspace state
 		let currentWorkspaceState: WorkspaceState | null = null;
 		const unsubscribe = workspaceStore.subscribe((state) => {

--- a/packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte
@@ -147,6 +147,12 @@
 		handleClose();
 	};
 
+	// Tailwind opacity-modified classes (e.g. `border-green/40`) can't be expressed
+	// as Svelte `class:` directives — the parser rejects `/` in directive names — so
+	// the published/draft badge classes are computed here instead.
+	const statusBadgeClass = (isPublished: boolean): string =>
+		isPublished ? 'border-green/40 bg-green/10 text-green' : 'bg-surface-2 text-dim';
+
 	const handleClickOutside = (event: MouseEvent) => {
 		const target = event.target as Element;
 		// Include the trigger (e.g. ScoreSongCard "Link to cloud song" / "change")
@@ -303,9 +309,9 @@
 											<span class="font-mono">{song.bpm} BPM</span>
 										{/if}
 										<span
-											class="ml-auto rounded px-2 py-0.5 text-xs font-medium {song.isPublished
-												? 'border-green/40 bg-green/10 text-green'
-												: 'bg-surface-2 text-dim'}"
+											class="ml-auto rounded px-2 py-0.5 text-xs font-medium {statusBadgeClass(
+												song.isPublished
+											)}"
 										>
 											{song.isPublished
 												? $_('score.link.published')

--- a/packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.svelte
@@ -17,7 +17,7 @@
 		title: string;
 		artist: string;
 		bpm?: number;
-		is_published: boolean;
+		isPublished: boolean;
 	}
 
 	let {
@@ -303,11 +303,11 @@
 											<span class="font-mono">{song.bpm} BPM</span>
 										{/if}
 										<span
-											class="ml-auto rounded px-2 py-0.5 text-xs font-medium {song.is_published
+											class="ml-auto rounded px-2 py-0.5 text-xs font-medium {song.isPublished
 												? 'border-green/40 bg-green/10 text-green'
 												: 'bg-surface-2 text-dim'}"
 										>
-											{song.is_published
+											{song.isPublished
 												? $_('score.link.published')
 												: $_('score.link.draft')}
 										</span>

--- a/packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/CloudSongAutocomplete.test.ts
@@ -22,8 +22,8 @@ afterEach(() => {
 });
 
 const defaultSongs = [
-	{ id: '1', title: 'Song Alpha', artist: 'Artist One', bpm: 120, is_published: true },
-	{ id: '2', title: 'Song Beta', artist: 'Artist Two', bpm: 140, is_published: false }
+	{ id: '1', title: 'Song Alpha', artist: 'Artist One', bpm: 120, isPublished: true },
+	{ id: '2', title: 'Song Beta', artist: 'Artist Two', bpm: 140, isPublished: false }
 ];
 
 describe('CloudSongAutocomplete – closed state', () => {

--- a/packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Music, X, Calendar, Link, Cloud } from '@lucide/svelte';
 	import { type SimfileModel, formatLevel } from '@dtx/common';
-	import { workspaceStore, type TreeNode } from '../stores/workspaceStore';
+	import { workspaceStore, type TreeNode } from '$lib/stores/workspaceStore';
 
 	interface Props {
 		simFile: SimfileModel;

--- a/packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { Music, X, Calendar, Link, Cloud } from '@lucide/svelte';
-	import { type SimfileWithDtx, formatLevel } from '@dtx/common';
+	import { type SimfileModel, formatLevel } from '@dtx/common';
 	import { workspaceStore, type TreeNode } from '../stores/workspaceStore';
 
 	interface Props {
-		simFile: SimfileWithDtx;
+		simFile: SimfileModel;
 	}
 	let { simFile }: Props = $props();
 
@@ -26,7 +26,7 @@
 
 	const linked = $derived(isLinked(simFile.id, workspaceState.treeStructure));
 	const levels = $derived(
-		(simFile.dtx_files ?? [])
+		(simFile.dtxFiles ?? [])
 			.map((f) => f.level)
 			.filter((l): l is number => typeof l === 'number')
 			.sort((a, b) => a - b)
@@ -75,7 +75,7 @@
 			<div class="border-hairline bg-surface-1 flex items-center gap-3 rounded-lg border p-3">
 				<Calendar size={16} class="text-faint shrink-0" />
 				<span class="text-faint w-24 shrink-0">Publish date</span>
-				<span class="text-hi">{formatDate(simFile.publish_date)}</span>
+				<span class="text-hi">{formatDate(simFile.publishDate)}</span>
 			</div>
 			<div class="border-hairline bg-surface-1 flex items-center gap-3 rounded-lg border p-3">
 				<Music size={16} class="text-faint shrink-0" />
@@ -95,7 +95,7 @@
 					Linked to workspace
 				</span>
 			{/if}
-			{#if simFile.is_published}
+			{#if simFile.isPublished}
 				<span class="border-green/40 bg-green/10 text-green rounded px-2 py-1 text-xs">
 					Published
 				</span>

--- a/packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/CloudSongDetail.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import { workspaceStore } from '../stores/workspaceStore';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 vi.mock('@lucide/svelte');
 
@@ -16,17 +16,17 @@ vi.mock('../services/linkageCacheService', () => ({
 
 import CloudSongDetail from './CloudSongDetail.svelte';
 
-const makeSimFile = (overrides: Partial<SimfileWithDtx> = {}): SimfileWithDtx =>
+const makeSimFile = (overrides: Partial<SimfileModel> = {}): SimfileModel =>
 	({
 		id: 1,
 		title: 'Spice & Wolf',
 		artist: 'Yoshino',
 		bpm: 145,
-		is_published: false,
-		publish_date: '2024-05-01',
-		dtx_files: [{ level: 5, label: 'BASIC' }],
+		isPublished: false,
+		publishDate: '2024-05-01',
+		dtxFiles: [{ level: 5, label: 'BASIC' }],
 		...overrides
-	}) as SimfileWithDtx;
+	}) as SimfileModel;
 
 describe('CloudSongDetail', () => {
 	beforeEach(() => {
@@ -42,19 +42,19 @@ describe('CloudSongDetail', () => {
 
 	it('renders BPM and sorted levels', () => {
 		render(CloudSongDetail, {
-			simFile: makeSimFile({ bpm: 160, dtx_files: [{ level: 90 }, { level: 30 }] })
+			simFile: makeSimFile({ bpm: 160, dtxFiles: [{ level: 90 }, { level: 30 }] })
 		});
 		expect(screen.getByText('160')).toBeInTheDocument();
 		expect(screen.getByText('3.00, 9.00')).toBeInTheDocument();
 	});
 
 	it('shows a Draft badge when unpublished', () => {
-		render(CloudSongDetail, { simFile: makeSimFile({ is_published: false }) });
+		render(CloudSongDetail, { simFile: makeSimFile({ isPublished: false }) });
 		expect(screen.getByText('Draft')).toBeInTheDocument();
 	});
 
 	it('shows a Published badge when published', () => {
-		render(CloudSongDetail, { simFile: makeSimFile({ is_published: true }) });
+		render(CloudSongDetail, { simFile: makeSimFile({ isPublished: true }) });
 		expect(screen.getByText('Published')).toBeInTheDocument();
 	});
 

--- a/packages/dtx-desktop/src/renderer/src/components/Scores.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/Scores.svelte
@@ -293,7 +293,7 @@
 
 		// Refresh placeholder titles in place. Charts/matches are already
 		// loaded from the upload-time restore, so only the title/artist/
-		// is_published fields are updated — no chart re-fetch needed.
+		// isPublished fields are updated — no chart re-fetch needed.
 		let applied = 0;
 		for (let idx = 0; idx < placeholderEntries.length; idx++) {
 			const { i, cloudId } = placeholderEntries[idx];
@@ -311,7 +311,7 @@
 					id: cloudId,
 					title: result.value.cloudSongData.title,
 					artist: result.value.cloudSongData.artist,
-					is_published: result.value.cloudSongData.is_published
+					isPublished: result.value.cloudSongData.isPublished
 				};
 				applied += 1;
 			}
@@ -334,7 +334,7 @@
 				id: cloudId,
 				title: `${PLACEHOLDER_PREFIX}${cloudId}`,
 				artist: songRow.artist,
-				is_published: false
+				isPublished: false
 			};
 			if (fetchTitles) {
 				const result = titleResults[idx];
@@ -347,7 +347,7 @@
 						id: cloudId,
 						title: result.value.cloudSongData.title,
 						artist: result.value.cloudSongData.artist,
-						is_published: result.value.cloudSongData.is_published
+						isPublished: result.value.cloudSongData.isPublished
 					};
 				}
 			}

--- a/packages/dtx-desktop/src/renderer/src/components/Scores.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/Scores.test.ts
@@ -90,11 +90,11 @@ beforeEach(() => {
 	host.parseDtxmaniaScores.mockResolvedValue(parsedSongs);
 	host.searchCloudSongs.mockResolvedValue({
 		success: true,
-		data: [{ id: '42', title: 'Cloud Song', artist: 'Artist A', is_published: true }]
+		data: [{ id: '42', title: 'Cloud Song', artist: 'Artist A', isPublished: true }]
 	});
 	host.fetchCloudSong.mockResolvedValue({
 		success: true,
-		cloudSongData: { id: 42, title: 'Cloud Song', artist: 'Artist A', is_published: true }
+		cloudSongData: { id: 42, title: 'Cloud Song', artist: 'Artist A', isPublished: true }
 	});
 	host.fetchCloudSongCharts.mockResolvedValue({
 		success: true,
@@ -293,7 +293,7 @@ describe('Scores', () => {
 				id: 42,
 				title: 'Cloud Song 11',
 				artist: 'Artist',
-				is_published: true
+				isPublished: true
 			}
 		});
 		host.fetchCloudSongCharts.mockResolvedValue({
@@ -736,7 +736,7 @@ describe('Scores', () => {
 				id: 42,
 				title: 'Cloud Mega Song',
 				artist: 'Artist A',
-				is_published: true
+				isPublished: true
 			}
 		});
 		host.fetchCloudSongCharts.mockResolvedValue({
@@ -797,7 +797,7 @@ describe('Scores', () => {
 				id: 42,
 				title: 'Cloud Mega Song',
 				artist: 'Artist A',
-				is_published: true
+				isPublished: true
 			}
 		});
 		host.fetchCloudSongCharts.mockResolvedValue({
@@ -872,7 +872,7 @@ describe('Scores', () => {
 				id: 42,
 				title: 'Cloud Mega Song',
 				artist: 'Artist A',
-				is_published: true
+				isPublished: true
 			}
 		});
 		host.fetchCloudSongCharts.mockResolvedValue({
@@ -938,7 +938,7 @@ describe('Scores', () => {
 				id: 42,
 				title: 'Cloud Mega Song',
 				artist: 'Artist A',
-				is_published: true
+				isPublished: true
 			}
 		});
 		host.fetchCloudSongCharts.mockResolvedValue({
@@ -1066,8 +1066,8 @@ describe('Scores', () => {
 		host.searchCloudSongs.mockResolvedValue({
 			success: true,
 			data: [
-				{ id: '42', title: 'Cloud Song A', artist: 'Artist A', is_published: true },
-				{ id: '99', title: 'Cloud Song B', artist: 'Artist A', is_published: true }
+				{ id: '42', title: 'Cloud Song A', artist: 'Artist A', isPublished: true },
+				{ id: '99', title: 'Cloud Song B', artist: 'Artist A', isPublished: true }
 			]
 		});
 
@@ -1203,7 +1203,7 @@ describe('Scores', () => {
 				id: 42,
 				title: 'Cloud Mega Song',
 				artist: 'Artist A',
-				is_published: true
+				isPublished: true
 			}
 		});
 		host.fetchCloudSongCharts.mockResolvedValue({

--- a/packages/dtx-desktop/src/renderer/src/components/SimFileList.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SimFileList.svelte
@@ -230,17 +230,17 @@
 									<Music size="14" />
 									{simFile.bpm} BPM
 								</div>
-								{#if simFile.publish_date}
+								{#if simFile.publishDate}
 									<div class="flex items-center gap-1">
 										<Calendar size="14" />
-										{formatDate(simFile.publish_date)}
+										{formatDate(simFile.publishDate)}
 									</div>
 								{/if}
 							</div>
-							{#if simFile.dtx_files && simFile.dtx_files.length > 0}
+							{#if simFile.dtxFiles && simFile.dtxFiles.length > 0}
 								<div class="mt-2">
 									<span class="text-dim text-xs">
-										Levels: {simFile.dtx_files
+										Levels: {simFile.dtxFiles
 											.map((f) => formatLevel(f.level))
 											.join(', ')}
 									</span>
@@ -256,7 +256,7 @@
 									Linked
 								</span>
 							{/if}
-							{#if simFile.is_published}
+							{#if simFile.isPublished}
 								<span
 									class="border-green/40 bg-green/10 text-green rounded px-2 py-1 text-xs"
 								>

--- a/packages/dtx-desktop/src/renderer/src/components/SimFileList.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SimFileList.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
 import { simFileStore } from '../stores/simFileStore';
 import { workspaceStore } from '../stores/workspaceStore';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 vi.mock('@lucide/svelte');
 
@@ -17,17 +17,17 @@ vi.mock('@skeletonlabs/skeleton-svelte');
 import SimFileList from './SimFileList.svelte';
 import { simFileService } from '../services/simFileService';
 
-const makeSimFile = (overrides: Partial<SimfileWithDtx> = {}): SimfileWithDtx =>
+const makeSimFile = (overrides: Partial<SimfileModel> = {}): SimfileModel =>
 	({
 		id: 1,
 		title: 'Test Song',
 		artist: 'Test Artist',
 		bpm: 120,
-		is_published: false,
-		publish_date: null,
-		dtx_files: [],
+		isPublished: false,
+		publishDate: null,
+		dtxFiles: [],
 		...overrides
-	}) as SimfileWithDtx;
+	}) as SimfileModel;
 
 describe('SimFileList', () => {
 	beforeEach(() => {
@@ -93,13 +93,13 @@ describe('SimFileList', () => {
 		});
 
 		it('shows Published badge for published simFiles', () => {
-			simFileStore.setUserSimFiles([makeSimFile({ id: 1, is_published: true })]);
+			simFileStore.setUserSimFiles([makeSimFile({ id: 1, isPublished: true })]);
 			render(SimFileList);
 			expect(screen.getByText('Published')).toBeInTheDocument();
 		});
 
 		it('shows Draft badge for unpublished simFiles', () => {
-			simFileStore.setUserSimFiles([makeSimFile({ id: 1, is_published: false })]);
+			simFileStore.setUserSimFiles([makeSimFile({ id: 1, isPublished: false })]);
 			render(SimFileList);
 			expect(screen.getByText('Draft')).toBeInTheDocument();
 		});

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -7,7 +7,7 @@
 	import { authStore } from '$lib/stores/authStore';
 	import { UploadedAssetFiles, ChartDetail } from '@dtx/common/components';
 	import { isValidDtxFile } from '@dtx/common';
-	import type { SimfileWithDtx, DtxFileRow } from '@dtx/common';
+	import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 	import { onMount } from 'svelte';
 	import CloudSongAutocomplete from '$lib/components/CloudSongAutocomplete.svelte';
 	import { simFileService } from '$lib/services/simFileService';
@@ -40,20 +40,20 @@
 		title: string;
 		artist: string;
 		bpm?: number;
-		is_published: boolean;
+		isPublished: boolean;
 	};
 
 	type CreateSimfileResult = {
 		success: boolean;
 		simfileId?: string;
-		data?: SimfileWithDtx;
+		data?: SimfileModel;
 		error?: string;
 		warnings?: string[];
 	};
 
 	type UpdateSimfileResult = {
 		success: boolean;
-		data?: Partial<SimfileWithDtx>;
+		data?: Partial<SimfileModel>;
 		error?: string;
 	};
 
@@ -322,9 +322,9 @@
 		return next;
 	};
 
-	const isSimfileWithDtx = (data: unknown): data is SimfileWithDtx => {
+	const isSimfileModel = (data: unknown): data is SimfileModel => {
 		if (!data || typeof data !== 'object') return false;
-		const candidate = data as Partial<SimfileWithDtx>;
+		const candidate = data as Partial<SimfileModel>;
 		return (
 			typeof candidate.id === 'number' &&
 			typeof candidate.title === 'string' &&
@@ -332,16 +332,6 @@
 			typeof candidate.bpm === 'number'
 		);
 	};
-
-	const normalizeSimfile = (data: SimfileWithDtx): SimfileWithDtx => ({
-		...data,
-		dtx_files: data.dtx_files?.map((file, index) => ({
-			...file,
-			level: file?.level !== undefined ? Number(file.level) : undefined,
-			id: (file as { id?: number })?.id ?? index + 1,
-			simfile_id: (file as { simfile_id?: number })?.simfile_id
-		}))
-	});
 
 	const mergeSuccessfulDriveFields = (
 		targetSong: TreeNode,
@@ -360,8 +350,8 @@
 		if (targetSong.linkedSimFile && targetSong.linkedSimFileId === simfileId) {
 			targetSong.linkedSimFile = {
 				...targetSong.linkedSimFile,
-				...(outcome.fileId === undefined ? {} : { google_drive_file_id: outcome.fileId }),
-				...(outcome.downloadUrl === undefined ? {} : { download_url: outcome.downloadUrl })
+				...(outcome.fileId === undefined ? {} : { googleDriveFileId: outcome.fileId }),
+				...(outcome.downloadUrl === undefined ? {} : { downloadUrl: outcome.downloadUrl })
 			};
 		}
 		workspaceStore.mergeGoogleDriveFields(targetPath, simfileId, fields);
@@ -523,14 +513,14 @@
 				save: async () => {
 					const result =
 						await desktopHost.createSimfileRecord<CreateSimfileResult>(simfileData);
-					if (!result.success || !result.data || !isSimfileWithDtx(result.data)) {
+					if (!result.success || !result.data || !isSimfileModel(result.data)) {
 						return {
 							success: false,
 							error: result.error || 'Failed to create simfile record'
 						};
 					}
 
-					const linkedSimfile = normalizeSimfile(result.data);
+					const linkedSimfile = result.data;
 					const savedSimfileId = result.simfileId || String(result.data.id);
 					targetSong.linkedSimFileId = savedSimfileId;
 					targetSong.linkedSimFile = linkedSimfile;
@@ -684,20 +674,20 @@
 			linkingSuccess = false;
 
 			try {
-				const result = await desktopHost.fetchCloudSong<
-					FetchCloudSongResult<SimfileWithDtx>
-				>({
-					cloudSongId: selectedSong.id
-				});
+				const result = await desktopHost.fetchCloudSong<FetchCloudSongResult<SimfileModel>>(
+					{
+						cloudSongId: selectedSong.id
+					}
+				);
 
 				if (
 					result.success &&
 					result.cloudSongData &&
-					isSimfileWithDtx(result.cloudSongData)
+					isSimfileModel(result.cloudSongData)
 				) {
-					const linkedSimfile = normalizeSimfile(result.cloudSongData);
+					const linkedSimfile = result.cloudSongData;
 					linkingSuccess = true;
-					song.linkedSimFileId = String(selectedSong.id);
+					song.linkedSimFileId = String(linkedSimfile.id);
 					song.linkedSimFile = linkedSimfile;
 
 					// Update the workspace store (this will automatically cache to localStorage)
@@ -753,15 +743,15 @@
 			// owns the URL via the guarded updateSimfileDriveFile mutation.
 			// Sending a cached download_url here would reintroduce the
 			// cross-device race where a stale URL overwrites a newer binding.
-			const isDriveBound = Boolean(targetSong.linkedSimFile?.google_drive_file_id);
+			const isDriveBound = Boolean(targetSong.linkedSimFile?.googleDriveFileId);
 			const updateData: Record<string, unknown> = {
-				display_id: Number(event.detail.displayId),
-				publish_date: String(event.detail.publishDate),
-				is_published: Boolean(event.detail.isPublished),
-				video_preview_url: String(event.detail.videoPreviewUrl)
+				displayId: Number(event.detail.displayId),
+				publishDate: String(event.detail.publishDate),
+				isPublished: Boolean(event.detail.isPublished),
+				videoPreviewUrl: String(event.detail.videoPreviewUrl)
 			};
 			if (!isDriveBound) {
-				updateData.download_url = String(event.detail.downloadUrl);
+				updateData.downloadUrl = String(event.detail.downloadUrl);
 			}
 
 			// Add parsed local data if available (BPM, artist, title)
@@ -788,10 +778,10 @@
 						};
 					}
 
-					const updatedSimfile = normalizeSimfile({
+					const updatedSimfile: SimfileModel = {
 						...targetSong.linkedSimFile,
 						...(result.data || {})
-					} as SimfileWithDtx);
+					};
 					targetSong.linkedSimFile = updatedSimfile;
 					workspaceStore.linkSimFileToFolder(targetPath, updatedSimfile);
 					if (selectionGeneration === selectionToken && song.path === targetPath) {
@@ -993,37 +983,35 @@
 	// Convert song data to simfile format for ChartDetail component
 	// Use parsed local data as fallback when linked simfile data is missing
 	const simfileData = $derived(() => {
-		const linkedSimfile = song.linkedSimFile ? normalizeSimfile(song.linkedSimFile) : null;
-		const fallbackDtxFiles: Partial<DtxFileRow>[] = parsedLocalData.levels
+		const linkedSimfile = song.linkedSimFile;
+		const fallbackDtxFiles: SimfileDtxFile[] = parsedLocalData.levels
 			? parsedLocalData.levels.map((l, index) => ({
 					id: index + 1,
 					label: l.label || 'Unknown',
 					// Store the raw #DLEVEL value directly — formatLevel decodes it
 					// via the DTXManiaCX formula (≥100 → /100, <100 → /10).
 					// Mirrors the upload site and DTXFile.level in @dtx/common.
-					level: Number(l.level || 0),
-					simfile_id: 0
+					level: Number(l.level || 0)
 				}))
 			: [];
-		const dtxFiles: Partial<DtxFileRow>[] =
-			linkedSimfile?.dtx_files?.map((file, index) => ({
+		const dtxFiles: SimfileDtxFile[] =
+			linkedSimfile?.dtxFiles?.map((file, index) => ({
 				...file,
 				level: file?.level !== undefined ? Number(file.level) : undefined,
-				id: (file as { id?: number })?.id ?? index + 1,
-				simfile_id: (file as { simfile_id?: number })?.simfile_id
+				id: (file as { id?: number })?.id ?? index + 1
 			})) || fallbackDtxFiles;
 
 		return {
 			title: linkedSimfile?.title || song.songTitle || song.name,
 			artist: linkedSimfile?.artist || parsedLocalData.artist,
 			bpm: linkedSimfile?.bpm ?? parsedLocalData.bpm,
-			publish_date: linkedSimfile?.publish_date || publishDate,
-			display_id: linkedSimfile?.display_id ?? displayId,
-			is_published: linkedSimfile?.is_published ?? false,
-			download_url: linkedSimfile?.download_url || downloadUrl,
-			video_preview_url: linkedSimfile?.video_preview_url || videoPreviewUrl,
-			dtx_files: dtxFiles
-		} satisfies Partial<SimfileWithDtx>;
+			publishDate: linkedSimfile?.publishDate || publishDate,
+			displayId: linkedSimfile?.displayId ?? displayId,
+			isPublished: linkedSimfile?.isPublished ?? false,
+			downloadUrl: linkedSimfile?.downloadUrl || downloadUrl,
+			videoPreviewUrl: linkedSimfile?.videoPreviewUrl || videoPreviewUrl,
+			dtxFiles
+		} satisfies Partial<SimfileModel>;
 	});
 
 	// Reset auto-populate state when switching songs to prevent stale IDs
@@ -1041,11 +1029,11 @@
 	$effect(() => {
 		const data = simfileData();
 		// Always update form values to reflect current data
-		displayId = data.display_id || 0;
-		publishDate = data.publish_date || new Date().toISOString().split('T')[0];
-		downloadUrl = data.download_url || '';
-		videoPreviewUrl = data.video_preview_url || '';
-		isPublished = data.is_published || false;
+		displayId = data.displayId || 0;
+		publishDate = data.publishDate || new Date().toISOString().split('T')[0];
+		downloadUrl = data.downloadUrl || '';
+		videoPreviewUrl = data.videoPreviewUrl || '';
+		isPublished = data.isPublished || false;
 	});
 
 	$effect(() => {
@@ -1141,14 +1129,14 @@
 						currentDriveOperation !== undefined ||
 						!$googleDriveStore.connection?.connected}
 					aria-label={$_(
-						song.linkedSimFile.google_drive_file_id
+						song.linkedSimFile.googleDriveFileId
 							? 'googleDrive.songDetails.reupload'
 							: 'googleDrive.songDetails.upload'
 					)}
 				>
 					<Upload size={16} />
 					{$_(
-						song.linkedSimFile.google_drive_file_id
+						song.linkedSimFile.googleDriveFileId
 							? 'googleDrive.songDetails.reupload'
 							: 'googleDrive.songDetails.upload'
 					)}
@@ -1164,7 +1152,7 @@
 			</div>
 		</div>
 
-		{#if song.linkedSimFile.google_drive_file_id}
+		{#if song.linkedSimFile.googleDriveFileId}
 			<p class="border-amber/40 bg-amber/10 text-amber m-4 rounded-lg border p-3 text-sm">
 				{$_('googleDrive.songDetails.linkedWarning')}
 			</p>

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -618,7 +618,7 @@
 		try {
 			const next = await simFileService.getNextDisplayId();
 			if (!Number.isSafeInteger(next)) {
-				throw new Error('Invalid next display_id response');
+				throw new Error('Invalid next displayId response');
 			}
 			// Record that we fetched for this path even if user navigated away,
 			// to prevent duplicate calls if they navigate back
@@ -631,7 +631,7 @@
 			}
 			displayIdAutoPopulateError = null;
 		} catch (error) {
-			console.warn('Failed to fetch next display_id:', error);
+			console.warn('Failed to fetch next displayId:', error);
 			// Guard against stale rejections: skip error mutation if user switched songs
 			if (song.path !== currentPath) return;
 			displayIdAutoPopulateError =
@@ -739,9 +739,9 @@
 
 		try {
 			// Build update data object
-			// Omit download_url for Drive-bound records: the Drive upload flow
+			// Omit downloadUrl for Drive-bound records: the Drive upload flow
 			// owns the URL via the guarded updateSimfileDriveFile mutation.
-			// Sending a cached download_url here would reintroduce the
+			// Sending a cached downloadUrl here would reintroduce the
 			// cross-device race where a stale URL overwrites a newer binding.
 			const isDriveBound = Boolean(targetSong.linkedSimFile?.googleDriveFileId);
 			const updateData: Record<string, unknown> = {

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.test.ts
@@ -160,13 +160,17 @@ const makeLinkedSimFile = () => ({
 	title: 'Test Song',
 	artist: 'Test Artist',
 	bpm: 120,
-	is_published: false,
-	publish_date: '2024-01-01',
-	display_id: 1,
-	download_url: '',
-	preview_url: '',
-	video_preview_url: '',
-	dtx_files: []
+	displayId: 1,
+	userId: 'test-user',
+	googleDriveFileId: null,
+	isPublished: false,
+	downloadUrl: '',
+	previewUrl: '',
+	videoPreviewUrl: '',
+	publishDate: '2024-01-01',
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-01T00:00:00Z',
+	dtxFiles: []
 });
 
 const getLastProps = <T>(mockFn: ReturnType<typeof vi.fn>): T | undefined => {
@@ -177,8 +181,8 @@ const getLastProps = <T>(mockFn: ReturnType<typeof vi.fn>): T | undefined => {
 
 type ChartDetailTestProps = {
 	simfile?: {
-		display_id?: number | null;
-		dtx_files?: Array<{ id: number; label: string; level: number; simfile_id: number }>;
+		displayId?: number | null;
+		dtxFiles?: Array<{ id: number; label: string; level: number }>;
 	};
 	desktop_info?: (anchor: Node) => void;
 	save?: (anchor: Node) => void;
@@ -342,12 +346,12 @@ describe('SongDetails', () => {
 		});
 	});
 
-	describe('isSimfileWithDtx type guard', () => {
-		it('renders with song that has dtx_files in linked simfile', () => {
+	describe('isSimfileModel type guard', () => {
+		it('renders with song that has dtxFiles in linked simfile', () => {
 			const song = makeNode('TestSong', '/test/TestSong', {
 				linkedSimFile: {
 					...makeLinkedSimFile(),
-					dtx_files: [{ id: 1, label: 'BASIC', level: 30, simfile_id: 1 }]
+					dtxFiles: [{ id: 1, label: 'BASIC', level: 30 }]
 				},
 				linkedSimFileId: '1'
 			});
@@ -453,9 +457,9 @@ describe('SongDetails', () => {
 
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.dtx_files).toEqual([
-					{ id: 1, label: 'BASIC', level: 5, simfile_id: 0 },
-					{ id: 2, label: 'EXT', level: 9, simfile_id: 0 }
+				expect(props?.simfile?.dtxFiles).toEqual([
+					{ id: 1, label: 'BASIC', level: 5 },
+					{ id: 2, label: 'EXT', level: 9 }
 				]);
 			});
 		});
@@ -584,7 +588,7 @@ describe('SongDetails', () => {
 		});
 	});
 
-	describe('auto-populate display_id', () => {
+	describe('auto-populate displayId', () => {
 		it('invokes get-next-display-id for unlinked songs when authenticated', async () => {
 			authState = { ...authState, isAuthenticated: true };
 			const invokeMock = mockHostInvoke;
@@ -614,10 +618,10 @@ describe('SongDetails', () => {
 			expect(mockHostInvoke).not.toHaveBeenCalledWith('get-next-display-id');
 		});
 
-		it('preserves a linked non-zero display_id instead of auto-populating over it', async () => {
+		it('preserves a linked non-zero displayId instead of auto-populating over it', async () => {
 			authState = { ...authState, isAuthenticated: true };
 			const song = makeNode('TestSong', '/test/TestSong', {
-				linkedSimFile: { ...makeLinkedSimFile(), display_id: 7 },
+				linkedSimFile: { ...makeLinkedSimFile(), displayId: 7 },
 				linkedSimFileId: '1'
 			});
 			render(SongDetails, { props: { song } });
@@ -625,7 +629,7 @@ describe('SongDetails', () => {
 				expect(vi.mocked(ChartDetail).mock.calls.length).toBeGreaterThan(0);
 			});
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-			expect(props?.simfile?.display_id).toBe(7);
+			expect(props?.simfile?.displayId).toBe(7);
 			expect(mockHostInvoke).not.toHaveBeenCalledWith('get-next-display-id');
 		});
 
@@ -686,7 +690,7 @@ describe('SongDetails', () => {
 			});
 		});
 
-		it('sends null displayId when saving an auto-populated display_id', async () => {
+		it('sends null displayId when saving an auto-populated displayId', async () => {
 			authState = { ...authState, isAuthenticated: true };
 			const invokeMock = mockHostInvoke;
 			if (vi.isMockFunction(invokeMock)) {
@@ -704,13 +708,13 @@ describe('SongDetails', () => {
 								title: 'TestSong',
 								artist: 'Artist',
 								bpm: 120,
-								display_id: 42,
-								is_published: false,
-								publish_date: '2024-01-01',
-								download_url: '',
-								preview_url: '',
-								video_preview_url: '',
-								dtx_files: []
+								displayId: 42,
+								isPublished: false,
+								publishDate: '2024-01-01',
+								downloadUrl: '',
+								previewUrl: '',
+								videoPreviewUrl: '',
+								dtxFiles: []
 							}
 						};
 					}
@@ -724,7 +728,7 @@ describe('SongDetails', () => {
 			});
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
@@ -797,7 +801,7 @@ describe('SongDetails', () => {
 			});
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 			const callsAfterSongA = getNextDisplayIdCallCount();
 
@@ -812,7 +816,7 @@ describe('SongDetails', () => {
 			await rerender({ props: { song: songA } });
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 			expect(getNextDisplayIdCallCount()).toBe(callsAfterSongB);
 		});
@@ -830,10 +834,10 @@ describe('SongDetails', () => {
 			const songA = makeNode('SongA', '/test/SongA');
 			const { rerender } = render(SongDetails, { props: { song: songA } });
 
-			// Wait for SongA to get display_id = 42
+			// Wait for SongA to get displayId = 42
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 
 			// Switch to SongB — displayId should reset and fetch a new value
@@ -842,8 +846,8 @@ describe('SongDetails', () => {
 
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				// SongB should get display_id = 43, not the stale 42 from SongA
-				expect(props?.simfile?.display_id).toBe(43);
+				// SongB should get displayId = 43, not the stale 42 from SongA
+				expect(props?.simfile?.displayId).toBe(43);
 			});
 		});
 
@@ -896,7 +900,7 @@ describe('SongDetails', () => {
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
 				// SongB should get 50, not the stale 99 from SongA
-				expect(props?.simfile?.display_id).toBe(50);
+				expect(props?.simfile?.displayId).toBe(50);
 			});
 		});
 
@@ -946,7 +950,7 @@ describe('SongDetails', () => {
 
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(50);
+				expect(props?.simfile?.displayId).toBe(50);
 			});
 
 			// No error banner should be visible for SongB
@@ -995,7 +999,7 @@ describe('SongDetails', () => {
 			await waitFor(() => {
 				expect(mockHostInvoke).toHaveBeenCalledWith('update-simfile-record', {
 					simfileId: '42',
-					updateData: expect.objectContaining({ display_id: 5 })
+					updateData: expect.objectContaining({ displayId: 5 })
 				});
 			});
 		});
@@ -1069,7 +1073,7 @@ describe('SongDetails', () => {
 			render(SongDetails, { props: { song } });
 			await waitFor(() => {
 				expect(
-					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.display_id
+					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.displayId
 				).toBe(42);
 			});
 
@@ -1102,8 +1106,8 @@ describe('SongDetails', () => {
 							...makeLinkedSimFile(),
 							id: 73,
 							title: 'Saved server title',
-							download_url: 'https://example.com/old.zip',
-							google_drive_file_id: 'drive-old'
+							downloadUrl: 'https://example.com/old.zip',
+							googleDriveFileId: 'drive-old'
 						}
 					};
 				}
@@ -1120,7 +1124,7 @@ describe('SongDetails', () => {
 			render(SongDetails, { props: { song } });
 			await waitFor(() => {
 				expect(
-					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.display_id
+					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.displayId
 				).toBe(42);
 			});
 
@@ -1142,8 +1146,8 @@ describe('SongDetails', () => {
 			});
 			expect(song.linkedSimFile).toMatchObject({
 				title: 'Saved server title',
-				google_drive_file_id: 'drive-new',
-				download_url: 'https://drive.google.com/uc?id=drive-new'
+				googleDriveFileId: 'drive-new',
+				downloadUrl: 'https://drive.google.com/uc?id=drive-new'
 			});
 			expect(workspaceStore.mergeGoogleDriveFields).toHaveBeenCalledWith(
 				'/test/TestSong',
@@ -1170,8 +1174,8 @@ describe('SongDetails', () => {
 			const song = makeNode('Unsaved Renderer Title', '/test/TestSong', {
 				linkedSimFile: {
 					...makeLinkedSimFile(),
-					google_drive_file_id: 'drive-old',
-					download_url: 'https://example.com/old.zip'
+					googleDriveFileId: 'drive-old',
+					downloadUrl: 'https://example.com/old.zip'
 				},
 				linkedSimFileId: '42',
 				containsDtxFiles: true
@@ -1215,8 +1219,8 @@ describe('SongDetails', () => {
 			});
 			expect(song.linkedSimFile).toMatchObject({
 				title: 'Fresh server title',
-				google_drive_file_id: 'drive-old',
-				download_url: 'https://example.com/old.zip'
+				googleDriveFileId: 'drive-old',
+				downloadUrl: 'https://example.com/old.zip'
 			});
 			expect(workspaceStore.mergeGoogleDriveFields).not.toHaveBeenCalled();
 		});
@@ -1363,7 +1367,7 @@ describe('SongDetails', () => {
 			const view = render(SongDetails, { props: { song } });
 			await waitFor(() => {
 				expect(
-					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.display_id
+					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.displayId
 				).toBe(42);
 			});
 
@@ -1445,7 +1449,7 @@ describe('SongDetails', () => {
 			const view = render(SongDetails, { props: { song: songA } });
 			await waitFor(() =>
 				expect(
-					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.display_id
+					getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail))?.simfile?.displayId
 				).toBe(42)
 			);
 
@@ -1768,8 +1772,8 @@ describe('SongDetails', () => {
 			const song = makeNode('TestSong', '/test/TestSong', {
 				linkedSimFile: {
 					...makeLinkedSimFile(),
-					google_drive_file_id: 'drive-old',
-					download_url: 'https://example.com/manual.zip'
+					googleDriveFileId: 'drive-old',
+					downloadUrl: 'https://example.com/manual.zip'
 				},
 				linkedSimFileId: '42',
 				containsDtxFiles: true
@@ -1821,8 +1825,8 @@ describe('SongDetails', () => {
 			const song = makeNode('TestSong', '/test/TestSong', {
 				linkedSimFile: {
 					...makeLinkedSimFile(),
-					google_drive_file_id: 'drive-old',
-					download_url: 'https://example.com/manual.zip'
+					googleDriveFileId: 'drive-old',
+					downloadUrl: 'https://example.com/manual.zip'
 				},
 				linkedSimFileId: '42',
 				containsDtxFiles: true
@@ -1834,7 +1838,7 @@ describe('SongDetails', () => {
 					/next successful Drive upload will replace the download URL/
 				)
 			).toBeInTheDocument();
-			expect(song.linkedSimFile?.google_drive_file_id).toBe('drive-old');
+			expect(song.linkedSimFile?.googleDriveFileId).toBe('drive-old');
 			expect(screen.queryByRole('button', { name: /unlink|delete associated/i })).toBeNull();
 
 			googleDriveStore.setConnection({ connected: false });
@@ -1844,8 +1848,8 @@ describe('SongDetails', () => {
 					return {
 						success: true,
 						data: {
-							google_drive_file_id: 'drive-old',
-							download_url: ''
+							googleDriveFileId: 'drive-old',
+							downloadUrl: ''
 						}
 					};
 				}
@@ -1863,8 +1867,8 @@ describe('SongDetails', () => {
 			});
 
 			await waitFor(() => {
-				expect(song.linkedSimFile?.google_drive_file_id).toBe('drive-old');
-				expect(song.linkedSimFile?.download_url).toBe('');
+				expect(song.linkedSimFile?.googleDriveFileId).toBe('drive-old');
+				expect(song.linkedSimFile?.downloadUrl).toBe('');
 			});
 			expect(mockDesktopHost.uploadSongZipToGoogleDrive).not.toHaveBeenCalled();
 		});
@@ -2044,7 +2048,7 @@ describe('SongDetails', () => {
 			const song = makeNode('TestSong', '/test/TestSong', {
 				linkedSimFile: {
 					...makeLinkedSimFile(),
-					google_drive_file_id: 'drive-old'
+					googleDriveFileId: 'drive-old'
 				},
 				linkedSimFileId: '42',
 				containsDtxFiles: true
@@ -2120,13 +2124,13 @@ describe('SongDetails', () => {
 								title: 'TestSong',
 								artist: 'Artist',
 								bpm: 120,
-								display_id: 42,
-								is_published: false,
-								publish_date: '2024-01-01',
-								download_url: '',
-								preview_url: '',
-								video_preview_url: '',
-								dtx_files: []
+								displayId: 42,
+								isPublished: false,
+								publishDate: '2024-01-01',
+								downloadUrl: '',
+								previewUrl: '',
+								videoPreviewUrl: '',
+								dtxFiles: []
 							}
 						};
 					}
@@ -2140,7 +2144,7 @@ describe('SongDetails', () => {
 			});
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
@@ -2195,13 +2199,13 @@ describe('SongDetails', () => {
 								title: 'TestSong',
 								artist: 'Artist',
 								bpm: 120,
-								display_id: 42,
-								is_published: true,
-								publish_date: '2024-01-01',
-								download_url: '',
-								preview_url: '',
-								video_preview_url: '',
-								dtx_files: []
+								displayId: 42,
+								isPublished: true,
+								publishDate: '2024-01-01',
+								downloadUrl: '',
+								previewUrl: '',
+								videoPreviewUrl: '',
+								dtxFiles: []
 							}
 						};
 					}
@@ -2212,7 +2216,7 @@ describe('SongDetails', () => {
 			render(SongDetails, { props: { song } });
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
@@ -2250,7 +2254,7 @@ describe('SongDetails', () => {
 			render(SongDetails, { props: { song } });
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
@@ -2288,13 +2292,13 @@ describe('SongDetails', () => {
 								title: 'Linked Song',
 								artist: 'Cloud Artist',
 								bpm: 130,
-								is_published: false,
-								publish_date: '2024-01-01',
-								display_id: 77,
-								download_url: '',
-								preview_url: '',
-								video_preview_url: '',
-								dtx_files: []
+								isPublished: false,
+								publishDate: '2024-01-01',
+								displayId: 77,
+								downloadUrl: '',
+								previewUrl: '',
+								videoPreviewUrl: '',
+								dtxFiles: []
 							}
 						};
 					}
@@ -2316,7 +2320,7 @@ describe('SongDetails', () => {
 					id: string;
 					title: string;
 					artist: string;
-					is_published: boolean;
+					isPublished: boolean;
 				}) => void;
 			};
 
@@ -2324,7 +2328,7 @@ describe('SongDetails', () => {
 				id: '77',
 				title: 'Linked Song',
 				artist: 'Cloud Artist',
-				is_published: false
+				isPublished: false
 			});
 
 			await waitFor(() => {
@@ -2359,11 +2363,11 @@ describe('SongDetails', () => {
 					id: string;
 					title: string;
 					artist: string;
-					is_published: boolean;
+					isPublished: boolean;
 				}) => void;
 			};
 
-			props?.onselect?.({ id: '77', title: 'Song', artist: 'Artist', is_published: false });
+			props?.onselect?.({ id: '77', title: 'Song', artist: 'Artist', isPublished: false });
 
 			await waitFor(() => {
 				expect(mockHostInvoke).toHaveBeenCalledWith('fetch-cloud-song', {
@@ -2544,13 +2548,13 @@ describe('SongDetails', () => {
 								title: 'TestSong',
 								artist: 'Artist',
 								bpm: 120,
-								display_id: 42,
-								is_published: false,
-								publish_date: '2024-01-01',
-								download_url: '',
-								preview_url: '',
-								video_preview_url: '',
-								dtx_files: []
+								displayId: 42,
+								isPublished: false,
+								publishDate: '2024-01-01',
+								downloadUrl: '',
+								previewUrl: '',
+								videoPreviewUrl: '',
+								dtxFiles: []
 							},
 							warnings: ['Preview image: file not found', 'Sound preview: too large']
 						};
@@ -2566,7 +2570,7 @@ describe('SongDetails', () => {
 			});
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
@@ -2632,7 +2636,7 @@ describe('SongDetails', () => {
 
 			await waitFor(() => {
 				const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
-				expect(props?.simfile?.display_id).toBe(42);
+				expect(props?.simfile?.displayId).toBe(42);
 			});
 			const props = getLastProps<ChartDetailTestProps>(vi.mocked(ChartDetail));
 			await props?.$$events?.onSave?.({
@@ -2658,7 +2662,7 @@ describe('SongDetails', () => {
 		});
 	});
 
-	describe('display_id auto-populate retry', () => {
+	describe('displayId auto-populate retry', () => {
 		it('re-fetches next display id when retry handler fires after a failure', async () => {
 			// populateNextDisplayId caches failures as displayIdAutoPopulateError;
 			// the renderer exposes a Retry button that re-invokes the IPC.

--- a/packages/dtx-desktop/src/renderer/src/components/Workspace.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/Workspace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 import type { TreeNode, ShellSection } from '../stores/workspaceStore';
 
 vi.mock('@lucide/svelte');
@@ -14,7 +14,7 @@ vi.mock('../stores/workspaceStore', () => {
 		isLoading: false,
 		error: null as string | null,
 		selectedSong: null as TreeNode | null,
-		selectedCloudSimFile: null as SimfileWithDtx | null,
+		selectedCloudSimFile: null as SimfileModel | null,
 		showCloudSongDetails: false,
 		showNewSong: false,
 		activeSection: 'library' as ShellSection

--- a/packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.svelte
@@ -9,12 +9,12 @@
 	import { buildCommands, type Command } from '../../commands/commands';
 	import { searchItems } from '../../lib/fuzzy';
 	import { toastStore } from '../../stores/toastStore';
-	import type { SimfileWithDtx } from '@dtx/common';
+	import type { SimfileModel } from '@dtx/common';
 
 	type FlatResult =
 		| { kind: 'command'; c: Command }
 		| { kind: 'song'; s: TreeNode }
-		| { kind: 'cloud'; s: SimfileWithDtx };
+		| { kind: 'cloud'; s: SimfileModel };
 
 	interface Props {
 		open: boolean;

--- a/packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/components/shell/CommandPalette.test.ts
@@ -5,7 +5,7 @@ import { workspaceStore } from '../../stores/workspaceStore';
 import { simFileStore } from '../../stores/simFileStore';
 import { toastStore } from '../../stores/toastStore';
 import { get } from 'svelte/store';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 vi.mock('@lucide/svelte');
 vi.mock('../../services/authService', () => ({ authService: { login: vi.fn(), logout: vi.fn() } }));
@@ -23,17 +23,20 @@ vi.mock('../../services/workspaceService', () => ({
 import CommandPalette from './CommandPalette.svelte';
 import { exportSelectedSong } from '../../services/exportService';
 
-const makeCloudSimFile = (overrides: Partial<SimfileWithDtx> = {}): SimfileWithDtx =>
+const makeCloudSimFile = (overrides: Partial<SimfileModel> = {}): SimfileModel =>
 	({
 		id: 1,
 		title: 'Cloud Anthem',
 		artist: 'Cloud Artist',
 		bpm: 120,
-		is_published: false,
-		publish_date: null,
-		dtx_files: [],
+		displayId: null,
+		userId: 'test-user',
+		googleDriveFileId: null,
+		isPublished: false,
+		publishDate: null,
+		dtxFiles: [],
 		...overrides
-	}) as SimfileWithDtx;
+	}) as SimfileModel;
 
 describe('CommandPalette', () => {
 	beforeEach(() => {

--- a/packages/dtx-desktop/src/renderer/src/lib/scoreTypes.ts
+++ b/packages/dtx-desktop/src/renderer/src/lib/scoreTypes.ts
@@ -1,3 +1,4 @@
+import type { SimfileModel } from '@dtx/common';
 import type { CloudChart } from './scoreMatching';
 
 export interface ScorePayload {
@@ -48,7 +49,7 @@ export interface CloudSong {
 	id: string;
 	title: string;
 	artist: string;
-	is_published: boolean;
+	isPublished: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,21 +85,14 @@ export interface UploadScoresData {
 	skipped: SkippedChart[];
 }
 
-/** Raw `cloudSongData` shape returned by the `fetch_cloud_song` IPC command. */
-export interface CloudSongData {
-	id: number;
-	title: string;
-	artist: string;
-	is_published: boolean;
-}
-
 /**
  * `fetch_cloud_song` envelope. Uses `cloudSongData` (not `data`) to match the
  * Rust side (api.rs:817-820). Generic over the payload shape so call sites
  * that need richer simfile fields (e.g. SongDetails.svelte) can substitute
- * their own type while sharing the envelope structure.
+ * their own type while sharing the envelope structure. Defaults to the
+ * current full `SimfileModel` shape the native boundary emits.
  */
-export interface FetchCloudSongResult<T = CloudSongData> {
+export interface FetchCloudSongResult<T = SimfileModel> {
 	success: boolean;
 	cloudSongData?: T;
 	error?: string;

--- a/packages/dtx-desktop/src/renderer/src/services/linkageCacheService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/linkageCacheService.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { linkageCacheService } from './linkageCacheService';
-import type { SimfileWithDtx } from '@dtx/common';
 
 // Mock localStorage
 const localStorageMock = {
@@ -10,21 +9,24 @@ const localStorageMock = {
 	clear: vi.fn()
 };
 
-const sampleSimfile: SimfileWithDtx = {
+// Current-model (camelCase) simfile shape, mirroring what the native boundary
+// emits (src-tauri/tests/fixtures/simfile_model.json).
+const sampleSimfile = {
 	id: 1,
 	title: 'Test Song',
 	artist: 'Artist',
 	bpm: 120,
-	preview_url: null,
-	download_url: null,
-	is_published: false,
-	display_id: null,
-	publish_date: '2024-01-01',
-	video_preview_url: null,
-	created_at: '2024-01-01T00:00:00Z',
-	updated_at: '2024-01-01T00:00:00Z',
-	user_id: 'test-user-id',
-	dtx_files: []
+	displayId: null,
+	userId: 'test-user-id',
+	googleDriveFileId: null,
+	isPublished: false,
+	downloadUrl: null,
+	previewUrl: null,
+	videoPreviewUrl: null,
+	publishDate: '2024-01-01',
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-01T00:00:00Z',
+	dtxFiles: []
 };
 
 // Replace global localStorage with mock
@@ -49,7 +51,7 @@ describe('linkageCacheService', () => {
 			linkageCacheService.saveLinkage(songPath, cloudSongId, cloudSongData);
 
 			expect(localStorageMock.setItem).toHaveBeenCalledWith(
-				'dtx_linkage_cache',
+				'dtx_linkage_cache_v2',
 				expect.stringContaining(songPath)
 			);
 
@@ -113,6 +115,38 @@ describe('linkageCacheService', () => {
 			const result = linkageCacheService.getLinkage('/path');
 			expect(result).toBeNull();
 		});
+
+		it('ignores a legacy cache seeded under the v1 key', () => {
+			// A previous app version wrote linkage entries (old snake_case
+			// shape) under 'dtx_linkage_cache'. The v2 service must not read,
+			// migrate, or delete it — every read misses.
+			localStorageMock.getItem.mockImplementation((key: string) => {
+				if (key !== 'dtx_linkage_cache') return null;
+				return JSON.stringify({
+					'/path/to/song': {
+						linkedSimFileId: 'song123',
+						linkedAt: '2025-06-28T12:00:00.000Z',
+						cloudSongData: { id: 1, title: 'Old Shape', is_published: false }
+					}
+				});
+			});
+
+			expect(linkageCacheService.getLinkage('/path/to/song')).toBeNull();
+			expect(linkageCacheService.hasLinkage('/path/to/song')).toBe(false);
+			expect(linkageCacheService.getLinkedSongPaths()).toEqual([]);
+
+			// saveLinkage must start from an empty v2 cache, not inherit v1 entries
+			linkageCacheService.saveLinkage('/new/path', 'song123', sampleSimfile);
+			const savedData = JSON.parse(localStorageMock.setItem.mock.calls[0][1]);
+			expect(savedData).toEqual({
+				'/new/path': {
+					linkedSimFileId: 'song123',
+					linkedAt: expect.any(String),
+					cloudSongData: sampleSimfile
+				}
+			});
+			expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('dtx_linkage_cache');
+		});
 	});
 
 	describe('removeLinkage', () => {
@@ -168,7 +202,7 @@ describe('linkageCacheService', () => {
 		it('should remove the entire cache from localStorage', () => {
 			linkageCacheService.clearCache();
 
-			expect(localStorageMock.removeItem).toHaveBeenCalledWith('dtx_linkage_cache');
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('dtx_linkage_cache_v2');
 		});
 	});
 

--- a/packages/dtx-desktop/src/renderer/src/services/linkageCacheService.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/linkageCacheService.ts
@@ -1,16 +1,19 @@
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 interface LinkageData {
 	linkedSimFileId: string;
 	linkedAt: string;
-	cloudSongData: SimfileWithDtx;
+	cloudSongData: SimfileModel;
 }
 
 interface LinkageCache {
 	[songPath: string]: LinkageData;
 }
 
-const LINKAGE_CACHE_KEY = 'dtx_linkage_cache';
+// v2: stores the current SimfileModel-shaped cloudSongData. The v1 key
+// ('dtx_linkage_cache') held the legacy snake_case shape and is deliberately
+// left untouched — no read, migration, or deletion.
+const LINKAGE_CACHE_KEY = 'dtx_linkage_cache_v2';
 
 export const linkageCacheService = {
 	/**
@@ -19,7 +22,7 @@ export const linkageCacheService = {
 	saveLinkage: (
 		songPath: string,
 		cloudSongId: string | number,
-		cloudSongData: SimfileWithDtx
+		cloudSongData: SimfileModel
 	): void => {
 		try {
 			const cache = linkageCacheService.getCache();

--- a/packages/dtx-desktop/src/renderer/src/services/linkingService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/linkingService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { linkingService } from './linkingService';
 import { workspaceStore } from '../stores/workspaceStore';
 import type { TreeNode } from '../stores/workspaceStore';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 // Mock the workspace store
 vi.mock('../stores/workspaceStore', () => ({
@@ -137,38 +137,40 @@ describe('LinkingService', () => {
 	});
 
 	describe('findMatchingSimFile', () => {
-		const mockSimFiles: SimfileWithDtx[] = [
+		const mockSimFiles: SimfileModel[] = [
 			{
 				id: 1,
 				title: 'Test Song',
 				artist: 'Test Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'test-user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'test-user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			},
 			{
 				id: 2,
 				title: 'Test Song Extended Version',
 				artist: 'Test Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'test-user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'test-user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			}
 		];
 
@@ -241,38 +243,40 @@ describe('LinkingService', () => {
 		});
 
 		it('should match Japanese titles exactly', () => {
-			const japaneseSimFiles: SimfileWithDtx[] = [
+			const japaneseSimFiles: SimfileModel[] = [
 				{
 					id: 1,
 					title: '千本桜',
 					artist: 'Test Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'test-user-id',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'test-user-id',
+					googleDriveFileId: null,
+					dtxFiles: []
 				},
 				{
 					id: 2,
 					title: 'ボーカロイド',
 					artist: 'Test Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'test-user-id',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'test-user-id',
+					googleDriveFileId: null,
+					dtxFiles: []
 				}
 			];
 
@@ -293,22 +297,23 @@ describe('LinkingService', () => {
 		});
 
 		it('should match mixed Japanese and ASCII titles', () => {
-			const mixedSimFiles: SimfileWithDtx[] = [
+			const mixedSimFiles: SimfileModel[] = [
 				{
 					id: 1,
 					title: 'BEMANI 音楽',
 					artist: 'Test Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'test-user-id',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'test-user-id',
+					googleDriveFileId: null,
+					dtxFiles: []
 				}
 			];
 
@@ -331,22 +336,23 @@ describe('LinkingService', () => {
 
 	describe('autoLinkSimFilesToFolders', () => {
 		it('should link matching folders to simFiles', () => {
-			const mockSimFiles: SimfileWithDtx[] = [
+			const mockSimFiles: SimfileModel[] = [
 				{
 					id: 1,
 					title: 'Test Song',
 					artist: 'Test Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'test-user-id',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'test-user-id',
+					googleDriveFileId: null,
+					dtxFiles: []
 				}
 			];
 
@@ -372,22 +378,23 @@ describe('LinkingService', () => {
 		});
 
 		it('should not link already linked folders', () => {
-			const mockSimFiles: SimfileWithDtx[] = [
+			const mockSimFiles: SimfileModel[] = [
 				{
 					id: 1,
 					title: 'Test Song',
 					artist: 'Test Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'test-user-id',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'test-user-id',
+					googleDriveFileId: null,
+					dtxFiles: []
 				}
 			];
 
@@ -413,22 +420,23 @@ describe('LinkingService', () => {
 
 	describe('linkSimFilesToNewNodes', () => {
 		it('should link newly loaded folders to simFiles', () => {
-			const mockSimFiles: SimfileWithDtx[] = [
+			const mockSimFiles: SimfileModel[] = [
 				{
 					id: 1,
 					title: 'New Song',
 					artist: 'Test Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'test-user-id',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'test-user-id',
+					googleDriveFileId: null,
+					dtxFiles: []
 				}
 			];
 
@@ -484,16 +492,17 @@ describe('LinkingService', () => {
 				title: null as unknown as string,
 				artist: 'Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			};
 
 			const result = linkingService.findMatchingFolder(simFile, mockFolders);
@@ -506,16 +515,17 @@ describe('LinkingService', () => {
 				title: 'Test Song',
 				artist: 'Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			};
 
 			const result = linkingService.findMatchingFolder(simFile, mockFolders);
@@ -529,16 +539,17 @@ describe('LinkingService', () => {
 				title: 'Test Song Extended',
 				artist: 'Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			};
 
 			const result = linkingService.findMatchingFolder(simFile, mockFolders);
@@ -551,16 +562,17 @@ describe('LinkingService', () => {
 				title: 'Completely Different Song XYZ',
 				artist: 'Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			};
 
 			const result = linkingService.findMatchingFolder(simFile, mockFolders);
@@ -585,16 +597,17 @@ describe('LinkingService', () => {
 				title: 'Any Song',
 				artist: 'Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			};
 
 			const result = linkingService.findMatchingFolder(simFile, foldersWithoutTitles);
@@ -627,16 +640,17 @@ describe('LinkingService', () => {
 				title: 'Test Song',
 				artist: 'Test Artist',
 				bpm: 120,
-				preview_url: null,
-				download_url: null,
-				is_published: true,
-				display_id: null,
-				publish_date: '2024-01-01',
-				video_preview_url: null,
-				created_at: '2024-01-01T00:00:00Z',
-				updated_at: '2024-01-01T00:00:00Z',
-				user_id: 'test-user-id',
-				dtx_files: []
+				previewUrl: null,
+				downloadUrl: null,
+				isPublished: true,
+				displayId: null,
+				publishDate: '2024-01-01',
+				videoPreviewUrl: null,
+				createdAt: '2024-01-01T00:00:00Z',
+				updatedAt: '2024-01-01T00:00:00Z',
+				userId: 'test-user-id',
+				googleDriveFileId: null,
+				dtxFiles: []
 			};
 
 			linkingService.linkSimFileToFolder(simFile, '/path/to/folder');
@@ -669,22 +683,23 @@ describe('LinkingService', () => {
 
 	describe('linkSimFilesToNewNodes - already linked folder', () => {
 		it('should skip folders that already have a linked simFile', () => {
-			const mockSimFiles: SimfileWithDtx[] = [
+			const mockSimFiles: SimfileModel[] = [
 				{
 					id: 1,
 					title: 'Song',
 					artist: 'Artist',
 					bpm: 120,
-					preview_url: null,
-					download_url: null,
-					is_published: true,
-					display_id: null,
-					publish_date: '2024-01-01',
-					video_preview_url: null,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					user_id: 'user',
-					dtx_files: []
+					previewUrl: null,
+					downloadUrl: null,
+					isPublished: true,
+					displayId: null,
+					publishDate: '2024-01-01',
+					videoPreviewUrl: null,
+					createdAt: '2024-01-01T00:00:00Z',
+					updatedAt: '2024-01-01T00:00:00Z',
+					userId: 'user',
+					googleDriveFileId: null,
+					dtxFiles: []
 				}
 			];
 

--- a/packages/dtx-desktop/src/renderer/src/services/linkingService.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/linkingService.ts
@@ -1,5 +1,5 @@
 import { workspaceStore, type TreeNode } from '../stores/workspaceStore';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 export const linkingService = {
 	/**
@@ -7,10 +7,7 @@ export const linkingService = {
 	 * @param remoteSimFiles Array of remote simFiles from Supabase
 	 * @param localFolders Array of local folder TreeNodes with song titles
 	 */
-	autoLinkSimFilesToFolders: (
-		remoteSimFiles: SimfileWithDtx[],
-		localFolders: TreeNode[]
-	): void => {
+	autoLinkSimFilesToFolders: (remoteSimFiles: SimfileModel[], localFolders: TreeNode[]): void => {
 		console.log('Starting automatic linking process...');
 		console.log(
 			`Remote simFiles: ${remoteSimFiles.length}, Local folders: ${localFolders.length}`
@@ -77,7 +74,7 @@ export const linkingService = {
 	 * @param localFolders Array of local folders with song titles
 	 * @returns Matching TreeNode or null if no match found
 	 */
-	findMatchingFolder: (simFile: SimfileWithDtx, localFolders: TreeNode[]): TreeNode | null => {
+	findMatchingFolder: (simFile: SimfileModel, localFolders: TreeNode[]): TreeNode | null => {
 		if (!simFile.title) {
 			return null;
 		}
@@ -109,12 +106,12 @@ export const linkingService = {
 	 * Finds a remote simFile that matches the given local folder by song title
 	 * @param folder Local folder to match
 	 * @param remoteSimFiles Array of remote simFiles
-	 * @returns Matching SimfileWithDtx or null if no match found
+	 * @returns Matching SimfileModel or null if no match found
 	 */
 	findMatchingSimFile: (
 		folder: TreeNode,
-		remoteSimFiles: SimfileWithDtx[]
-	): SimfileWithDtx | null => {
+		remoteSimFiles: SimfileModel[]
+	): SimfileModel | null => {
 		if (!folder.songTitle) {
 			return null;
 		}
@@ -131,7 +128,7 @@ export const linkingService = {
 
 		// If no exact match, try fuzzy matching and find the best match
 		if (!match) {
-			let bestMatch: SimfileWithDtx | null = null;
+			let bestMatch: SimfileModel | null = null;
 			let bestSimilarity = 0;
 
 			remoteSimFiles.forEach((simFile) => {
@@ -243,7 +240,7 @@ export const linkingService = {
 	 * @param simFile SimFile to link
 	 * @param folderPath Path of the folder to link to
 	 */
-	linkSimFileToFolder: (simFile: SimfileWithDtx, folderPath: string): void => {
+	linkSimFileToFolder: (simFile: SimfileModel, folderPath: string): void => {
 		console.log(`Manually linking simFile "${simFile.title}" to folder "${folderPath}"`);
 		workspaceStore.linkSimFileToFolder(folderPath, simFile);
 	},
@@ -262,7 +259,7 @@ export const linkingService = {
 	 * @param remoteSimFiles Array of remote simFiles from Supabase
 	 * @param newNodes Array of newly loaded TreeNodes
 	 */
-	linkSimFilesToNewNodes: (remoteSimFiles: SimfileWithDtx[], newNodes: TreeNode[]): void => {
+	linkSimFilesToNewNodes: (remoteSimFiles: SimfileModel[], newNodes: TreeNode[]): void => {
 		console.log('Linking simFiles to newly loaded nodes...');
 		console.log(`Remote simFiles: ${remoteSimFiles.length}, New nodes: ${newNodes.length}`);
 

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
@@ -259,7 +259,7 @@ describe('SimFileService', () => {
 		it('rejects invalid IPC response shapes', async () => {
 			host.getNextDisplayId.mockResolvedValue(undefined);
 			await expect(simFileService.getNextDisplayId()).rejects.toThrow(
-				'Invalid next display_id response'
+				'Invalid next displayId response'
 			);
 		});
 	});

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
@@ -242,7 +242,7 @@ describe('SimFileService', () => {
 	});
 
 	describe('getNextDisplayId', () => {
-		it('returns the next display_id from IPC', async () => {
+		it('returns the next displayId from IPC', async () => {
 			host.getNextDisplayId.mockResolvedValue(7);
 
 			const result = await simFileService.getNextDisplayId();

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { simFileService } from './simFileService';
 import { desktopHost } from './desktopHost';
 
@@ -12,6 +14,15 @@ vi.mock('./desktopHost', () => ({
 }));
 
 const host = vi.mocked(desktopHost);
+
+// Shared behavioral seam: the exact camelCase full-simfile JSON emitted by
+// the native boundary (src-tauri/tests/fixtures/simfile_model.json). Read at
+// runtime with Node so tests stay excluded from the production typecheck
+// (tsconfig.web.json). This test asserts the renderer reads the current
+// model's field names off real native-shaped traffic.
+const sharedSimfileFixture = JSON.parse(
+	readFileSync(resolve(process.cwd(), 'src-tauri/tests/fixtures/simfile_model.json'), 'utf8')
+);
 
 // Mock localStorage
 const localStorageMock = {
@@ -34,32 +45,29 @@ describe('SimFileService', () => {
 
 	describe('fetchUserSimFiles', () => {
 		it('should fetch user simFiles from the Rust backend', async () => {
-			const mockData = [
-				{
-					id: '1',
-					title: 'Test Song',
-					artist: 'Test Artist',
-					bpm: 120,
-					dtx_files: [{ level: 5 }]
-				}
-			];
-
 			host.fetchUserSimfiles.mockResolvedValue({
 				success: true,
-				data: mockData,
+				data: [sharedSimfileFixture],
 				fromCache: false
 			});
 
 			const result = await simFileService.fetchUserSimFiles();
 
 			expect(host.fetchUserSimfiles).toHaveBeenCalledWith();
-			expect(result.data).toEqual(mockData);
+			expect(result.data).toEqual([sharedSimfileFixture]);
+			// Renderer code reads the current-model field names of the native payload
+			expect(result.data[0].title).toBe('Fixture Song');
+			expect(result.data[0].artist).toBe('Fixture Artist');
+			expect(result.data[0].bpm).toBe(123.5);
+			expect(result.data[0].isPublished).toBe(true);
+			expect(result.data[0].publishDate).toBe('2026-08-15');
+			expect(result.data[0].dtxFiles).toEqual([{ id: 99, label: 'EXT', level: 85 }]);
 			expect(result.fromCache).toBe(false);
 			expect(result.error).toBeUndefined();
 		});
 
 		it('should return cached data when available', async () => {
-			const cachedData = [{ id: '1', title: 'Cached Song' }];
+			const cachedData = [sharedSimfileFixture];
 			const cacheTimestamp = Date.now().toString();
 
 			localStorageMock.getItem
@@ -70,6 +78,7 @@ describe('SimFileService', () => {
 
 			expect(host.fetchUserSimfiles).not.toHaveBeenCalled();
 			expect(result.data).toEqual(cachedData);
+			expect(result.data[0].title).toBe('Fixture Song');
 			expect(result.fromCache).toBe(true);
 		});
 
@@ -100,8 +109,36 @@ describe('SimFileService', () => {
 
 			await simFileService.fetchUserSimFiles();
 
-			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache');
-			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache_timestamp');
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache_v2');
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache_timestamp_v2');
+		});
+
+		it('ignores a valid-looking legacy cache under the v1 key and still calls IPC', async () => {
+			// A previous app version cached the old snake_case shape under
+			// 'simfiles_cache'. The v2 service must not read, migrate, or
+			// delete it — it simply misses and falls through to IPC.
+			localStorageMock.getItem.mockImplementation((key: string) => {
+				if (key === 'simfiles_cache') {
+					return JSON.stringify([{ id: 1, title: 'Old Shape', is_published: false }]);
+				}
+				if (key === 'simfiles_cache_timestamp') return Date.now().toString();
+				return null;
+			});
+
+			host.fetchUserSimfiles.mockResolvedValue({
+				success: true,
+				data: [sharedSimfileFixture],
+				fromCache: false
+			});
+
+			const result = await simFileService.fetchUserSimFiles();
+
+			expect(host.fetchUserSimfiles).toHaveBeenCalledWith();
+			expect(result.data).toEqual([sharedSimfileFixture]);
+			expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('simfiles_cache');
+			expect(localStorageMock.removeItem).not.toHaveBeenCalledWith(
+				'simfiles_cache_timestamp'
+			);
 		});
 	});
 
@@ -109,12 +146,12 @@ describe('SimFileService', () => {
 		it('should clear cache', () => {
 			simFileService.clearCache();
 
-			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache');
-			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache_timestamp');
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache_v2');
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith('simfiles_cache_timestamp_v2');
 		});
 
 		it('should refresh user simFiles by clearing cache and fetching new data', async () => {
-			const mockData = [{ id: '1', title: 'Refreshed Song' }];
+			const mockData = [{ id: 1, title: 'Refreshed Song' }];
 			host.fetchUserSimfiles.mockResolvedValue({
 				success: true,
 				data: mockData,
@@ -130,7 +167,7 @@ describe('SimFileService', () => {
 		it('should fall through to IPC when cache timestamp is expired', async () => {
 			const expiredTimestamp = (Date.now() - 10 * 60 * 1000).toString();
 			localStorageMock.getItem
-				.mockReturnValueOnce(JSON.stringify([{ id: '1' }]))
+				.mockReturnValueOnce(JSON.stringify([{ id: 1 }]))
 				.mockReturnValueOnce(expiredTimestamp);
 
 			host.fetchUserSimfiles.mockResolvedValue({ success: true, data: [], fromCache: false });
@@ -147,7 +184,7 @@ describe('SimFileService', () => {
 			});
 			host.fetchUserSimfiles.mockResolvedValue({
 				success: true,
-				data: [{ id: '1', title: 'Test' }],
+				data: [{ id: 1, title: 'Test' }],
 				fromCache: false
 			});
 

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
@@ -1,26 +1,29 @@
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 import { desktopHost } from './desktopHost';
 
-const CACHE_KEY = 'simfiles_cache';
-const CACHE_TIMESTAMP_KEY = 'simfiles_cache_timestamp';
+// v2: current SimfileModel-shaped cache. The v1 keys ('simfiles_cache' /
+// 'simfiles_cache_timestamp') held the legacy snake_case shape and are
+// deliberately left untouched — no read, migration, or deletion.
+const CACHE_KEY = 'simfiles_cache_v2';
+const CACHE_TIMESTAMP_KEY = 'simfiles_cache_timestamp_v2';
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
 
 // Match the discriminated union type from Rust backend
 type MainProcessSimFileResult =
 	| {
 			success: true;
-			data: SimfileWithDtx[];
+			data: SimfileModel[];
 			fromCache: boolean;
 	  }
 	| {
 			success: false;
 			error: string;
-			data: SimfileWithDtx[];
+			data: SimfileModel[];
 			fromCache: boolean;
 	  };
 
 export interface SimFileServiceResult {
-	data: SimfileWithDtx[];
+	data: SimfileModel[];
 	fromCache: boolean;
 	error?: string;
 }
@@ -75,7 +78,7 @@ class SimFileService {
 	private getCachedData(
 		cacheKey: string = CACHE_KEY,
 		timestampKey: string = CACHE_TIMESTAMP_KEY
-	): SimfileWithDtx[] | null {
+	): SimfileModel[] | null {
 		try {
 			const cachedData = localStorage.getItem(cacheKey);
 			const cacheTimestamp = localStorage.getItem(timestampKey);
@@ -109,7 +112,7 @@ class SimFileService {
 	 * Caches simFiles data in localStorage
 	 */
 	private setCachedData(
-		data: SimfileWithDtx[],
+		data: SimfileModel[],
 		cacheKey: string = CACHE_KEY,
 		timestampKey: string = CACHE_TIMESTAMP_KEY
 	): void {

--- a/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/simFileService.ts
@@ -143,7 +143,7 @@ class SimFileService {
 	async getNextDisplayId(): Promise<number> {
 		const result = await desktopHost.getNextDisplayId();
 		if (typeof result !== 'number' || !Number.isSafeInteger(result)) {
-			throw new Error('Invalid next display_id response');
+			throw new Error('Invalid next displayId response');
 		}
 		return result;
 	}

--- a/packages/dtx-desktop/src/renderer/src/stores/simFileStore.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/stores/simFileStore.test.ts
@@ -1,23 +1,24 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { simFileStore } from './simFileStore';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
-const makeSimFile = (id: number, title: string = `Song ${id}`): SimfileWithDtx => ({
+const makeSimFile = (id: number, title: string = `Song ${id}`): SimfileModel => ({
 	id,
 	title,
 	artist: 'Artist',
 	bpm: 120,
-	preview_url: null,
-	download_url: null,
-	is_published: false,
-	display_id: null,
-	publish_date: '2024-01-01',
-	video_preview_url: null,
-	created_at: '2024-01-01T00:00:00Z',
-	updated_at: '2024-01-01T00:00:00Z',
-	user_id: 'test-user',
-	dtx_files: []
+	previewUrl: null,
+	downloadUrl: null,
+	isPublished: false,
+	displayId: null,
+	publishDate: '2024-01-01',
+	videoPreviewUrl: null,
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-01T00:00:00Z',
+	userId: 'test-user',
+	googleDriveFileId: null,
+	dtxFiles: []
 });
 
 describe('simFileStore', () => {

--- a/packages/dtx-desktop/src/renderer/src/stores/simFileStore.ts
+++ b/packages/dtx-desktop/src/renderer/src/stores/simFileStore.ts
@@ -1,8 +1,8 @@
 import { writable } from 'svelte/store';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 
 export interface SimFileState {
-	userSimFiles: SimfileWithDtx[];
+	userSimFiles: SimfileModel[];
 	isLoading: boolean;
 	error: string | null;
 	lastUpdated: Date | null;
@@ -39,7 +39,7 @@ function createSimFileStore() {
 		},
 
 		// Set user simFiles
-		setUserSimFiles: (userSimFiles: SimfileWithDtx[], fromCache: boolean = false) => {
+		setUserSimFiles: (userSimFiles: SimfileModel[], fromCache: boolean = false) => {
 			update((state) => ({
 				...state,
 				userSimFiles,
@@ -51,7 +51,7 @@ function createSimFileStore() {
 		},
 
 		// Add a new simFile to user simFiles
-		addUserSimFile: (simFile: SimfileWithDtx) => {
+		addUserSimFile: (simFile: SimfileModel) => {
 			update((state) => ({
 				...state,
 				userSimFiles: [simFile, ...state.userSimFiles],
@@ -60,7 +60,7 @@ function createSimFileStore() {
 		},
 
 		// Update an existing simFile
-		updateUserSimFile: (updatedSimFile: SimfileWithDtx) => {
+		updateUserSimFile: (updatedSimFile: SimfileModel) => {
 			update((state) => ({
 				...state,
 				userSimFiles: state.userSimFiles.map((simFile) =>
@@ -80,8 +80,8 @@ function createSimFileStore() {
 		},
 
 		// Filter user simFiles by criteria
-		filterUserSimFiles: (filterFn: (simFile: SimfileWithDtx) => boolean) => {
-			let filteredSimFiles: SimfileWithDtx[] = [];
+		filterUserSimFiles: (filterFn: (simFile: SimfileModel) => boolean) => {
+			let filteredSimFiles: SimfileModel[] = [];
 			update((state) => {
 				filteredSimFiles = state.userSimFiles.filter(filterFn);
 				return state; // Don't modify the store, just return filtered data
@@ -90,10 +90,10 @@ function createSimFileStore() {
 		},
 
 		// Get simFile by ID
-		getSimFileById: (id: number): SimfileWithDtx | undefined => {
-			let simFile: SimfileWithDtx | undefined;
+		getSimFileById: (id: number): SimfileModel | undefined => {
+			let simFile: SimfileModel | undefined;
 			update((state) => {
-				simFile = state.userSimFiles.find((sf: SimfileWithDtx) => sf.id === id);
+				simFile = state.userSimFiles.find((sf: SimfileModel) => sf.id === id);
 				return state; // Don't modify the store
 			});
 			return simFile;

--- a/packages/dtx-desktop/src/renderer/src/stores/workspaceStore.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/stores/workspaceStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get } from 'svelte/store';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 import type { TreeNode } from './workspaceStore';
 
 // Mock linkageCacheService before importing workspaceStore
@@ -16,21 +16,22 @@ vi.mock('../services/linkageCacheService', () => ({
 const { workspaceStore } = await import('./workspaceStore');
 const { linkageCacheService } = await import('../services/linkageCacheService');
 
-const makeSimFile = (id: number): SimfileWithDtx => ({
+const makeSimFile = (id: number): SimfileModel => ({
 	id,
 	title: `Song ${id}`,
 	artist: 'Artist',
 	bpm: 120,
-	preview_url: null,
-	download_url: null,
-	is_published: false,
-	display_id: null,
-	publish_date: '2024-01-01',
-	video_preview_url: null,
-	created_at: '2024-01-01T00:00:00Z',
-	updated_at: '2024-01-01T00:00:00Z',
-	user_id: 'test-user',
-	dtx_files: []
+	previewUrl: null,
+	downloadUrl: null,
+	isPublished: false,
+	displayId: null,
+	publishDate: '2024-01-01',
+	videoPreviewUrl: null,
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-01T00:00:00Z',
+	userId: 'test-user',
+	googleDriveFileId: null,
+	dtxFiles: []
 });
 
 const makeTreeNode = (name: string, path: string, children = []) => ({
@@ -420,8 +421,8 @@ describe('workspaceStore', () => {
 		it('merges only returned Drive fields into the linked tree and cache', () => {
 			const old = {
 				...makeSimFile(42),
-				google_drive_file_id: 'drive-old',
-				download_url: 'https://example.com/old.zip',
+				googleDriveFileId: 'drive-old',
+				downloadUrl: 'https://example.com/old.zip',
 				title: 'Fresh cloud title'
 			};
 			workspaceStore.setTreeStructure([makeTreeNode('Song1', '/path/Song1')]);
@@ -436,8 +437,8 @@ describe('workspaceStore', () => {
 			const linked = get(workspaceStore).treeStructure[0].linkedSimFile;
 			expect(linked).toEqual({
 				...old,
-				google_drive_file_id: 'drive-new',
-				download_url: 'https://drive.google.com/uc?id=drive-new'
+				googleDriveFileId: 'drive-new',
+				downloadUrl: 'https://drive.google.com/uc?id=drive-new'
 			});
 			expect(linkageCacheService.saveLinkage).toHaveBeenCalledWith('/path/Song1', 42, linked);
 		});
@@ -445,8 +446,8 @@ describe('workspaceStore', () => {
 		it('does not clear an old Drive ID or URL when successful output omits a field', () => {
 			const old = {
 				...makeSimFile(42),
-				google_drive_file_id: 'drive-old',
-				download_url: 'https://example.com/old.zip'
+				googleDriveFileId: 'drive-old',
+				downloadUrl: 'https://example.com/old.zip'
 			};
 			workspaceStore.setTreeStructure([makeTreeNode('Song1', '/path/Song1')]);
 			workspaceStore.linkSimFileToFolder('/path/Song1', old);
@@ -459,8 +460,8 @@ describe('workspaceStore', () => {
 		it('ignores a stale result for a different linked simfile', () => {
 			const current = {
 				...makeSimFile(99),
-				google_drive_file_id: 'current-drive',
-				download_url: 'https://example.com/current.zip'
+				googleDriveFileId: 'current-drive',
+				downloadUrl: 'https://example.com/current.zip'
 			};
 			workspaceStore.setTreeStructure([makeTreeNode('Song1', '/path/Song1')]);
 			workspaceStore.linkSimFileToFolder('/path/Song1', current);

--- a/packages/dtx-desktop/src/renderer/src/stores/workspaceStore.ts
+++ b/packages/dtx-desktop/src/renderer/src/stores/workspaceStore.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import type { SimfileWithDtx } from '@dtx/common';
+import type { SimfileModel } from '@dtx/common';
 import { linkageCacheService } from '../services/linkageCacheService';
 
 export type ShellSection = 'library' | 'cloud' | 'templates' | 'settings' | 'scores';
@@ -14,7 +14,7 @@ export interface TreeNode {
 	containsDtxFiles?: boolean; // New property to identify folders with .dtx files
 	songTitle?: string | null; // Song title from SET.def file
 	linkedSimFileId?: string | null; // ID of linked remote simFile
-	linkedSimFile?: SimfileWithDtx | null; // Full linked remote simFile data
+	linkedSimFile?: SimfileModel | null; // Full linked remote simFile data
 }
 
 export interface WorkspaceState {
@@ -29,7 +29,7 @@ export interface WorkspaceState {
 	isLoading: boolean;
 	error: string | null;
 	selectedSong: TreeNode | null;
-	selectedCloudSimFile: SimfileWithDtx | null;
+	selectedCloudSimFile: SimfileModel | null;
 	showCloudSongDetails: boolean;
 	showNewSong: boolean;
 	activeSection: ShellSection;
@@ -166,7 +166,7 @@ function createWorkspaceStore() {
 				showCloudSongDetails: false
 			}));
 		},
-		selectCloudSimFile: (simFile: SimfileWithDtx) => {
+		selectCloudSimFile: (simFile: SimfileModel) => {
 			update((state) => ({
 				...state,
 				selectedCloudSimFile: simFile,
@@ -209,7 +209,7 @@ function createWorkspaceStore() {
 				showNewSong: false
 			}));
 		},
-		linkSimFileToFolder: (folderPath: string, simFile: SimfileWithDtx) => {
+		linkSimFileToFolder: (folderPath: string, simFile: SimfileModel) => {
 			// Save to localStorage cache
 			linkageCacheService.saveLinkage(folderPath, simFile.id, simFile);
 
@@ -226,17 +226,17 @@ function createWorkspaceStore() {
 			simfileId: string,
 			fields: GoogleDriveFields
 		) => {
-			const driveUpdates: Partial<SimfileWithDtx> = {};
+			const driveUpdates: Partial<SimfileModel> = {};
 			if (fields.googleDriveFileId) {
-				driveUpdates.google_drive_file_id = fields.googleDriveFileId;
+				driveUpdates.googleDriveFileId = fields.googleDriveFileId;
 			}
 			if (fields.downloadUrl) {
-				driveUpdates.download_url = fields.downloadUrl;
+				driveUpdates.downloadUrl = fields.downloadUrl;
 			}
 			if (Object.keys(driveUpdates).length === 0) return;
 
 			update((state) => {
-				let mergedSimfile: SimfileWithDtx | null = null;
+				let mergedSimfile: SimfileModel | null = null;
 				const mergeNode = (node: TreeNode): TreeNode => {
 					let mergedNode = node;
 					if (

--- a/packages/dtx-web/src/lib/api/chart.test.ts
+++ b/packages/dtx-web/src/lib/api/chart.test.ts
@@ -59,7 +59,7 @@ describe('listSimfiles (GraphQL path)', () => {
 		expect(requestMock).toHaveBeenCalledOnce();
 		expect(result.count).toBe(2);
 		expect(result.data).toHaveLength(2);
-		expect(result.data[0].has_uploaded_files).toBe(true);
+		expect(result.data[0].hasUploadedFiles).toBe(true);
 	});
 
 	it('maps scope string mine → MINE enum', async () => {
@@ -84,13 +84,28 @@ describe('getSimfile', () => {
 				id: '7',
 				title: 't',
 				googleDriveFileId: 'drive-file-123',
+				displayId: null,
+				isPublished: false,
+				publishDate: '2026-08-15',
+				createdAt: '2026-08-15T00:00:00Z',
+				updatedAt: '2026-08-15T00:00:01Z',
+				dtxFiles: [],
 				files: [],
 				hasUploadedFiles: false
 			}
 		});
 		const result = await getSimfile('7');
-		expect(result.id).toBe(7);
-		expect(result.google_drive_file_id).toBe('drive-file-123');
+		expect(result).toMatchObject({
+			id: 7,
+			title: 't',
+			googleDriveFileId: 'drive-file-123',
+			displayId: null,
+			isPublished: false,
+			publishDate: '2026-08-15',
+			createdAt: '2026-08-15T00:00:00Z',
+			updatedAt: '2026-08-15T00:00:01Z',
+			dtxFiles: []
+		});
 	});
 
 	it('throws "Simfile not found" when result.simfile is null', async () => {
@@ -113,7 +128,7 @@ describe('updateSimfile', () => {
 		expect(result.title).toBe('new');
 		expect(result.files).toHaveLength(1);
 		expect(result.files?.[0]?.key).toBe('charts/test.zip');
-		expect(result.has_uploaded_files).toBe(true);
+		expect(result.hasUploadedFiles).toBe(true);
 	});
 });
 
@@ -138,8 +153,8 @@ describe('updateSimfileDriveFile', () => {
 		});
 		expect(result).toEqual({
 			id: 9,
-			google_drive_file_id: 'drive-file-123',
-			download_url: downloadUrl
+			googleDriveFileId: 'drive-file-123',
+			downloadUrl
 		});
 	});
 
@@ -178,8 +193,8 @@ describe('updateSimfileDriveFile', () => {
 
 		expect(result).toEqual({
 			id: 9,
-			google_drive_file_id: null,
-			download_url: null
+			googleDriveFileId: null,
+			downloadUrl: null
 		});
 	});
 });

--- a/packages/dtx-web/src/lib/api/chart.ts
+++ b/packages/dtx-web/src/lib/api/chart.ts
@@ -32,7 +32,7 @@ type AdaptSimfileInput = Omit<SimfileWithFilesFragment, 'files' | 'hasUploadedFi
 
 const parseSimfileId = (id: string): number => {
 	const numId = Number(id);
-	if (!Number.isFinite(numId)) throw new Error(`Invalid simfile id: ${id}`);
+	if (!Number.isSafeInteger(numId)) throw new Error(`Invalid simfile id: ${id}`);
 	return numId;
 };
 

--- a/packages/dtx-web/src/lib/api/chart.ts
+++ b/packages/dtx-web/src/lib/api/chart.ts
@@ -10,36 +10,17 @@ import {
 	type SimfileWithFilesFragment
 } from './generated/graphql';
 import { getClient, type ClientCtx } from './client';
+import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 
 export type ScopeString = 'mine' | 'published';
 
-export type LegacySimfile = {
-	id: number;
-	display_id: number | null;
-	title: string;
-	artist: string;
-	bpm: number;
-	user_id: string | null;
-	is_published: boolean;
-	google_drive_file_id: string | null;
-	download_url: string | null;
-	preview_url: string | null;
-	video_preview_url: string | null;
-	publish_date: string;
-	created_at: string;
-	updated_at: string;
-	dtx_files: { level: number; label: string }[];
-	files?: { key: string; size: number; uploaded: string }[];
-	has_uploaded_files?: boolean;
-};
-
-export type SimfileListResult = { data: LegacySimfile[]; count: number };
+export type SimfileListResult = { data: SimfileModel[]; count: number };
 
 const scopeToEnum = (scope: ScopeString): SimfileScope =>
 	scope === 'mine' ? SimfileScope.Mine : SimfileScope.Published;
 
 /**
- * Input type for adaptSimfile, derived from the generated GraphQL fragment.
+ * Input type for toSimfileModel, derived from the generated GraphQL fragment.
  * Both `getSimfile` and `updateSimfile` return the full `SimfileWithFilesFragment`
  * (so `files` and `hasUploadedFiles` are present), while `listSimfiles` returns
  * a partial fragment without `files` (but includes `hasUploadedFiles`).
@@ -49,29 +30,34 @@ type AdaptSimfileInput = Omit<SimfileWithFilesFragment, 'files' | 'hasUploadedFi
 	hasUploadedFiles?: SimfileWithFilesFragment['hasUploadedFiles'];
 };
 
-const adaptSimfile = (s: AdaptSimfileInput): LegacySimfile => {
-	const numId = Number(s.id);
-	if (!Number.isFinite(numId)) throw new Error(`Invalid simfile id: ${s.id}`);
-	return {
-		id: numId,
-		display_id: s.displayId ?? null,
-		title: s.title,
-		artist: s.artist,
-		bpm: s.bpm,
-		user_id: s.userId ?? null,
-		is_published: s.isPublished,
-		google_drive_file_id: s.googleDriveFileId ?? null,
-		download_url: s.downloadUrl ?? null,
-		preview_url: s.previewUrl ?? null,
-		video_preview_url: s.videoPreviewUrl ?? null,
-		publish_date: s.publishDate ?? '',
-		created_at: s.createdAt ?? '',
-		updated_at: s.updatedAt ?? '',
-		dtx_files: s.dtxFiles ?? [],
-		files: s.files,
-		has_uploaded_files: s.hasUploadedFiles
-	};
+const parseSimfileId = (id: string): number => {
+	const numId = Number(id);
+	if (!Number.isFinite(numId)) throw new Error(`Invalid simfile id: ${id}`);
+	return numId;
 };
+
+const toSimfileModel = (simfile: AdaptSimfileInput): SimfileModel => ({
+	id: parseSimfileId(simfile.id),
+	title: simfile.title,
+	artist: simfile.artist,
+	bpm: simfile.bpm,
+	displayId: simfile.displayId ?? null,
+	userId: simfile.userId ?? null,
+	googleDriveFileId: simfile.googleDriveFileId ?? null,
+	isPublished: simfile.isPublished,
+	downloadUrl: simfile.downloadUrl ?? null,
+	previewUrl: simfile.previewUrl ?? null,
+	videoPreviewUrl: simfile.videoPreviewUrl ?? null,
+	publishDate: simfile.publishDate,
+	createdAt: simfile.createdAt,
+	updatedAt: simfile.updatedAt,
+	dtxFiles: (simfile.dtxFiles ?? []).map((file): SimfileDtxFile => ({
+		label: file.label,
+		level: file.level
+	})),
+	...(simfile.files == null ? {} : { files: simfile.files }),
+	...(simfile.hasUploadedFiles == null ? {} : { hasUploadedFiles: simfile.hasUploadedFiles })
+});
 
 export type ListParams = {
 	scope: ScopeString;
@@ -92,16 +78,16 @@ export const listSimfiles = async (
 		pageSize: params.pageSize ?? 20
 	});
 	return {
-		data: result.simfiles.data.map(adaptSimfile),
+		data: result.simfiles.data.map(toSimfileModel),
 		count: result.simfiles.count
 	};
 };
 
-export const getSimfile = async (id: string, ctx?: ClientCtx): Promise<LegacySimfile> => {
+export const getSimfile = async (id: string, ctx?: ClientCtx): Promise<SimfileModel> => {
 	const client = await getClient(ctx);
 	const result = await client.request(GetSimfileDocument, { id });
 	if (!result.simfile) throw new Error('Simfile not found');
-	return adaptSimfile(result.simfile);
+	return toSimfileModel(result.simfile);
 };
 
 export type PreviewLevel = { level: number; label: string; fileUrl: string };
@@ -125,8 +111,7 @@ export const getPreviewSimfile = async (id: string, ctx?: ClientCtx): Promise<Pr
 	const client = await getClient(ctx);
 	const result = await client.request(GetPreviewSimfileDocument, { id });
 	if (!result.simfile) throw new Error('Simfile not found');
-	const numId = Number(result.simfile.id);
-	if (!Number.isFinite(numId)) throw new Error(`Invalid simfile id: ${result.simfile.id}`);
+	const numId = parseSimfileId(result.simfile.id);
 	return {
 		id: numId,
 		title: result.simfile.title,
@@ -147,16 +132,16 @@ export const updateSimfile = async (
 	id: string,
 	input: UpdateSimfileInput,
 	ctx?: ClientCtx
-): Promise<LegacySimfile> => {
+): Promise<SimfileModel> => {
 	const client = await getClient(ctx);
 	const result = await client.request(UpdateSimfileDocument, { id, input });
-	return adaptSimfile(result.updateSimfile);
+	return toSimfileModel(result.updateSimfile);
 };
 
 export type DriveFileBinding = {
 	id: number;
-	google_drive_file_id: string | null;
-	download_url: string | null;
+	googleDriveFileId: string | null;
+	downloadUrl: string | null;
 };
 
 export const updateSimfileDriveFile = async (
@@ -171,14 +156,10 @@ export const updateSimfileDriveFile = async (
 		googleDriveFileId,
 		downloadUrl
 	});
-	const numId = Number(result.updateSimfileDriveFile.id);
-	if (!Number.isFinite(numId)) {
-		throw new Error(`Invalid simfile id: ${result.updateSimfileDriveFile.id}`);
-	}
 	return {
-		id: numId,
-		google_drive_file_id: result.updateSimfileDriveFile.googleDriveFileId ?? null,
-		download_url: result.updateSimfileDriveFile.downloadUrl ?? null
+		id: parseSimfileId(result.updateSimfileDriveFile.id),
+		googleDriveFileId: result.updateSimfileDriveFile.googleDriveFileId ?? null,
+		downloadUrl: result.updateSimfileDriveFile.downloadUrl ?? null
 	};
 };
 
@@ -192,10 +173,8 @@ export type DeleteResult = {
 export const deleteSimfile = async (id: string, ctx?: ClientCtx): Promise<DeleteResult> => {
 	const client = await getClient(ctx);
 	const result = await client.request(DeleteSimfileDocument, { id });
-	const numId = Number(result.deleteSimfile.id);
-	if (!Number.isFinite(numId)) throw new Error(`Invalid simfile id: ${result.deleteSimfile.id}`);
 	return {
-		id: numId,
+		id: parseSimfileId(result.deleteSimfile.id),
 		deleted: result.deleteSimfile.deleted,
 		partialDeletion: result.deleteSimfile.partialDeletion ?? undefined,
 		message: result.deleteSimfile.message ?? undefined

--- a/packages/dtx-web/src/lib/components/ChartList.helpers.ts
+++ b/packages/dtx-web/src/lib/components/ChartList.helpers.ts
@@ -48,20 +48,20 @@ export const supportsBulkDownloadStreaming = (saveFilePickerWindow: SaveFilePick
 
 export const resetBulkSelection = () => new Set<number>();
 
-export const canBulkSelect = (item: { has_uploaded_files?: boolean }) =>
-	item.has_uploaded_files === true;
+export const canBulkSelect = (item: { hasUploadedFiles?: boolean }) =>
+	item.hasUploadedFiles === true;
 
 export type ChartNavigationItem = {
 	id?: number;
-	is_published?: boolean;
-	has_uploaded_files?: boolean;
+	isPublished?: boolean;
+	hasUploadedFiles?: boolean;
 };
 
 /** A `ChartNavigationItem` whose `id` is a defined number, narrowed by `isPreviewable`. */
 export type PreviewableChartItem = ChartNavigationItem & { id: number };
 
 export const isPreviewable = (item: ChartNavigationItem): item is PreviewableChartItem =>
-	item.id !== undefined && item.is_published === true && item.has_uploaded_files === true;
+	item.id !== undefined && item.isPublished === true && item.hasUploadedFiles === true;
 
 /**
  * Resolves the primary navigation destination for a chart title.
@@ -73,7 +73,7 @@ export const isPreviewable = (item: ChartNavigationItem): item is PreviewableCha
 export const chartTitleHref = (item: ChartNavigationItem, isBlog: boolean): string | null => {
 	if (item.id === undefined) return null;
 	if (isBlog) return isPreviewable(item) ? `/preview/${item.id}` : null;
-	return item.has_uploaded_files === true ? `/editor/${item.id}` : null;
+	return item.hasUploadedFiles === true ? `/editor/${item.id}` : null;
 };
 
 export const changePage = (newPage: number, totalPages: number) => {

--- a/packages/dtx-web/src/lib/components/ChartList.svelte
+++ b/packages/dtx-web/src/lib/components/ChartList.svelte
@@ -38,9 +38,9 @@
 		enableDownload?: boolean;
 	}
 
-	import type { SimfileWithDtx } from '@dtx/common';
+	import type { SimfileModel } from '@dtx/common';
 
-	type ListedChart = SimfileWithDtx & { has_uploaded_files?: boolean };
+	type ListedChart = SimfileModel;
 
 	let { pageSize = 12, isBlog = false, enableDownload = false }: Props = $props();
 
@@ -61,7 +61,7 @@
 
 	// Replace the run() function with a reactive effect using $effect
 	$effect(() => {
-		filteredItems = hideUnpublished ? items.filter((item) => item.is_published) : items;
+		filteredItems = hideUnpublished ? items.filter((item) => item.isPublished) : items;
 	});
 
 	const togglePublishChart = async (id: number, published: boolean) => {
@@ -70,7 +70,7 @@
 
 			// Update local state
 			items = items.map((item) =>
-				item.id === id ? { ...item, is_published: !published } : item
+				item.id === id ? { ...item, isPublished: !published } : item
 			);
 
 			toastStore.success({
@@ -380,10 +380,10 @@
 									<a
 										href={chartTitleHref(item, isBlog)}
 										class="hover:text-purple-300"
-										>{item.display_id}. {item.title}</a
+										>{item.displayId}. {item.title}</a
 									>
 								{:else}
-									{item.display_id}. {item.title}
+									{item.displayId}. {item.title}
 								{/if}
 							</h3>
 						</div>
@@ -420,7 +420,7 @@
 								</svg>
 								<span class="font-medium text-cyan-300">{item.bpm} BPM</span>
 							</div>
-							{#if item.publish_date}
+							{#if item.publishDate}
 								<div class="flex items-center gap-2 text-slate-300">
 									<svg
 										class="h-4 w-4 text-amber-400"
@@ -436,16 +436,16 @@
 										></path>
 									</svg>
 									<span class="font-medium text-amber-300">
-										{new Date(item.publish_date).toLocaleDateString()}
+										{new Date(item.publishDate).toLocaleDateString()}
 									</span>
 								</div>
 							{/if}
 						</div>
-						{#if item.dtx_files && item.dtx_files.length > 0}
+						{#if item.dtxFiles && item.dtxFiles.length > 0}
 							<div class="mt-3 flex items-center gap-2">
 								<span class="text-xs font-medium text-slate-400">Levels:</span>
 								<div class="flex flex-wrap gap-1">
-									{#each formatLevelDisplay(item.dtx_files).split(', ') as level}
+									{#each formatLevelDisplay(item.dtxFiles).split(', ') as level}
 										<span
 											class="rounded-full border border-purple-500/30 bg-linear-to-r from-purple-600/30 to-cyan-600/30 px-2 py-1 text-xs text-purple-200"
 										>

--- a/packages/dtx-web/src/lib/components/ChartList.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartList.test.ts
@@ -57,16 +57,16 @@ const mockListedChart = {
 	title: 'Test Song 1',
 	artist: 'Test Artist 1',
 	bpm: 120,
-	download_url: 'https://example.com/download1',
-	has_uploaded_files: true,
-	is_published: true,
-	display_id: 'TST001',
-	dtx_files: [{ level: 3 }, { level: 5 }],
-	created_at: '2023-01-01',
-	updated_at: '2023-01-02',
-	publish_date: '2023-01-03',
-	user_id: 'user-1',
-	video_preview_url: null
+	downloadUrl: 'https://example.com/download1',
+	hasUploadedFiles: true,
+	isPublished: true,
+	displayId: 1,
+	dtxFiles: [{ level: 3, label: 'BSC' }],
+	createdAt: '2023-01-01',
+	updatedAt: '2023-01-02',
+	publishDate: '2023-01-03',
+	userId: 'user-1',
+	videoPreviewUrl: null
 };
 
 const createJsonResponse = (body: unknown, status = 200): Response =>
@@ -307,7 +307,7 @@ describe('ChartList helpers', () => {
 	it('allows bulk selection only for charts with uploaded files', () => {
 		expect(chartListHelpers.canBulkSelect(mockListedChart)).toBe(true);
 		expect(
-			chartListHelpers.canBulkSelect({ ...mockListedChart, has_uploaded_files: false })
+			chartListHelpers.canBulkSelect({ ...mockListedChart, hasUploadedFiles: false })
 		).toBe(false);
 		expect(chartListHelpers.canBulkSelect({})).toBe(false);
 	});
@@ -334,9 +334,9 @@ describe('ChartList helpers', () => {
 	});
 
 	it('treats a chart as previewable only when published and uploaded', () => {
-		const previewable = { id: 1, is_published: true, has_uploaded_files: true };
-		const unpublished = { ...previewable, is_published: false };
-		const withoutUpload = { ...previewable, has_uploaded_files: false };
+		const previewable = { id: 1, isPublished: true, hasUploadedFiles: true };
+		const unpublished = { ...previewable, isPublished: false };
+		const withoutUpload = { ...previewable, hasUploadedFiles: false };
 
 		expect(chartListHelpers.isPreviewable(previewable)).toBe(true);
 		expect(chartListHelpers.isPreviewable(unpublished)).toBe(false);
@@ -345,9 +345,9 @@ describe('ChartList helpers', () => {
 	});
 
 	it('resolves the title navigation destination by context', () => {
-		const previewable = { id: 1, is_published: true, has_uploaded_files: true };
-		const unpublished = { ...previewable, is_published: false };
-		const withoutUpload = { ...previewable, has_uploaded_files: false };
+		const previewable = { id: 1, isPublished: true, hasUploadedFiles: true };
+		const unpublished = { ...previewable, isPublished: false };
+		const withoutUpload = { ...previewable, hasUploadedFiles: false };
 
 		// Blog: only previewable charts link to /preview/[id].
 		expect(chartListHelpers.chartTitleHref(previewable, true)).toBe('/preview/1');
@@ -384,14 +384,14 @@ describe('ChartList component bulk download behavior', () => {
 				...mockListedChart,
 				id: i + 1,
 				title: `Song ${i + 1}`,
-				display_id: `D${i + 1}`
+				displayId: `D${i + 1}`
 			})
 		);
 		const extraChart = {
 			...mockListedChart,
 			id: chartListHelpers.MAX_BULK_DOWNLOAD_CHARTS + 1,
 			title: 'Extra Song',
-			display_id: 'EX'
+			displayId: 'EX'
 		};
 		const allCharts = [...maxCharts, extraChart];
 
@@ -556,12 +556,12 @@ describe('ChartList Rendering', () => {
 					title: 'My Song',
 					artist: 'Artist',
 					bpm: 120,
-					is_published: true,
-					display_id: 1,
-					dtx_files: [],
-					publish_date: '2024-01-01',
-					download_url: null,
-					video_preview_url: null
+					isPublished: true,
+					displayId: 1,
+					dtxFiles: [],
+					publishDate: '2024-01-01',
+					downloadUrl: null,
+					videoPreviewUrl: null
 				}
 			],
 			1
@@ -581,13 +581,13 @@ describe('ChartList Rendering', () => {
 					title: 'My Song',
 					artist: 'Artist',
 					bpm: 120,
-					is_published: true,
-					display_id: 1,
-					has_uploaded_files: true,
-					dtx_files: [],
-					publish_date: '2024-01-01',
-					download_url: null,
-					video_preview_url: null
+					isPublished: true,
+					displayId: 1,
+					hasUploadedFiles: true,
+					dtxFiles: [],
+					publishDate: '2024-01-01',
+					downloadUrl: null,
+					videoPreviewUrl: null
 				}
 			],
 			1
@@ -752,12 +752,12 @@ describe('ChartList – handleFileDelete via ChartListTableItem prop', () => {
 		title: 'Delete Me',
 		artist: 'Artist',
 		bpm: 120,
-		is_published: true,
-		display_id: 1,
-		dtx_files: [],
-		publish_date: null,
-		download_url: null,
-		video_preview_url: null
+		isPublished: true,
+		displayId: 1,
+		dtxFiles: [],
+		publishDate: null,
+		downloadUrl: null,
+		videoPreviewUrl: null
 	};
 
 	it('handleFileDelete calls deleteSimfile and shows success toast on clean deletion', async () => {
@@ -862,17 +862,17 @@ describe('ChartList – togglePublishChart via ChartListTableItem prop', () => {
 		title: 'Toggle Chart',
 		artist: 'Artist',
 		bpm: 120,
-		is_published: true,
-		display_id: 2,
-		dtx_files: [],
-		publish_date: null,
-		download_url: null,
-		video_preview_url: null
+		isPublished: true,
+		displayId: 2,
+		dtxFiles: [],
+		publishDate: null,
+		downloadUrl: null,
+		videoPreviewUrl: null
 	};
 
 	it('togglePublishChart calls updateSimfile and shows success toast when publish succeeds', async () => {
 		mockApi.listSimfiles.mockResolvedValueOnce({ data: [item], count: 1 });
-		mockApi.updateSimfile.mockResolvedValueOnce({ ...item, is_published: false });
+		mockApi.updateSimfile.mockResolvedValueOnce({ ...item, isPublished: false });
 
 		render(ChartList, { props: { isBlog: false } });
 		await fireEvent.click(screen.getByRole('button', { name: 'Table view' }));

--- a/packages/dtx-web/src/lib/components/ChartListItem.svelte
+++ b/packages/dtx-web/src/lib/components/ChartListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
 	import ImageAudio from './ImageAudio.svelte';
-	import type { SimfileWithDtx } from '@dtx/common';
+	import type { SimfileModel } from '@dtx/common';
 	import { Popover } from '@skeletonlabs/skeleton-svelte';
 	import { formatLevelDisplay, buildPreviewUrl } from '$lib/utils';
 	import { EllipsisVertical } from '@lucide/svelte/icons';
@@ -12,7 +12,7 @@
 	import { isPreviewable, chartTitleHref } from '$lib/components/ChartList.helpers';
 	import { createAudioPreview, audioToggleLabelKey } from '$lib/audioPreview.svelte';
 
-	type ChartListItemData = Partial<SimfileWithDtx> & { has_uploaded_files?: boolean };
+	type ChartListItemData = Partial<SimfileModel>;
 
 	let {
 		item,
@@ -33,7 +33,7 @@
 	let popoverOpen = $state(false);
 	let modalOpen = $state(false);
 
-	const hasUploadedChart = $derived(item.id !== undefined && item.has_uploaded_files === true);
+	const hasUploadedChart = $derived(item.id !== undefined && item.hasUploadedFiles === true);
 	const previewable = $derived(isPreviewable(item));
 	const titleHref = $derived(chartTitleHref(item, isBlog));
 
@@ -79,7 +79,7 @@
 						class="h-1.5 w-1.5 rounded-full bg-gradient-to-r from-purple-400 to-cyan-400"
 					></div>
 					<span class="text-xs font-medium tracking-wider text-purple-300 uppercase"
-						>#{item.display_id}</span
+						>#{item.displayId}</span
 					>
 				</div>
 				<h2
@@ -220,10 +220,10 @@
 								</a>
 							{/if}
 
-							{#if !isBlog && item.id !== undefined && item.is_published !== undefined}
+							{#if !isBlog && item.id !== undefined && item.isPublished !== undefined}
 								<Button
 									onclick={() => {
-										togglePublishChart(item.id!, item.is_published!);
+										togglePublishChart(item.id!, item.isPublished!);
 									}}
 									variant="menuItem"
 									fullWidth
@@ -241,12 +241,12 @@
 												stroke-linecap="round"
 												stroke-linejoin="round"
 												stroke-width="2"
-												d={item.is_published
+												d={item.isPublished
 													? 'M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L12 12m-3-3l6-6'
 													: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z'}
 											></path>
 										</svg>
-										{item.is_published ? 'Unpublish' : 'Publish'}
+										{item.isPublished ? 'Unpublish' : 'Publish'}
 									{/snippet}
 								</Button>
 							{/if}
@@ -346,7 +346,7 @@
 			<div class="flex items-center gap-2">
 				<span class="text-xs font-medium text-slate-400">{$_('blog.level')}:</span>
 				<div class="flex flex-wrap gap-1">
-					{#each formatLevelDisplay(item.dtx_files).split(', ') as level}
+					{#each formatLevelDisplay(item.dtxFiles).split(', ') as level}
 						<span
 							class="rounded-full border border-amber-500/30 bg-gradient-to-r from-amber-600/30 to-orange-600/30 px-2 py-0.5 text-xs text-amber-200"
 						>
@@ -362,12 +362,12 @@
 				{#if enableDownload}
 					<DownloadDropdown
 						simfileId={item.id}
-						externalUrl={item.download_url ?? null}
-						hasUploadedFiles={item.has_uploaded_files}
+						externalUrl={item.downloadUrl ?? null}
+						hasUploadedFiles={item.hasUploadedFiles}
 					/>
-				{:else if item.download_url}
+				{:else if item.downloadUrl}
 					<a
-						href={item.download_url}
+						href={item.downloadUrl}
 						target="_blank"
 						rel="noopener noreferrer"
 						class="music-btn-primary inline-flex items-center gap-2 px-4 py-2 text-sm"

--- a/packages/dtx-web/src/lib/components/ChartListItem.svelte
+++ b/packages/dtx-web/src/lib/components/ChartListItem.svelte
@@ -346,7 +346,7 @@
 			<div class="flex items-center gap-2">
 				<span class="text-xs font-medium text-slate-400">{$_('blog.level')}:</span>
 				<div class="flex flex-wrap gap-1">
-					{#each formatLevelDisplay(item.dtxFiles).split(', ') as level}
+					{#each formatLevelDisplay(item.dtxFiles ?? []).split(', ') as level}
 						<span
 							class="rounded-full border border-amber-500/30 bg-gradient-to-r from-amber-600/30 to-orange-600/30 px-2 py-0.5 text-xs text-amber-200"
 						>

--- a/packages/dtx-web/src/lib/components/ChartListItem.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartListItem.test.ts
@@ -70,16 +70,19 @@ const mockItem = {
 	title: 'Test Song 1',
 	artist: 'Test Artist 1',
 	bpm: 120,
-	download_url: 'https://example.com/download1',
-	has_uploaded_files: true,
-	is_published: true,
-	display_id: 1,
-	dtx_files: [{ level: 3 }, { level: 5 }],
-	created_at: '2023-01-01',
-	updated_at: '2023-01-02',
-	publish_date: '2023-01-03',
-	user_id: 'user-1',
-	video_preview_url: null,
+	downloadUrl: 'https://example.com/download1',
+	hasUploadedFiles: true,
+	isPublished: true,
+	displayId: 1,
+	dtxFiles: [
+		{ level: 3, label: 'BSC' },
+		{ level: 5, label: 'ADV' }
+	],
+	createdAt: '2023-01-01',
+	updatedAt: '2023-01-02',
+	publishDate: '2023-01-03',
+	userId: 'user-1',
+	videoPreviewUrl: null,
 	label: 'Test Label 1',
 	value: 'test-value-1',
 	bg_video_url: null,
@@ -96,16 +99,16 @@ const mockItemNoPreview = {
 	title: 'Test Song 2',
 	artist: 'Test Artist 2',
 	bpm: 140,
-	download_url: null,
-	has_uploaded_files: false,
-	is_published: false,
-	display_id: 2,
-	dtx_files: [{ level: 4 }],
-	created_at: '2023-02-01',
-	updated_at: '2023-02-02',
-	publish_date: '2023-02-03',
-	user_id: 'user-1',
-	video_preview_url: null,
+	downloadUrl: null,
+	hasUploadedFiles: false,
+	isPublished: false,
+	displayId: 2,
+	dtxFiles: [{ level: 4, label: 'ADV' }],
+	createdAt: '2023-02-01',
+	updatedAt: '2023-02-02',
+	publishDate: '2023-02-03',
+	userId: 'user-1',
+	videoPreviewUrl: null,
 	label: 'Test Label 2',
 	value: 'test-value-2',
 	bg_video_url: null,
@@ -135,10 +138,10 @@ describe('ChartListItem Component Logic', () => {
 	// Test the togglePublishChart function
 	it('calls togglePublishChart with correct parameters', async () => {
 		// Call the function directly with the expected parameters
-		await mockTogglePublishChart(mockItem.id, mockItem.is_published);
+		await mockTogglePublishChart(mockItem.id, mockItem.isPublished);
 
 		// Verify the function was called with the correct parameters
-		expect(mockTogglePublishChart).toHaveBeenCalledWith(mockItem.id, mockItem.is_published);
+		expect(mockTogglePublishChart).toHaveBeenCalledWith(mockItem.id, mockItem.isPublished);
 		expect(mockTogglePublishChart).toHaveBeenCalledTimes(1);
 	});
 
@@ -170,13 +173,13 @@ describe('ChartListItem Component Logic', () => {
 		const isBlog = true;
 
 		// Test with an item that has a download URL
-		if (isBlog && mockItem.download_url) {
-			expect(mockItem.download_url).toBe('https://example.com/download1');
+		if (isBlog && mockItem.downloadUrl) {
+			expect(mockItem.downloadUrl).toBe('https://example.com/download1');
 		}
 
 		// Test with an item that doesn't have a download URL
-		if (isBlog && !mockItemNoPreview.download_url) {
-			expect(mockItemNoPreview.download_url).toBeNull();
+		if (isBlog && !mockItemNoPreview.downloadUrl) {
+			expect(mockItemNoPreview.downloadUrl).toBeNull();
 		}
 	});
 
@@ -213,7 +216,7 @@ describe('ChartListItem Component Logic', () => {
 			render(ChartListItem, {
 				props: {
 					...baseProps,
-					item: { ...mockItem, has_uploaded_files: false }
+					item: { ...mockItem, hasUploadedFiles: false }
 				}
 			});
 
@@ -222,7 +225,7 @@ describe('ChartListItem Component Logic', () => {
 			).not.toBeInTheDocument();
 			expect(screen.getByRole('link', { name: /external download link/i })).toHaveAttribute(
 				'href',
-				mockItem.download_url
+				mockItem.downloadUrl
 			);
 		});
 	});
@@ -236,7 +239,7 @@ describe('ChartListItem Component Logic', () => {
 			onFileDelete: vi.fn()
 		};
 
-		it('renders display_id', () => {
+		it('renders displayId', () => {
 			render(ChartListItem, { props: renderProps });
 			expect(screen.getByText(/#1/)).toBeInTheDocument();
 		});
@@ -331,7 +334,7 @@ describe('ChartListItem Component Logic', () => {
 					...renderProps,
 					isBlog: true,
 					enableDownload: true,
-					item: { ...renderProps.item, download_url: 'https://example.com/download1' }
+					item: { ...renderProps.item, downloadUrl: 'https://example.com/download1' }
 				}
 			});
 			const downloadButton = screen.getByRole('button', { name: 'chart_actions.download' });
@@ -346,7 +349,7 @@ describe('ChartListItem Component Logic', () => {
 					enableDownload: true,
 					item: (() => {
 						const item = { ...mockItem };
-						delete (item as { has_uploaded_files?: boolean }).has_uploaded_files;
+						delete (item as { hasUploadedFiles?: boolean }).hasUploadedFiles;
 						return item;
 					})()
 				}
@@ -365,7 +368,7 @@ describe('ChartListItem Component Logic', () => {
 					...renderProps,
 					isBlog: true,
 					enableDownload: true,
-					item: { ...mockItem, has_uploaded_files: false }
+					item: { ...mockItem, hasUploadedFiles: false }
 				}
 			});
 			expect(
@@ -373,19 +376,19 @@ describe('ChartListItem Component Logic', () => {
 			).not.toBeInTheDocument();
 		});
 
-		it('shows external link in blog mode when download_url is set and downloads are disabled', () => {
+		it('shows external link in blog mode when downloadUrl is set and downloads are disabled', () => {
 			render(ChartListItem, { props: { ...renderProps, isBlog: true } });
 			const externalLink = screen.getByRole('link', { name: /blog\.download/i });
 			expect(externalLink).toBeInTheDocument();
-			expect(externalLink).toHaveAttribute('href', renderProps.item.download_url);
+			expect(externalLink).toHaveAttribute('href', renderProps.item.downloadUrl);
 		});
 
-		it('shows download unavailable state in blog mode when download_url is null and downloads are disabled', () => {
+		it('shows download unavailable state in blog mode when downloadUrl is null and downloads are disabled', () => {
 			render(ChartListItem, {
 				props: {
 					...renderProps,
 					isBlog: true,
-					item: { ...mockItem, download_url: null }
+					item: { ...mockItem, downloadUrl: null }
 				}
 			});
 			expect(
@@ -394,26 +397,26 @@ describe('ChartListItem Component Logic', () => {
 			expect(screen.getByText('Download not available')).toBeInTheDocument();
 		});
 
-		it('shows R2 download link in blog mode when download_url is null', () => {
+		it('shows R2 download link in blog mode when downloadUrl is null', () => {
 			render(ChartListItem, {
 				props: {
 					...renderProps,
 					isBlog: true,
 					enableDownload: true,
-					item: { ...mockItem, download_url: null }
+					item: { ...mockItem, downloadUrl: null }
 				}
 			});
 			const downloadLink = screen.getByRole('button', { name: 'chart_actions.download' });
 			expect(downloadLink).toBeInTheDocument();
 		});
 
-		it('hides R2 download link in blog mode when download_url is null and uploads are unavailable', () => {
+		it('hides R2 download link in blog mode when downloadUrl is null and uploads are unavailable', () => {
 			render(ChartListItem, {
 				props: {
 					...renderProps,
 					isBlog: true,
 					enableDownload: true,
-					item: { ...mockItemNoPreview, download_url: null, has_uploaded_files: false }
+					item: { ...mockItemNoPreview, downloadUrl: null, hasUploadedFiles: false }
 				}
 			});
 			expect(
@@ -431,7 +434,7 @@ describe('ChartListItem Component Logic', () => {
 					item: {
 						...mockItem,
 						id: undefined,
-						download_url: 'https://example.com/download1'
+						downloadUrl: 'https://example.com/download1'
 					}
 				}
 			});
@@ -485,7 +488,7 @@ describe('ChartListItem Component Logic', () => {
 				props: {
 					...renderProps,
 					isBlog: true,
-					item: { ...mockItem, is_published: false }
+					item: { ...mockItem, isPublished: false }
 				}
 			});
 			expect(
@@ -566,7 +569,7 @@ describe('ChartListItem Component Logic', () => {
 			render(ChartListItem, { props: { ...handlerProps, togglePublishChart } });
 
 			await fireEvent.click(screen.getByRole('button', { name: /unpublish/i }));
-			expect(togglePublishChart).toHaveBeenCalledWith(mockItem.id, mockItem.is_published);
+			expect(togglePublishChart).toHaveBeenCalledWith(mockItem.id, mockItem.isPublished);
 		});
 	});
 
@@ -603,18 +606,18 @@ describe('ChartListItem Component Logic', () => {
 			).not.toBeInTheDocument();
 		});
 
-		it('"Open in Editor" menu item is not shown when has_uploaded_files is false', () => {
+		it('"Open in Editor" menu item is not shown when hasUploadedFiles is false', () => {
 			render(ChartListItem, {
-				props: { ...navProps, item: { ...mockItem, has_uploaded_files: false } }
+				props: { ...navProps, item: { ...mockItem, hasUploadedFiles: false } }
 			});
 			expect(
 				screen.queryByRole('button', { name: 'Open in Editor' })
 			).not.toBeInTheDocument();
 		});
 
-		it('"Open in Editor" menu item is not shown when has_uploaded_files is undefined', () => {
+		it('"Open in Editor" menu item is not shown when hasUploadedFiles is undefined', () => {
 			const item = { ...mockItem };
-			delete (item as { has_uploaded_files?: boolean }).has_uploaded_files;
+			delete (item as { hasUploadedFiles?: boolean }).hasUploadedFiles;
 			render(ChartListItem, { props: { ...navProps, item } });
 			expect(
 				screen.queryByRole('button', { name: 'Open in Editor' })

--- a/packages/dtx-web/src/lib/components/ChartListItem.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartListItem.test.ts
@@ -167,22 +167,6 @@ describe('ChartListItem Component Logic', () => {
 		}
 	});
 
-	// Test the download URL display in blog mode
-	it('handles download URL in blog mode correctly', () => {
-		// In blog mode, the download URL should be shown if available
-		const isBlog = true;
-
-		// Test with an item that has a download URL
-		if (isBlog && mockItem.downloadUrl) {
-			expect(mockItem.downloadUrl).toBe('https://example.com/download1');
-		}
-
-		// Test with an item that doesn't have a download URL
-		if (isBlog && !mockItemNoPreview.downloadUrl) {
-			expect(mockItemNoPreview.downloadUrl).toBeNull();
-		}
-	});
-
 	describe('Blog Mode Download Logic', () => {
 		const baseProps = {
 			isBlog: true,

--- a/packages/dtx-web/src/lib/components/ChartListTableItem.svelte
+++ b/packages/dtx-web/src/lib/components/ChartListTableItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SimfileWithDtx } from '@dtx/common';
+	import type { SimfileModel } from '@dtx/common';
 	import { Popover } from '@skeletonlabs/skeleton-svelte';
 	import { EllipsisVertical, ExternalLink, Eye } from '@lucide/svelte/icons';
 	import DownloadDropdown from '$lib/components/DownloadDropdown.svelte';
@@ -10,8 +10,8 @@
 	import { isPreviewable } from '$lib/components/ChartList.helpers';
 	import { _ } from 'svelte-i18n';
 
-	type ChartListTableItemData = Pick<SimfileWithDtx, 'id' | 'is_published' | 'download_url'> & {
-		has_uploaded_files?: boolean;
+	type ChartListTableItemData = Pick<SimfileModel, 'id' | 'isPublished' | 'downloadUrl'> & {
+		hasUploadedFiles?: boolean;
 	};
 
 	let {
@@ -31,7 +31,7 @@
 	let popoverOpen = $state(false);
 	let modalOpen = $state(false);
 
-	const canOpenEditor = $derived(item.has_uploaded_files === true);
+	const canOpenEditor = $derived(item.hasUploadedFiles === true);
 	const previewable = $derived(isPreviewable(item));
 
 	function handleDeleteConfirm() {
@@ -98,12 +98,12 @@
 				</a>
 
 				<Button
-					onclick={() => togglePublishChart(item.id, item.is_published)}
+					onclick={() => togglePublishChart(item.id, item.isPublished)}
 					variant="menuItem"
 					fullWidth
 					justify="start"
 				>
-					{#snippet children()}{item.is_published ? 'Unpublish' : 'Publish'}{/snippet}
+					{#snippet children()}{item.isPublished ? 'Unpublish' : 'Publish'}{/snippet}
 				</Button>
 
 				<Button onclick={openModal} variant="menuItem" fullWidth justify="start">
@@ -127,13 +127,13 @@
 		{#if enableDownload}
 			<DownloadDropdown
 				simfileId={item.id}
-				externalUrl={item.download_url ?? null}
-				hasUploadedFiles={item.has_uploaded_files}
+				externalUrl={item.downloadUrl ?? null}
+				hasUploadedFiles={item.hasUploadedFiles}
 				compact={true}
 			/>
-		{:else if item.download_url}
+		{:else if item.downloadUrl}
 			<a
-				href={item.download_url}
+				href={item.downloadUrl}
 				target="_blank"
 				rel="noopener noreferrer"
 				class="inline-flex items-center justify-center rounded-full bg-slate-100 p-2 text-slate-600 hover:bg-slate-200"

--- a/packages/dtx-web/src/lib/components/ChartListTableItem.test.ts
+++ b/packages/dtx-web/src/lib/components/ChartListTableItem.test.ts
@@ -34,9 +34,9 @@ import { goto } from '$app/navigation';
 
 const mockItem = {
 	id: 10,
-	is_published: false,
-	download_url: null as string | null,
-	has_uploaded_files: true
+	isPublished: false,
+	downloadUrl: null as string | null,
+	hasUploadedFiles: true
 };
 
 describe('ChartListTableItem', () => {
@@ -52,7 +52,7 @@ describe('ChartListTableItem', () => {
 		vi.clearAllMocks();
 	});
 
-	it('does not render a dialog in blog mode with no download_url', () => {
+	it('does not render a dialog in blog mode with no downloadUrl', () => {
 		render(ChartListTableItem, { props: { ...defaultProps, isBlog: true } });
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 	});
@@ -63,7 +63,7 @@ describe('ChartListTableItem', () => {
 				...defaultProps,
 				isBlog: true,
 				enableDownload: true,
-				item: { ...mockItem, download_url: 'https://dl.example.com' }
+				item: { ...mockItem, downloadUrl: 'https://dl.example.com' }
 			}
 		});
 		const r2Button = screen.getByRole('button', { name: 'chart_actions.download' });
@@ -79,8 +79,8 @@ describe('ChartListTableItem', () => {
 				isBlog: true,
 				enableDownload: true,
 				item: (() => {
-					const item = { ...mockItem, download_url: 'https://dl.example.com' };
-					delete (item as { has_uploaded_files?: boolean }).has_uploaded_files;
+					const item = { ...mockItem, downloadUrl: 'https://dl.example.com' };
+					delete (item as { hasUploadedFiles?: boolean }).hasUploadedFiles;
 					return item;
 				})()
 			}
@@ -91,25 +91,25 @@ describe('ChartListTableItem', () => {
 		expect(screen.getByRole('link', { name: /external download link/i })).toBeInTheDocument();
 	});
 
-	it('shows R2 download link in blog mode when download_url is null', () => {
+	it('shows R2 download link in blog mode when downloadUrl is null', () => {
 		render(ChartListTableItem, {
 			props: {
 				...defaultProps,
 				isBlog: true,
 				enableDownload: true,
-				item: { ...mockItem, download_url: null }
+				item: { ...mockItem, downloadUrl: null }
 			}
 		});
 		expect(screen.getByRole('button', { name: 'chart_actions.download' })).toBeInTheDocument();
 	});
 
-	it('hides the R2 download link in blog mode when download_url is null and uploads are unavailable', () => {
+	it('hides the R2 download link in blog mode when downloadUrl is null and uploads are unavailable', () => {
 		render(ChartListTableItem, {
 			props: {
 				...defaultProps,
 				isBlog: true,
 				enableDownload: true,
-				item: { ...mockItem, download_url: null, has_uploaded_files: false }
+				item: { ...mockItem, downloadUrl: null, hasUploadedFiles: false }
 			}
 		});
 		expect(
@@ -126,8 +126,8 @@ describe('ChartListTableItem', () => {
 				enableDownload: true,
 				item: {
 					...mockItem,
-					has_uploaded_files: false,
-					download_url: 'https://dl.example.com'
+					hasUploadedFiles: false,
+					downloadUrl: 'https://dl.example.com'
 				}
 			}
 		});
@@ -143,7 +143,7 @@ describe('ChartListTableItem', () => {
 				...defaultProps,
 				isBlog: true,
 				enableDownload: false,
-				item: { ...mockItem, download_url: 'https://dl.example.com' }
+				item: { ...mockItem, downloadUrl: 'https://dl.example.com' }
 			}
 		});
 
@@ -167,7 +167,7 @@ describe('ChartListTableItem', () => {
 			props: {
 				...defaultProps,
 				isBlog: true,
-				item: { ...mockItem, is_published: true }
+				item: { ...mockItem, isPublished: true }
 			}
 		});
 
@@ -179,7 +179,7 @@ describe('ChartListTableItem', () => {
 
 	it('shows Preview and Edit details in owner mode for a published uploaded chart', () => {
 		render(ChartListTableItem, {
-			props: { ...defaultProps, item: { ...mockItem, is_published: true } }
+			props: { ...defaultProps, item: { ...mockItem, isPublished: true } }
 		});
 
 		// PopoverStub always renders its content.
@@ -216,18 +216,18 @@ describe('ChartListTableItem', () => {
 			).not.toBeInTheDocument();
 		});
 
-		it('"Open in Editor" is not rendered when has_uploaded_files is false', () => {
+		it('"Open in Editor" is not rendered when hasUploadedFiles is false', () => {
 			render(ChartListTableItem, {
-				props: { ...defaultProps, item: { ...mockItem, has_uploaded_files: false } }
+				props: { ...defaultProps, item: { ...mockItem, hasUploadedFiles: false } }
 			});
 			expect(
 				screen.queryByRole('button', { name: 'Open in Editor' })
 			).not.toBeInTheDocument();
 		});
 
-		it('"Open in Editor" is not rendered when has_uploaded_files is undefined', () => {
+		it('"Open in Editor" is not rendered when hasUploadedFiles is undefined', () => {
 			const item = { ...mockItem };
-			delete (item as { has_uploaded_files?: boolean }).has_uploaded_files;
+			delete (item as { hasUploadedFiles?: boolean }).hasUploadedFiles;
 			render(ChartListTableItem, { props: { ...defaultProps, item } });
 			expect(
 				screen.queryByRole('button', { name: 'Open in Editor' })

--- a/packages/dtx-web/src/lib/utils.test.ts
+++ b/packages/dtx-web/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { formatLevel, formatLevelDisplay, filterFiles, buildPreviewUrl } from './utils';
-import type { DtxFileRow } from '@dtx/common';
+import type { SimfileDtxFile } from '@dtx/common';
 
 describe('utils', () => {
 	describe('formatLevel', () => {
@@ -47,24 +47,18 @@ describe('utils', () => {
 
 	describe('formatLevelDisplay', () => {
 		it('should format level display for normal levels', () => {
-			const dtxFiles: DtxFileRow[] = [
+			const dtxFiles: SimfileDtxFile[] = [
 				{
 					level: 25,
-					id: 1,
-					label: 'Test 1',
-					simfile_id: 1
+					label: 'Test 1'
 				},
 				{
 					level: 15,
-					id: 2,
-					label: 'Test 2',
-					simfile_id: 1
+					label: 'Test 2'
 				},
 				{
 					level: 35,
-					id: 3,
-					label: 'Test 3',
-					simfile_id: 1
+					label: 'Test 3'
 				}
 			];
 
@@ -73,18 +67,14 @@ describe('utils', () => {
 		});
 
 		it('should format level display for high levels (> 100)', () => {
-			const dtxFiles: DtxFileRow[] = [
+			const dtxFiles: SimfileDtxFile[] = [
 				{
 					level: 150,
-					id: 1,
-					label: 'Test 1',
-					simfile_id: 1
+					label: 'Test 1'
 				},
 				{
 					level: 250,
-					id: 2,
-					label: 'Test 2',
-					simfile_id: 1
+					label: 'Test 2'
 				}
 			];
 
@@ -93,18 +83,14 @@ describe('utils', () => {
 		});
 
 		it('should handle mixed level ranges', () => {
-			const dtxFiles: DtxFileRow[] = [
+			const dtxFiles: SimfileDtxFile[] = [
 				{
 					level: 25,
-					id: 1,
-					label: 'Test 1',
-					simfile_id: 1
+					label: 'Test 1'
 				},
 				{
 					level: 150,
-					id: 2,
-					label: 'Test 2',
-					simfile_id: 1
+					label: 'Test 2'
 				}
 			];
 
@@ -115,18 +101,14 @@ describe('utils', () => {
 		});
 
 		it('should handle zero levels', () => {
-			const dtxFiles: DtxFileRow[] = [
+			const dtxFiles: SimfileDtxFile[] = [
 				{
 					level: 0,
-					id: 1,
-					label: 'Test 1',
-					simfile_id: 1
+					label: 'Test 1'
 				},
 				{
 					level: 25,
-					id: 2,
-					label: 'Test 2',
-					simfile_id: 1
+					label: 'Test 2'
 				}
 			];
 
@@ -137,9 +119,9 @@ describe('utils', () => {
 		it('should sort mixed ×10 and ×100 encodings by normalized level', () => {
 			// 55 → 5.50 (×10), 500 → 5.00 (×100). Raw sort would give
 			// 5.50 / 5.00 (55 < 500); normalized sort gives 5.00 / 5.50.
-			const dtxFiles: DtxFileRow[] = [
-				{ level: 55, id: 1, label: 'BSC', simfile_id: 1 },
-				{ level: 500, id: 2, label: 'ADV', simfile_id: 1 }
+			const dtxFiles: SimfileDtxFile[] = [
+				{ level: 55, label: 'BSC' },
+				{ level: 500, label: 'ADV' }
 			];
 			const result = formatLevelDisplay(dtxFiles);
 			expect(result).toBe('5.00 / 5.50');
@@ -151,24 +133,18 @@ describe('utils', () => {
 		});
 
 		it('should sort levels correctly', () => {
-			const dtxFiles: DtxFileRow[] = [
+			const dtxFiles: SimfileDtxFile[] = [
 				{
 					level: 35,
-					id: 3,
-					label: 'Test 3',
-					simfile_id: 1
+					label: 'Test 3'
 				},
 				{
 					level: 15,
-					id: 1,
-					label: 'Test 1',
-					simfile_id: 1
+					label: 'Test 1'
 				},
 				{
 					level: 25,
-					id: 2,
-					label: 'Test 2',
-					simfile_id: 1
+					label: 'Test 2'
 				}
 			];
 
@@ -176,11 +152,11 @@ describe('utils', () => {
 			expect(result).toBe('1.50 / 2.50 / 3.50');
 		});
 
-		it('should not mutate the original dtx_files array order', () => {
-			const dtxFiles: DtxFileRow[] = [
-				{ level: 35, id: 3, label: 'Third', simfile_id: 1 },
-				{ level: 15, id: 1, label: 'First', simfile_id: 1 },
-				{ level: 25, id: 2, label: 'Second', simfile_id: 1 }
+		it('should not mutate the original dtxFiles array order', () => {
+			const dtxFiles: SimfileDtxFile[] = [
+				{ level: 35, label: 'Third' },
+				{ level: 15, label: 'First' },
+				{ level: 25, label: 'Second' }
 			];
 
 			formatLevelDisplay(dtxFiles);

--- a/packages/dtx-web/src/lib/utils.ts
+++ b/packages/dtx-web/src/lib/utils.ts
@@ -3,14 +3,14 @@ import { formatLevel, normalizeLevel } from '@dtx/common';
 export { formatLevel };
 
 /**
- * Decode and join the `dtx_files.level` values for list display, sorted by
- * normalized (display-scale) level so mixed encodings (×10 and ×100) are
- * ordered correctly. See `formatLevel` / `normalizeLevel` (re-exported from
- * `@dtx/common`) for the per-value decode contract.
+ * Decode and join the `dtxFiles.level` DTX level values for list display,
+ * sorted by normalized (display-scale) level so mixed encodings (×10 and
+ * ×100) are ordered correctly. See `formatLevel` / `normalizeLevel`
+ * (re-exported from `@dtx/common`) for the per-value decode contract.
  */
-export const formatLevelDisplay = (dtx_files: Array<{ level?: string | number }>): string => {
+export const formatLevelDisplay = (dtxFiles: Array<{ level?: string | number }>): string => {
 	return (
-		dtx_files
+		dtxFiles
 			?.slice()
 			.sort((a, b) => normalizeLevel(a.level) - normalizeLevel(b.level))
 			.map((file) => formatLevel(file.level))

--- a/packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte
@@ -3,13 +3,13 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { _ } from 'svelte-i18n';
-	import type { SimFile, DTXFile } from '@dtx/common';
+	import type { SimFile, DTXFile, SimfileModel } from '@dtx/common';
 	import { UploadedAssetFiles, ChartDetail } from '@dtx/common/components';
 	import toastStore from '@/lib/toaster';
 	import { PUBLIC_SIMFILE_BUCKET_URL } from '$env/static/public';
-	import { getSimfile, updateSimfile, type LegacySimfile } from '$lib/api';
+	import { getSimfile, updateSimfile } from '$lib/api';
 
-	let simfile: LegacySimfile | null = $state(null);
+	let simfile: SimfileModel | null = $state(null);
 	let loading = $state(true);
 	let error: string | null = $state(null);
 	let updatedHighestDtx = $state<DTXFile | null>(null);
@@ -96,7 +96,7 @@
 	{:else if error}
 		<p class="text-red-500">Error: {error}</p>
 	{:else if simfile}
-		{#if simfile.is_published}
+		{#if simfile.isPublished}
 			<div class="mb-4">
 				<a
 					class="rounded-sm bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
@@ -109,7 +109,7 @@
 			</div>
 		{/if}
 		<ChartDetail
-			simfile={simfile as import('@dtx/common').SimfileWithDtxFiles}
+			{simfile}
 			on:onSave={(e) =>
 				handleUpdateSimfile(
 					e.detail.displayId,

--- a/packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte
+++ b/packages/dtx-web/src/routes/(app)/app/chart/[id]/+page.svelte
@@ -5,7 +5,7 @@
 	import { _ } from 'svelte-i18n';
 	import type { SimFile, DTXFile, SimfileModel } from '@dtx/common';
 	import { UploadedAssetFiles, ChartDetail } from '@dtx/common/components';
-	import toastStore from '@/lib/toaster';
+	import toastStore from '$lib/toaster';
 	import { PUBLIC_SIMFILE_BUCKET_URL } from '$env/static/public';
 	import { getSimfile, updateSimfile } from '$lib/api';
 

--- a/packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts
+++ b/packages/dtx-web/src/routes/(app)/app/chart/[id]/chart-detail-page.test.ts
@@ -91,7 +91,7 @@ import ChartDetailPage from './+page.svelte';
 import { ChartDetail, UploadedAssetFiles } from '@dtx/common/components';
 import toastStore from '$lib/toaster';
 
-const mockSimfileResponse = { id: 123, title: 'Test Song', is_published: false };
+const mockSimfileResponse = { id: 123, title: 'Test Song', isPublished: false };
 
 describe('Chart Detail Page', () => {
 	beforeEach(() => {
@@ -159,7 +159,7 @@ describe('handleUpdateSimfile via ChartDetail onSave prop', () => {
 
 	it('calls updateSimfile and shows success toast when update succeeds', async () => {
 		mockGetSimfile.mockResolvedValue(mockSimfileResponse);
-		mockUpdateSimfile.mockResolvedValue({ ...mockSimfileResponse, is_published: true });
+		mockUpdateSimfile.mockResolvedValue({ ...mockSimfileResponse, isPublished: true });
 
 		render(ChartDetailPage);
 
@@ -376,7 +376,7 @@ describe('handleUpdateSimfile basic update flow', () => {
 			bpm: 120
 		};
 		mockGetSimfile.mockResolvedValue(simfileResponse);
-		mockUpdateSimfile.mockResolvedValue({ ...simfileResponse, is_published: true });
+		mockUpdateSimfile.mockResolvedValue({ ...simfileResponse, isPublished: true });
 
 		render(ChartDetailPage);
 
@@ -460,7 +460,7 @@ describe('Chart Detail Page - preview link visibility', () => {
 	});
 
 	it('hides the preview link when the simfile is unpublished', async () => {
-		mockGetSimfile.mockResolvedValue({ ...mockSimfileResponse, is_published: false });
+		mockGetSimfile.mockResolvedValue({ ...mockSimfileResponse, isPublished: false });
 		render(ChartDetailPage);
 		await waitFor(() => {
 			expect(vi.mocked(ChartDetail).mock.calls.length).toBeGreaterThan(0);
@@ -469,7 +469,7 @@ describe('Chart Detail Page - preview link visibility', () => {
 	});
 
 	it('shows the preview link when the simfile is published', async () => {
-		mockGetSimfile.mockResolvedValue({ ...mockSimfileResponse, is_published: true });
+		mockGetSimfile.mockResolvedValue({ ...mockSimfileResponse, isPublished: true });
 		render(ChartDetailPage);
 		const link = await screen.findByText('preview.open');
 		expect(link).toBeInTheDocument();

--- a/packages/e2e-desktop/scripts/google-drive-crash-recovery.ts
+++ b/packages/e2e-desktop/scripts/google-drive-crash-recovery.ts
@@ -257,7 +257,7 @@ const seedRendererState = async (
 				})
 			);
 			localStorage.setItem(
-				'dtx_linkage_cache',
+				'dtx_linkage_cache_v2',
 				JSON.stringify({
 					[songPath]: {
 						linkedSimFileId: simfileId,
@@ -267,14 +267,17 @@ const seedRendererState = async (
 							title: 'Critical Workspace Song',
 							artist: 'Integration Test',
 							bpm: 120,
-							is_published: false,
-							publish_date: '2026-07-25',
-							display_id: Number(simfileId),
-							download_url: null,
-							google_drive_file_id: null,
-							preview_url: null,
-							video_preview_url: null,
-							dtx_files: []
+							displayId: Number(simfileId),
+							userId: null,
+							googleDriveFileId: null,
+							isPublished: false,
+							downloadUrl: null,
+							previewUrl: null,
+							videoPreviewUrl: null,
+							publishDate: '2026-07-25',
+							createdAt: '2026-07-25T00:00:00.000Z',
+							updatedAt: '2026-07-25T00:00:00.000Z',
+							dtxFiles: []
 						}
 					}
 				})

--- a/packages/e2e-desktop/specs/google-drive-upload.e2e.ts
+++ b/packages/e2e-desktop/specs/google-drive-upload.e2e.ts
@@ -70,27 +70,33 @@ const linkedSimfile = ({
 	title: string;
 	artist: string;
 	bpm: number;
-	is_published: boolean;
-	publish_date: string;
-	display_id: number;
-	download_url: string | null;
-	google_drive_file_id: string | null;
-	preview_url: string | null;
-	video_preview_url: string | null;
-	dtx_files: never[];
+	displayId: number;
+	userId: null;
+	googleDriveFileId: string | null;
+	isPublished: boolean;
+	downloadUrl: string | null;
+	previewUrl: null;
+	videoPreviewUrl: null;
+	publishDate: string;
+	createdAt: string;
+	updatedAt: string;
+	dtxFiles: never[];
 } => ({
 	id: Number(simfileId),
 	title: rendererTitle,
 	artist: 'Integration Test',
 	bpm: 120,
-	is_published: false,
-	publish_date: '2026-07-25',
-	display_id: Number(simfileId),
-	download_url: downloadUrl,
-	google_drive_file_id: googleDriveFileId,
-	preview_url: null,
-	video_preview_url: null,
-	dtx_files: []
+	displayId: Number(simfileId),
+	userId: null,
+	googleDriveFileId,
+	isPublished: false,
+	downloadUrl,
+	previewUrl: null,
+	videoPreviewUrl: null,
+	publishDate: '2026-07-25',
+	createdAt: '2026-07-25T00:00:00.000Z',
+	updatedAt: '2026-07-25T00:00:00.000Z',
+	dtxFiles: []
 });
 
 const openAuthenticatedLinkedSong = async ({
@@ -118,7 +124,7 @@ const openAuthenticatedLinkedSong = async ({
 				})
 			);
 			localStorage.setItem(
-				'dtx_linkage_cache',
+				'dtx_linkage_cache_v2',
 				JSON.stringify({
 					[songPath]: {
 						linkedSimFileId: String(cloudSong.id),


### PR DESCRIPTION
## Summary

- selects HPA-614 as the next actionable DTXWeb slice because it is unblocked and blocks HPA-615, HPA-616, and HPA-617
- proposes one camelCase `SimfileModel` in `@dtx/common` for shared/web/desktop application code
- keeps D1 snake_case at the server persistence boundary and normalizes once at the web GraphQL and desktop native boundaries
- versions the three renderer caches instead of adding old-shape compatibility readers
- intentionally retains the Supabase `Database` type and root `gen-types` task because current web auth still consumes them

## Documents

- `docs/superpowers/specs/2026-08-15-hpa-614-current-simfile-model-design.md`
- `docs/superpowers/plans/2026-08-15-hpa-614-current-simfile-model.md`

## Scope

Planning-only draft PR. No product code changes.

Linear: https://linear.app/cwchanap/issue/HPA-614/dtxwebarchitecture-replace-legacy-simfile-compatibility-shapes-with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a consistent simfile format across web and desktop experiences.
  * Added consistent display of publication status, timestamps, previews, download links, and DTX files.
* **Bug Fixes**
  * Improved handling of missing or invalid simfile and download information.
  * Prevented outdated cache entries from being reused.
* **Tests**
  * Expanded coverage for simfile display, downloads, linking, caching, and Google Drive workflows.
* **Documentation**
  * Updated manual cache-clearing instructions for the latest cache keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->