### PR TITLE
docs: plan HPA-613 affected CI

### DIFF
--- a/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Reduce ready-PR GitHub Actions cost by running expensive validation only for affected application/native areas while preserving the required `test` and `lint-and-format` status contexts and all current `main`/release behavior.
+**Goal:** Reduce ready-PR GitHub Actions cost by running expensive validation only for affected application/native areas while preserving the required `test` and `lint-and-format` status contexts, repo-wide formatting/lint coverage, Codecov's 90% policy, and all current `main`/release behavior.
 
-**Architecture:** Keep the current workflow boundaries. The two required jobs perform a cheap Turborepo affected-package query inside the existing job and conditionally skip expensive steps; non-required workflows use PR path filters; packaging stops running on ordinary PRs; CodeQL dynamically selects relevant languages on PRs while remaining full on `main` and schedule.
+**Architecture:** Keep the current workflow boundaries. Add one small tested fail-open scope script that uses Git diff plus Turborepo's affected-package JSON; the required unit job uses it as a binary coverage gate, the required lint job gates only schema/codegen/typecheck work while always running install/ESLint/Prettier, and CodeQL reuses it for PR language selection. Non-required E2E/Rust workflows use native path filters, ordinary PR packaging is removed, and Codecov uses carryforward flags for intentionally skipped suites.
 
 **Tech Stack:** GitHub Actions, Bun 1.3.9, Turborepo 2.10.x, Bash/jq, CodeQL, Codecov, Tauri/Rust 1.95.
 
@@ -12,171 +12,362 @@
 
 - Keep job ids `test` in `.github/workflows/unit-test.yml` and `lint-and-format` in `.github/workflows/lint-and-format.yml` unchanged; the active `Main` ruleset requires those exact contexts.
 - Do not add `pull_request.paths` to either required workflow.
-- On any scope-detection error, run the existing expensive validation rather than silently skipping it.
-- Pushes to `main` keep full validation behavior.
+- Keep checkout `fetch-depth: 0` for affected-scope jobs; do not add a second Git-history scheme.
+- On any missing ref, Git diff failure, Turbo failure, unexpected Turbo JSON, jq failure, or wrapper failure, run the existing expensive validation rather than silently skipping it.
+- Root `bun run test:coverage` remains one all-or-nothing Turborepo command; do not split it into package-specific coverage commands.
+- `lint-and-format` always runs dependency installation, repo ESLint, and repo Prettier on ready PRs.
 - Keep GraphQL schema generation before generated-client verification.
-- Keep Codecov project/patch targets in `codecov.yml` unchanged; only uploader failures become non-blocking.
+- Keep Codecov project/patch targets at 90% with `threshold: 0%`; carryforward flags are routing support, not a threshold change.
 - Keep `preview`, `main`, `v*`, and `workflow_dispatch` desktop packaging/release entry points.
-- No new CI service, dependency graph implementation, remote cache, or monolithic CI workflow.
+- Keep CodeQL full on `main` and schedule; PR scans remain language-specific because HPA-613 explicitly requires it.
+- No new CI service, dependency graph implementation, remote cache, generic classifier framework, or monolithic CI workflow.
 
 ---
 
-## File map
+## File structure
 
-- `.github/workflows/unit-test.yml` — required `test` context and TypeScript coverage upload.
-- `.github/workflows/lint-and-format.yml` — required lint/codegen/typecheck/format context.
-- `.github/workflows/e2e-test.yml` — web/Supabase/Playwright E2E path gate.
-- `.github/workflows/desktop-e2e-test.yml` — existing desktop path gate and Codecov uploader behavior.
-- `.github/workflows/tauri-rust-ci.yml` — Rust PR path gate and Codecov uploader behavior.
-- `.github/workflows/desktop-build-deploy.yml` — release-only cross-platform packaging after this change.
-- `.github/workflows/codeql.yml` — PR path gate, changed-language selector, and dynamic matrix.
-- `CLAUDE.md` — contributor-facing affected-area matrix and required-check explanation.
+**Create**
+
+- `.github/scripts/ci-affected-scope.sh` — one fail-open scope implementation for `unit`, `lint`, and `codeql` modes.
+- `.github/scripts/fixtures/turbo-ls-web.json` — recorded Turbo JSON with `dtx-web` affected.
+- `.github/scripts/fixtures/turbo-ls-empty.json` — recorded Turbo JSON with zero affected packages.
+- `.github/scripts/fixtures/turbo-ls-malformed.json` — intentionally invalid/unexpected payload for failure coverage.
+
+**Modify**
+
+- `.github/workflows/unit-test.yml` — preserve required `test`; gate full root coverage.
+- `.github/workflows/lint-and-format.yml` — preserve required `lint-and-format`; always lint/format, gate workspace/generated work.
+- `.github/workflows/e2e-test.yml` — add web-stack PR paths.
+- `.github/workflows/desktop-e2e-test.yml` — add Codecov flag and non-blocking uploader transport behavior only.
+- `.github/workflows/tauri-rust-ci.yml` — add narrow native PR paths and Codecov flag/transport behavior.
+- `.github/workflows/desktop-build-deploy.yml` — remove ordinary PR packaging and PR-only unsigned branches.
+- `.github/workflows/codeql.yml` — add PR source paths and reuse the shared script for language selection.
+- `codecov.yml` — define three carryforward flags; keep existing 90% statuses.
+- `CLAUDE.md` — document the ready-PR affected-area matrix and fail-open rule.
 
 ---
 
-### Task 1: Make the two required jobs cheap on unrelated PRs
+### Task 1: Add and execute the fail-open scope script
+
+**Files:**
+- Create: `.github/scripts/ci-affected-scope.sh`
+- Create: `.github/scripts/fixtures/turbo-ls-web.json`
+- Create: `.github/scripts/fixtures/turbo-ls-empty.json`
+- Create: `.github/scripts/fixtures/turbo-ls-malformed.json`
+
+**Interfaces:**
+- Consumes: `TURBO_SCM_BASE`, `TURBO_SCM_HEAD`; optional fixture-only `CI_CHANGED_FILES_FILE` and `CI_AFFECTED_JSON_FILE`.
+- Produces: stdout is exactly `true`/`false` for `unit`/`lint`, or a non-empty compact JSON language array for `codeql`; diagnostics go to stderr. Unexpected runtime failures exit non-zero so workflow wrappers can fail open.
+
+- [ ] **Step 1: Record representative Turbo JSON fixtures using the live `turbo ls --affected --output=json` schema**
+
+`turbo-ls-web.json`:
+
+```json
+{
+  "packageManager": "bun",
+  "packages": {
+    "count": 1,
+    "items": [
+      {
+        "name": "dtx-web",
+        "path": "packages/dtx-web"
+      }
+    ]
+  }
+}
+```
+
+`turbo-ls-empty.json`:
+
+```json
+{
+  "packageManager": "bun",
+  "packages": {
+    "count": 0,
+    "items": []
+  }
+}
+```
+
+`turbo-ls-malformed.json`:
+
+```text
+{"packages":{"count":1,"items":"not-an-array"}}
+```
+
+The exact recorded non-package metadata may differ from the fixture above when the implementation is started. If the checked-in Turbo command emits a different real schema, update these fixtures and the parser together **before** wiring any workflow. Do not preserve a parser contradicted by live output.
+
+- [ ] **Step 2: Implement the small shared script**
+
+Create `.github/scripts/ci-affected-scope.sh` with this shape:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+all_codeql='["actions","javascript-typescript","python","rust"]'
+
+case "$mode" in
+  unit|lint|codeql) ;;
+  *)
+    echo "usage: $0 <unit|lint|codeql>" >&2
+    exit 2
+    ;;
+esac
+
+read_changed_files() {
+  if [[ -n "${CI_CHANGED_FILES_FILE:-}" ]]; then
+    cat "$CI_CHANGED_FILES_FILE"
+    return
+  fi
+
+  : "${TURBO_SCM_BASE:?TURBO_SCM_BASE is required}"
+  : "${TURBO_SCM_HEAD:?TURBO_SCM_HEAD is required}"
+  git diff --name-only "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD"
+}
+
+read_affected_json() {
+  if [[ -n "${CI_AFFECTED_JSON_FILE:-}" ]]; then
+    cat "$CI_AFFECTED_JSON_FILE"
+    return
+  fi
+
+  : "${TURBO_SCM_BASE:?TURBO_SCM_BASE is required}"
+  : "${TURBO_SCM_HEAD:?TURBO_SCM_HEAD is required}"
+  TURBO_SCM_BASE="$TURBO_SCM_BASE" \
+    TURBO_SCM_HEAD="$TURBO_SCM_HEAD" \
+    bunx turbo ls --affected --output=json
+}
+
+changed_files="$(read_changed_files)"
+printf '%s\n' '--- changed files ---' "$changed_files" >&2
+
+if [[ "$mode" == "codeql" ]]; then
+  languages=()
+
+  grep -Eq '^\.github/workflows/' <<<"$changed_files" && languages+=(actions)
+  grep -Eq '(^|/)[^/]+\.(js|jsx|cjs|mjs|ts|tsx|svelte)$' <<<"$changed_files" \
+    && languages+=(javascript-typescript)
+  grep -Eq '^scripts/.*\.py$' <<<"$changed_files" && languages+=(python)
+  grep -Eq '^packages/dtx-desktop/src-tauri/.*\.rs$' <<<"$changed_files" \
+    && languages+=(rust)
+
+  if [[ ${#languages[@]} -eq 0 ]]; then
+    printf '%s\n' "$all_codeql"
+  else
+    printf '%s\n' "${languages[@]}" | jq -R . | jq -sc .
+  fi
+  exit 0
+fi
+
+affected_json="$(read_affected_json)"
+printf '%s\n' '--- turbo affected json ---' "$affected_json" >&2
+
+jq -e '
+  (.packages | type) == "object" and
+  (.packages.count | type) == "number" and
+  (.packages.items | type) == "array" and
+  .packages.count == (.packages.items | length) and
+  all(.packages.items[]; (.name | type) == "string" and (.path | type) == "string")
+' <<<"$affected_json" >/dev/null
+
+if [[ "$mode" == "unit" ]]; then
+  if grep -Eq '^(\.github/workflows/unit-test\.yml|\.github/scripts/ci-affected-scope\.sh|package\.json|bun\.lock|turbo\.json|codecov\.yml)$' \
+    <<<"$changed_files"; then
+    echo true
+    exit 0
+  fi
+
+  if jq -e '
+    [.packages.items[].name]
+    | any(
+        . == "@dtx/common" or
+        . == "@dtx/ui-components" or
+        . == "dtx-web" or
+        . == "dtx-api" or
+        . == "dtx-desktop"
+      )
+  ' <<<"$affected_json" >/dev/null; then
+    echo true
+  else
+    echo false
+  fi
+  exit 0
+fi
+
+if grep -Eq '^(\.github/workflows/lint-and-format\.yml|\.github/scripts/ci-affected-scope\.sh|package\.json|bun\.lock|turbo\.json)$' \
+  <<<"$changed_files"; then
+  echo true
+elif jq -e '.packages.count > 0' <<<"$affected_json" >/dev/null; then
+  echo true
+else
+  echo false
+fi
+```
+
+Keep the literal rules here. Do not introduce config files, reusable workflow abstractions, or a generic rule DSL.
+
+- [ ] **Step 3: Make the script executable and syntax-check it**
+
+Run:
+
+```bash
+chmod +x .github/scripts/ci-affected-scope.sh
+bash -n .github/scripts/ci-affected-scope.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Verify the package parser against fixtures before any YAML wiring**
+
+Create an empty changed-files fixture temporarily:
+
+```bash
+empty_changed="$(mktemp)"
+: > "$empty_changed"
+```
+
+Run:
+
+```bash
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-web.json \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected stdout:
+
+```text
+true
+```
+
+Run:
+
+```bash
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected stdout:
+
+```text
+false
+```
+
+Run:
+
+```bash
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
+  .github/scripts/ci-affected-scope.sh lint
+```
+
+Expected stdout:
+
+```text
+false
+```
+
+Run:
+
+```bash
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-malformed.json \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected: non-zero. This is intentional; the workflow wrapper added in Tasks 2/3 turns it into full validation.
+
+- [ ] **Step 5: Verify force-full root changes**
+
+```bash
+changed="$(mktemp)"
+printf '%s\n' 'codecov.yml' > "$changed"
+CI_CHANGED_FILES_FILE="$changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected stdout: `true`.
+
+- [ ] **Step 6: Execute the script with a real Git/Turborepo comparison**
+
+Run from a branch with at least one parent commit:
+
+```bash
+TURBO_SCM_BASE="$(git rev-parse HEAD^)" \
+TURBO_SCM_HEAD="$(git rev-parse HEAD)" \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected: exit 0 and stderr contains the raw `turbo ls --affected --output=json` payload. The boolean result depends on the actual last commit.
+
+This step is load-bearing. Do not proceed to workflow gating if the live Turbo JSON contradicts the fixture/parser.
+
+- [ ] **Step 7: Verify a dtx-web fixture still turns coverage on**
+
+Re-run the web fixture from Step 4 immediately before committing. Expected: `true`.
+
+- [ ] **Step 8: Commit the detector seam**
+
+```bash
+git add .github/scripts/ci-affected-scope.sh .github/scripts/fixtures/
+git commit -m "ci: add affected scope detector"
+```
+
+---
+
+### Task 2: Gate the required root unit-coverage job
 
 **Files:**
 - Modify: `.github/workflows/unit-test.yml`
-- Modify: `.github/workflows/lint-and-format.yml`
 
 **Interfaces:**
-- Consumes: PR base/head SHAs from `github.event.pull_request`, the repository workspace graph from Turborepo, and the existing job ids.
-- Produces: `steps.scope.outputs.run_expensive` (`true` or `false`) used only by later steps in the same required job.
+- Consumes: `.github/scripts/ci-affected-scope.sh unit`.
+- Produces: existing required job id `test`; output `steps.scope.outputs.run_expensive` controls the existing coverage stack.
 
-- [ ] **Step 1: Preserve full git history in the required workflows**
+- [ ] **Step 1: Give checkout full history**
 
-In both workflows, keep `actions/checkout@v7` but add:
+Change checkout to:
 
 ```yaml
-with:
-  fetch-depth: 0
+- name: Checkout code
+  uses: actions/checkout@v7
+  with:
+    fetch-depth: 0
 ```
 
-The scope query needs both PR SHAs locally. Do not add workflow-level path filters.
+Keep the existing draft job guard.
 
-- [ ] **Step 2: Add the unit-test scope step before dependency installation**
-
-After `Setup Bun`, add this step to `unit-test.yml`:
+- [ ] **Step 2: Add the fail-open scope wrapper after Bun setup and before install**
 
 ```yaml
-- name: Detect affected unit-test packages
+- name: Determine unit coverage scope
   id: scope
   shell: bash
   env:
-    EVENT_NAME: ${{ github.event_name }}
-    BASE_SHA: ${{ github.event.pull_request.base.sha }}
-    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+    TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
   run: |
-    set -euo pipefail
-
-    if [[ "$EVENT_NAME" != "pull_request" ]]; then
+    if [[ "${{ github.event_name }}" != "pull_request" ]]; then
       echo "run_expensive=true" >> "$GITHUB_OUTPUT"
       exit 0
     fi
 
-    changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
-    if grep -Eq '^(\.github/workflows/unit-test\.yml|package\.json|bun\.lock|turbo\.json|codecov\.yml)$' <<<"$changed_files"; then
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
-
-    if ! affected="$(
-      TURBO_SCM_BASE="$BASE_SHA" \
-      TURBO_SCM_HEAD="$HEAD_SHA" \
-      bunx turbo@2.10.9 ls --affected --output=json
-    )"; then
-      echo "::warning::Affected-package detection failed; running full unit coverage."
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
-
-    if jq -e '
-      [.packages[].name]
-      | any(
-          . == "@dtx/common"
-          or . == "@dtx/ui-components"
-          or . == "dtx-api"
-          or . == "dtx-web"
-          or . == "dtx-desktop"
-        )
-    ' <<<"$affected" >/dev/null; then
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+    if run_expensive="$(.github/scripts/ci-affected-scope.sh unit)"; then
+      echo "run_expensive=$run_expensive" >> "$GITHUB_OUTPUT"
     else
-      echo "run_expensive=false" >> "$GITHUB_OUTPUT"
-      echo "No unit-test-bearing workspace package is affected; required test context will finish after the cheap gate."
+      echo "Affected-scope detection failed; running full unit coverage." >&2
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
     fi
 ```
 
-Keep the full `bun run test:coverage` command when the gate is true. Do not switch to partial-package coverage in this task.
+Do not use a bare `git diff` in the YAML. Git/Turbo/jq failures belong behind the wrapper and must resolve to `true`.
 
-- [ ] **Step 3: Condition all expensive unit-test steps on the scope output**
-
-Add this condition to the existing steps from `Install dependencies` through `Upload coverage to Codecov`:
-
-```yaml
-if: steps.scope.outputs.run_expensive == 'true'
-```
-
-The required job itself must still run and finish successfully when the condition is false.
-
-- [ ] **Step 4: Make the TypeScript Codecov uploader non-blocking**
-
-Change only the uploader transport behavior:
-
-```yaml
-with:
-  token: ${{ secrets.CODECOV_TOKEN }}
-  fail_ci_if_error: false
-```
-
-Do not edit `codecov.yml`.
-
-- [ ] **Step 5: Add the broader lint/codegen scope step**
-
-After `Setup Bun` in `lint-and-format.yml`, add:
-
-```yaml
-- name: Detect affected lint/codegen scope
-  id: scope
-  shell: bash
-  env:
-    EVENT_NAME: ${{ github.event_name }}
-    BASE_SHA: ${{ github.event.pull_request.base.sha }}
-    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-  run: |
-    set -euo pipefail
-
-    if [[ "$EVENT_NAME" != "pull_request" ]]; then
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
-
-    changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
-    if grep -Eq '^(\.editorconfig|\.eslintignore|\.eslintrc\.cjs|\.prettierignore|\.prettierrc|\.github/workflows/lint-and-format\.yml|package\.json|bun\.lock|turbo\.json)$' <<<"$changed_files"; then
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
-
-    if ! affected="$(
-      TURBO_SCM_BASE="$BASE_SHA" \
-      TURBO_SCM_HEAD="$HEAD_SHA" \
-      bunx turbo@2.10.9 ls --affected --output=json
-    )"; then
-      echo "::warning::Affected-package detection failed; running full lint/codegen validation."
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
-
-    if jq -e '.packages | length > 0' <<<"$affected" >/dev/null; then
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-    else
-      echo "run_expensive=false" >> "$GITHUB_OUTPUT"
-      echo "No workspace package is affected; required lint-and-format context will finish after the cheap gate."
-    fi
-```
-
-- [ ] **Step 6: Condition the existing full lint/codegen sequence without reordering it**
+- [ ] **Step 3: Condition the existing expensive steps, not the job**
 
 Add:
 
@@ -184,55 +375,163 @@ Add:
 if: steps.scope.outputs.run_expensive == 'true'
 ```
 
-to every existing step after scope detection:
+to the existing steps for:
 
-- `Install dependencies`
-- `Generate SvelteKit types`
-- `Build packages`
-- `Generate and verify GraphQL schema`
-- `Verify generated GraphQL client`
-- `Typecheck e2e packages`
-- `Run linting`
-- `Run formatting check`
+- `bun install --frozen-lockfile`;
+- SvelteKit type preparation;
+- `@dtx/common` build;
+- `bun run test:coverage`;
+- Codecov upload.
 
-Do not split schema generation and client drift into separate gates.
+Do not change root `bun run test:coverage` itself.
 
-- [ ] **Step 7: Validate the required-job YAML and status names**
+- [ ] **Step 4: Validate workflow syntax and required context**
 
 Run:
 
 ```bash
-actionlint .github/workflows/unit-test.yml .github/workflows/lint-and-format.yml
+actionlint .github/workflows/unit-test.yml
 grep -n '^  test:' .github/workflows/unit-test.yml
-grep -n '^  lint-and-format:' .github/workflows/lint-and-format.yml
-git diff --check
+grep -n 'paths:' .github/workflows/unit-test.yml || true
 ```
 
-Expected: `actionlint` and `git diff --check` are clean; the existing job ids are unchanged.
+Expected:
 
-- [ ] **Step 8: Commit the required-job gate**
+- actionlint passes;
+- job id remains `test`;
+- no PR event-level `paths` was introduced.
+
+- [ ] **Step 5: Re-run the detector web fixture before accepting the workflow gate**
 
 ```bash
-git add .github/workflows/unit-test.yml .github/workflows/lint-and-format.yml
-git commit -m "ci: gate required checks by affected workspace"
+empty_changed="$(mktemp)"
+: > "$empty_changed"
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-web.json \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected: `true`. If not, stop; a green required `test` would be unsafe.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/unit-test.yml
+git commit -m "ci: gate root unit coverage by affected scope"
 ```
 
 ---
 
-### Task 2: Add PR path gates to the non-required web/native test workflows
+### Task 3: Keep repo lint/format always-on and gate only heavy lint work
+
+**Files:**
+- Modify: `.github/workflows/lint-and-format.yml`
+
+**Interfaces:**
+- Consumes: `.github/scripts/ci-affected-scope.sh lint`.
+- Produces: existing required job id `lint-and-format`; `steps.scope.outputs.run_workspace_checks` controls only build/schema/codegen/E2E typecheck steps.
+
+- [ ] **Step 1: Give checkout full history**
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@v7
+  with:
+    fetch-depth: 0
+```
+
+- [ ] **Step 2: Add the fail-open heavy-work wrapper after Bun setup**
+
+```yaml
+- name: Determine workspace lint scope
+  id: scope
+  shell: bash
+  env:
+    TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+    TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
+  run: |
+    if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+      echo "run_workspace_checks=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    if run_workspace_checks="$(.github/scripts/ci-affected-scope.sh lint)"; then
+      echo "run_workspace_checks=$run_workspace_checks" >> "$GITHUB_OUTPUT"
+    else
+      echo "Affected-scope detection failed; running full workspace lint checks." >&2
+      echo "run_workspace_checks=true" >> "$GITHUB_OUTPUT"
+    fi
+```
+
+- [ ] **Step 3: Leave install, ESLint, and Prettier unconditional**
+
+These steps must have **no** `if: steps.scope...` condition:
+
+```yaml
+- name: Install dependencies
+  run: bun install --frozen-lockfile
+
+- name: Run linting
+  run: bun run lint
+
+- name: Run formatting check
+  run: bunx prettier --check .
+```
+
+This is what keeps a docs-only PR from merging Markdown that fails the repo format check.
+
+- [ ] **Step 4: Gate only the workspace/generated sequence**
+
+Add:
+
+```yaml
+if: steps.scope.outputs.run_workspace_checks == 'true'
+```
+
+to the existing steps that:
+
+- generate SvelteKit types / prepare the web package;
+- build `@dtx/common`;
+- generate and verify the API GraphQL schema;
+- verify the generated web GraphQL client;
+- typecheck `dtx-e2e-web` and `dtx-e2e-desktop`.
+
+Keep schema generation before `lint:codegen`.
+
+- [ ] **Step 5: Verify docs-only still reaches repo-wide checks**
+
+Run:
+
+```bash
+actionlint .github/workflows/lint-and-format.yml
+grep -n 'Run linting\|Run formatting check' .github/workflows/lint-and-format.yml
+grep -n '^  lint-and-format:' .github/workflows/lint-and-format.yml
+```
+
+Inspect the two repo-wide steps and confirm they have no affected-scope `if`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/lint-and-format.yml
+git commit -m "ci: gate generated lint work by affected scope"
+```
+
+---
+
+### Task 4: Add native PR path filters to non-required validation
 
 **Files:**
 - Modify: `.github/workflows/e2e-test.yml`
-- Modify: `.github/workflows/desktop-e2e-test.yml`
 - Modify: `.github/workflows/tauri-rust-ci.yml`
 
 **Interfaces:**
-- Consumes: GitHub's native `pull_request.paths` evaluation.
-- Produces: web E2E, desktop E2E, and Tauri Rust workflows that are not created for unrelated PRs; push behavior remains unchanged.
+- Consumes: GitHub Actions native event path matching.
+- Produces: web E2E starts only for web/shared/E2E/root-test inputs; Rust CI starts only for native/generated-contract/root-build inputs. `main`/`master` pushes remain full.
 
-- [ ] **Step 1: Gate web E2E by the web/API/shared path set**
+- [ ] **Step 1: Add web E2E PR paths**
 
-Keep the existing `push` trigger broad. Add only this PR path list under `pull_request` in `e2e-test.yml`:
+Under `pull_request` in `e2e-test.yml`, keep the existing branches/types and add:
 
 ```yaml
 paths:
@@ -248,104 +547,60 @@ paths:
   - 'turbo.json'
 ```
 
-Do not add desktop paths.
+Do not add this path filter to the push trigger; `main`/`master` web E2E stays full.
 
-- [ ] **Step 2: Keep the existing desktop E2E path set and make its Codecov uploader non-blocking**
+- [ ] **Step 2: Add a narrower Tauri Rust PR path set**
 
-Verify `desktop-e2e-test.yml` still includes:
-
-```yaml
-paths:
-  - 'packages/dtx-desktop/**'
-  - 'packages/e2e-desktop/**'
-  - 'packages/common/**'
-  - 'packages/ui-components/**'
-  - '.github/workflows/desktop-e2e-test.yml'
-  - 'package.json'
-  - 'bun.lock'
-  - 'turbo.json'
-```
-
-Then change its Codecov action to:
-
-```yaml
-fail_ci_if_error: false
-```
-
-Do not change coverage generation or artifact upload behavior.
-
-- [ ] **Step 3: Add the desktop/shared PR path set to Tauri Rust CI**
-
-Keep `push` on `main`/`master` unchanged. Add under `pull_request`:
+Under `pull_request` in `tauri-rust-ci.yml`, add:
 
 ```yaml
 paths:
   - 'packages/dtx-desktop/**'
   - 'packages/e2e-desktop/**'
-  - 'packages/common/**'
-  - 'packages/ui-components/**'
   - '.github/workflows/tauri-rust-ci.yml'
   - 'package.json'
   - 'bun.lock'
   - 'turbo.json'
 ```
 
-Keep both existing Rust jobs and the generated-TypeScript drift check unchanged.
+Do **not** include `packages/common/**` or `packages/ui-components/**`. The Rust workflow's generated drift outputs live under desktop/E2E-desktop, while the existing desktop E2E workflow already covers renderer/shared changes.
 
-- [ ] **Step 4: Make the Tauri Rust Codecov uploader non-blocking**
+Do not path-filter the Rust push trigger; `main`/`master` remains full.
 
-Change:
+- [ ] **Step 3: Leave desktop E2E's existing shared paths intact**
 
-```yaml
-fail_ci_if_error: true
-```
+Do not narrow `desktop-e2e-test.yml` in this task. It should continue to include `packages/common/**` and `packages/ui-components/**` because those are real desktop-renderer/E2E dependencies.
 
-to:
-
-```yaml
-fail_ci_if_error: false
-```
-
-Only for the Codecov upload action. Test/coverage generation failures still fail the job.
-
-- [ ] **Step 5: Validate workflow syntax**
-
-Run:
+- [ ] **Step 4: Validate syntax**
 
 ```bash
-actionlint \
-  .github/workflows/e2e-test.yml \
-  .github/workflows/desktop-e2e-test.yml \
-  .github/workflows/tauri-rust-ci.yml
+actionlint .github/workflows/e2e-test.yml .github/workflows/tauri-rust-ci.yml
 git diff --check
 ```
 
-Expected: clean.
+Expected: pass.
 
-- [ ] **Step 6: Commit the non-required test gates**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add \
-  .github/workflows/e2e-test.yml \
-  .github/workflows/desktop-e2e-test.yml \
-  .github/workflows/tauri-rust-ci.yml
-git commit -m "ci: skip unaffected web and desktop validation"
+git add .github/workflows/e2e-test.yml .github/workflows/tauri-rust-ci.yml
+git commit -m "ci: scope e2e and rust checks by path"
 ```
 
 ---
 
-### Task 3: Remove ordinary PR packaging while preserving release channels
+### Task 5: Remove ordinary PR desktop packaging
 
 **Files:**
 - Modify: `.github/workflows/desktop-build-deploy.yml`
 
 **Interfaces:**
-- Consumes: existing `preview`, `main`, tag, and manual-dispatch events.
-- Produces: Windows/macOS packaging only for those release/preproduction entry points; no ordinary PR packaging runs.
+- Consumes: existing `preview`, `main`, `v*`, and `workflow_dispatch` entry points.
+- Produces: no Windows/macOS packaging for ordinary PRs; current release/preview paths remain.
 
-- [ ] **Step 1: Remove the PR trigger**
+- [ ] **Step 1: Remove the pull-request trigger**
 
-Delete only the `pull_request` event block. The top-level trigger must remain equivalent to:
+Delete the `pull_request` block from `on:`. Keep:
 
 ```yaml
 on:
@@ -356,106 +611,90 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Semver version (MAJOR.MINOR.PATCH) written to the updater manifest. Must exceed the currently installed version to be offered as an update.'
-        required: true
-        type: string
 ```
 
-- [ ] **Step 2: Remove job conditions that only existed to admit/skip PR builds**
+Preserve existing manual inputs below `workflow_dispatch`.
 
-Delete the Windows/macOS job-level conditions shaped like:
+- [ ] **Step 2: Remove job conditions that only filtered PRs**
+
+Delete/simplify conditions such as:
 
 ```yaml
-if: github.event_name != 'pull_request' || (...)
+if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.head_ref != 'preview')
 ```
 
-All remaining triggers are intended packaging events.
+They are unnecessary once the workflow has no PR event.
 
-- [ ] **Step 3: Retarget Google Drive environment conditions to `preview` vs release only**
+- [ ] **Step 3: Remove both unsigned PR build steps**
 
-For both Windows and macOS jobs, change preproduction selection to:
+Delete Windows/macOS steps whose only branch is:
 
 ```yaml
-if: github.ref == 'refs/heads/preview'
+if: github.event_name == 'pull_request'
 ```
 
-and production selection to:
+Keep the existing non-PR signed build commands and their signing secrets.
 
-```yaml
-if: github.ref != 'refs/heads/preview'
-```
+- [ ] **Step 4: Simplify preproduction/production configuration conditions without changing preview semantics**
 
-Do not change the validation scripts or environment variable names.
+Change preproduction Google Drive configuration from PR-or-preview to preview only.
 
-- [ ] **Step 4: Delete unsigned PR build steps and make the existing signed build the single build step**
+Keep production configuration for non-preview release paths.
 
-Remove both platform steps named like:
+Do not change updater versioning, artifact layout, signing, R2 deployment, release manifests, or target architectures.
 
-```text
-Build Tauri App for ... (PR, unsigned)
-```
-
-Rename the signed steps to normal platform build names and remove their now-always-true `if: github.event_name != 'pull_request'` conditions. Keep the signing-key environment variables exactly as they are.
-
-- [ ] **Step 5: Remove stale PR-only comments and prove no PR condition remains**
-
-Run:
-
-```bash
-grep -n "pull_request" .github/workflows/desktop-build-deploy.yml
-```
-
-Expected: no matches.
-
-Do not rewrite unrelated release/version/signing comments.
-
-- [ ] **Step 6: Validate and commit**
+- [ ] **Step 5: Validate release entry points and syntax**
 
 ```bash
 actionlint .github/workflows/desktop-build-deploy.yml
-git diff --check
+grep -n 'pull_request' .github/workflows/desktop-build-deploy.yml || true
+grep -n 'preview\|main\|v\*\|workflow_dispatch' .github/workflows/desktop-build-deploy.yml
+```
+
+Expected: no executable PR trigger/PR-only build branches remain; release entry points remain present.
+
+- [ ] **Step 6: Commit**
+
+```bash
 git add .github/workflows/desktop-build-deploy.yml
-git commit -m "ci: reserve desktop packaging for release flows"
+git commit -m "ci: stop packaging desktop apps on pull requests"
 ```
 
 ---
 
-### Task 4: Select only relevant CodeQL languages on pull requests
+### Task 6: Keep PR CodeQL language-scoped without a third classifier
 
 **Files:**
 - Modify: `.github/workflows/codeql.yml`
+- Reuse: `.github/scripts/ci-affected-scope.sh`
 
 **Interfaces:**
-- Consumes: changed PR file paths.
-- Produces: `select-languages.outputs.matrix` and `select-languages.outputs.should_run`; the existing `analyze` job consumes the dynamic matrix.
+- Consumes: `.github/scripts/ci-affected-scope.sh codeql` and GitHub PR source path filtering.
+- Produces: non-empty JSON language matrix; main/schedule always use all four existing languages.
 
-- [ ] **Step 1: Add a combined PR source-path trigger without changing push/schedule**
+- [ ] **Step 1: Add PR-level source/workflow paths**
 
-Under `pull_request`, add:
+Keep push-to-main and schedule unchanged. Under `pull_request`, add paths matching at least one CodeQL language:
 
 ```yaml
 paths:
   - '.github/workflows/**'
-  - '.github/actions/**'
   - '**/*.js'
+  - '**/*.jsx'
   - '**/*.cjs'
   - '**/*.mjs'
   - '**/*.ts'
+  - '**/*.tsx'
   - '**/*.svelte'
-  - '**/package.json'
-  - 'bun.lock'
   - 'scripts/**/*.py'
-  - 'scripts/**/requirements*.txt'
-  - 'packages/dtx-desktop/src-tauri/**'
+  - 'packages/dtx-desktop/src-tauri/**/*.rs'
 ```
 
-CodeQL is not a required context, so workflow-level path filtering is safe here.
+This is the cheap docs-only filter. It does not replace per-language PR selection.
 
-- [ ] **Step 2: Add a `select-languages` job before `analyze`**
+- [ ] **Step 2: Add a selector job that reuses the shared script**
 
-Add:
+Add before `analyze`:
 
 ```yaml
 select-languages:
@@ -463,219 +702,375 @@ select-languages:
   permissions:
     contents: read
   outputs:
-    matrix: ${{ steps.select.outputs.matrix }}
-    should_run: ${{ steps.select.outputs.should_run }}
+    languages: ${{ steps.scope.outputs.languages }}
   steps:
     - name: Checkout repository
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Select CodeQL languages
-      id: select
+      id: scope
       shell: bash
       env:
-        EVENT_NAME: ${{ github.event_name }}
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+        TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
       run: |
-        set -euo pipefail
+        all='["actions","javascript-typescript","python","rust"]'
 
-        languages='[]'
-        add_language() {
-          local language="$1"
-          languages="$(jq -c --arg language "$language" '. + [{language: $language, "build-mode": "none"}]' <<<"$languages")"
-        }
-
-        if [[ "$EVENT_NAME" != "pull_request" ]]; then
-          add_language actions
-          add_language javascript-typescript
-          add_language python
-          add_language rust
-        else
-          if ! changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"; then
-            echo "::warning::Could not calculate PR diff; scanning all CodeQL languages."
-            add_language actions
-            add_language javascript-typescript
-            add_language python
-            add_language rust
-          else
-            if grep -Eq '^\.github/(workflows|actions)/' <<<"$changed_files"; then
-              add_language actions
-            fi
-
-            if grep -Eq '(^|/)(package\.json)$|^bun\.lock$|\.(js|cjs|mjs|ts|svelte)$' <<<"$changed_files"; then
-              add_language javascript-typescript
-            fi
-
-            if grep -Eq '^scripts/.*\.py$|^scripts/.*/requirements[^/]*\.txt$|^scripts/requirements[^/]*\.txt$' <<<"$changed_files"; then
-              add_language python
-            fi
-
-            if grep -Eq '^packages/dtx-desktop/src-tauri/' <<<"$changed_files"; then
-              add_language rust
-            fi
-          fi
+        if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          echo "languages=$all" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
 
-        matrix="$(jq -cn --argjson include "$languages" '{include: $include}')"
-        echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
-        if [[ "$(jq 'length' <<<"$languages")" -gt 0 ]]; then
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        if languages="$(.github/scripts/ci-affected-scope.sh codeql)"; then
+          echo "languages=$languages" >> "$GITHUB_OUTPUT"
         else
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          echo "CodeQL scope detection failed; analyzing all languages." >&2
+          echo "languages=$all" >> "$GITHUB_OUTPUT"
         fi
 ```
 
-The failure fallback is intentionally all languages.
+The script returns all four on an unexpected empty mapping after the workflow has triggered, so the matrix is never empty.
 
-- [ ] **Step 3: Feed the selector into the existing analyze job**
+- [ ] **Step 3: Replace the static analyze matrix source**
 
 Add:
 
 ```yaml
 needs: select-languages
-if: >-
-  ${{
-    (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    && needs.select-languages.outputs.should_run == 'true'
-  }}
 ```
 
-Replace the static matrix `include` block with:
+and change the matrix to:
 
 ```yaml
 strategy:
   fail-fast: false
-  matrix: ${{ fromJSON(needs.select-languages.outputs.matrix) }}
+  matrix:
+    language: ${{ fromJSON(needs.select-languages.outputs.languages) }}
 ```
 
-Keep the existing dynamic job name, runner choice, permissions, CodeQL init, and analyze steps unchanged.
+Retain the existing runner selection, permissions, CodeQL init, and analysis steps.
 
-- [ ] **Step 4: Validate the four mapping cases directly**
+- [ ] **Step 4: Fixture-check language mapping**
 
-Before committing, copy the selector shell into a temporary local shell function or inspect it with representative newline-separated paths and verify:
+```bash
+changed="$(mktemp)"
+printf '%s\n' \
+  '.github/workflows/unit-test.yml' \
+  'packages/dtx-web/src/lib/example.ts' \
+  'packages/dtx-desktop/src-tauri/src/api.rs' > "$changed"
 
-```text
-.github/workflows/unit-test.yml                     -> actions
-packages/dtx-web/src/routes/+page.svelte           -> javascript-typescript
-scripts/cli.py                                      -> python
-packages/dtx-desktop/src-tauri/src/api.rs           -> rust
+CI_CHANGED_FILES_FILE="$changed" \
+  .github/scripts/ci-affected-scope.sh codeql
 ```
 
-A path list containing both renderer TypeScript and Rust must emit both languages exactly once.
+Expected JSON contains exactly:
 
-- [ ] **Step 5: Validate and commit**
+```json
+["actions", "javascript-typescript", "rust"]
+```
+
+(order may be compacted but stays deterministic from the script).
+
+- [ ] **Step 5: Validate workflow syntax**
 
 ```bash
 actionlint .github/workflows/codeql.yml
-git diff --check
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
 git add .github/workflows/codeql.yml
-git commit -m "ci: scope CodeQL PR analysis by language"
+git commit -m "ci: scope PR CodeQL by changed language"
 ```
 
 ---
 
-### Task 5: Document the affected-area matrix and perform final verification
+### Task 7: Make partial coverage uploads compatible with Codecov policy
+
+**Files:**
+- Modify: `codecov.yml`
+- Modify: `.github/workflows/unit-test.yml`
+- Modify: `.github/workflows/tauri-rust-ci.yml`
+- Modify: `.github/workflows/desktop-e2e-test.yml`
+
+**Interfaces:**
+- Produces three named coverage streams: `typescript`, `tauri-rust`, and `desktop-e2e-rust`, each with carryforward enabled.
+
+- [ ] **Step 1: Add carryforward flag definitions without touching thresholds**
+
+Extend `codecov.yml`:
+
+```yaml
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 0%
+        informational: false
+        if_not_found: failure
+    patch:
+      default:
+        target: 90%
+        threshold: 0%
+        informational: false
+        if_not_found: failure
+
+flags:
+  typescript:
+    carryforward: true
+  tauri-rust:
+    carryforward: true
+  desktop-e2e-rust:
+    carryforward: true
+```
+
+Do not change the 90% values, threshold, or informational settings.
+
+- [ ] **Step 2: Flag root TypeScript coverage and make uploader transport informational**
+
+In `unit-test.yml`:
+
+```yaml
+with:
+  token: ${{ secrets.CODECOV_TOKEN }}
+  flags: typescript
+  fail_ci_if_error: false
+```
+
+Keep the upload step under the Task 2 `run_expensive` gate.
+
+- [ ] **Step 3: Flag Tauri Rust unit coverage**
+
+In `tauri-rust-ci.yml`:
+
+```yaml
+with:
+  token: ${{ secrets.CODECOV_TOKEN }}
+  files: packages/dtx-desktop/src-tauri/lcov.info
+  flags: tauri-rust
+  fail_ci_if_error: false
+```
+
+- [ ] **Step 4: Flag desktop E2E Rust coverage**
+
+In `desktop-e2e-test.yml`:
+
+```yaml
+with:
+  token: ${{ secrets.CODECOV_TOKEN }}
+  files: packages/dtx-desktop/src-tauri/e2e-lcov.info
+  flags: desktop-e2e-rust
+  fail_ci_if_error: false
+```
+
+- [ ] **Step 5: Verify the implementation PR establishes all three flags**
+
+Because this implementation changes `unit-test.yml`, `tauri-rust-ci.yml`, `desktop-e2e-test.yml`, and `codecov.yml`, all three coverage-producing workflows should be selected on the implementation PR. Confirm Codecov receives one upload for each flag before relying on carryforward on later PRs.
+
+- [ ] **Step 6: Validate thresholds and upload settings**
+
+```bash
+grep -n 'target: 90%\|threshold: 0%\|carryforward: true' codecov.yml
+grep -R -n 'flags: \|fail_ci_if_error:' \
+  .github/workflows/unit-test.yml \
+  .github/workflows/tauri-rust-ci.yml \
+  .github/workflows/desktop-e2e-test.yml
+actionlint \
+  .github/workflows/unit-test.yml \
+  .github/workflows/tauri-rust-ci.yml \
+  .github/workflows/desktop-e2e-test.yml
+```
+
+Expected: three carryforward flags, three matching uploader flags, all uploader transport failures non-blocking, 90% policy unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codecov.yml \
+  .github/workflows/unit-test.yml \
+  .github/workflows/tauri-rust-ci.yml \
+  .github/workflows/desktop-e2e-test.yml
+git commit -m "ci: carry forward partial coverage suites"
+```
+
+---
+
+### Task 8: Document and verify the complete affected-area matrix
 
 **Files:**
 - Modify: `CLAUDE.md`
+- Verify: every HPA-613 workflow/script/config change
 
 **Interfaces:**
-- Consumes: the final workflow path/gate behavior from Tasks 1-4.
-- Produces: one contributor-facing matrix that future workflow edits can compare against.
+- Produces: contributor-visible CI rules and final evidence that scope reduction cannot silently suppress required validation.
 
-- [ ] **Step 1: Add an `Affected-area CI` subsection near the development/testing commands**
+- [ ] **Step 1: Add the ready-PR matrix to `CLAUDE.md`**
 
-Document these invariants:
+Document these cases:
 
-```markdown
-### Affected-area CI
+| Change | Unit coverage | ESLint/Prettier | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| docs only | skip | run | skip | skip | skip | skip | skip | skip |
+| `dtx-web` | run | run | run | run | skip | skip | skip | JS/TS |
+| `dtx-api` | run | run | run | run | skip | skip | skip | JS/TS |
+| `common` | run | run | run | run | run | skip | skip | JS/TS |
+| `ui-components` | run | run | run | run | run | skip | skip | JS/TS |
+| desktop renderer | run | run | run | skip | run | run | skip | JS/TS |
+| desktop Rust | run | run | run | skip | run | run | skip | Rust |
+| web E2E only | skip | run | run | run | skip | skip | skip | JS/TS when source matches |
+| desktop E2E only | skip | run | run | skip | run | run | skip | JS/TS when source matches |
 
-The `Main` ruleset requires the `test` and `lint-and-format` job contexts. Those two workflows always start for a ready PR and perform a cheap Turborepo affected-package gate inside the existing required job; do not add PR-level `paths` filters to them.
+Also state:
 
-| PR change | `test` | `lint-and-format` | Web E2E | Desktop E2E | Tauri Rust | PR packaging | CodeQL |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| docs only | cheap gate | cheap gate | no | no | no | no | no |
-| `dtx-web` | full | full | yes | no | no | no | JS/TS |
-| `dtx-api` | full | full | yes | no | no | no | JS/TS |
-| `dtx-desktop` renderer | full | full | no | yes | yes | no | JS/TS |
-| `dtx-desktop/src-tauri` | full | full | no | yes | yes | no | Rust (+ JS/TS only when JS/TS files also change) |
-| `common` | full | full | yes | yes | yes | no | JS/TS |
-| `ui-components` | full | full | yes | yes | yes | no | JS/TS |
-| `e2e-web` | cheap/no unit work | full | yes | no | no | no | JS/TS |
-| `e2e-desktop` | cheap/no unit work | full | no | yes | yes | no | JS/TS |
-| `package.json` / `bun.lock` / `turbo.json` | full | full | yes | yes | yes | no | JS/TS |
+- `test` and `lint-and-format` must remain event-visible required contexts;
+- scope-detection failures run more CI, never less;
+- ordinary PR packaging is intentionally absent;
+- `main` and scheduled CodeQL remain full;
+- skipped coverage suites use Codecov carryforward flags.
 
-Windows/macOS packaging runs only from `preview`, `main`, `v*` tags, or manual dispatch. `main`/scheduled CodeQL remains a full language scan.
-```
-
-Keep the wording concise; this is an operational matrix, not a second design document.
-
-- [ ] **Step 2: Run final workflow lint and diff checks**
+- [ ] **Step 2: Re-run script verification**
 
 ```bash
-actionlint .github/workflows/*.yml
+bash -n .github/scripts/ci-affected-scope.sh
+
+empty_changed="$(mktemp)"
+: > "$empty_changed"
+
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-web.json \
+  .github/scripts/ci-affected-scope.sh unit | grep -qx true
+
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
+  .github/scripts/ci-affected-scope.sh unit | grep -qx false
+
+CI_CHANGED_FILES_FILE="$empty_changed" \
+CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
+  .github/scripts/ci-affected-scope.sh lint | grep -qx false
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Prove the malformed detector path fails open at wrapper level**
+
+Run the script directly and require failure:
+
+```bash
+if CI_CHANGED_FILES_FILE="$empty_changed" \
+  CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-malformed.json \
+  .github/scripts/ci-affected-scope.sh unit; then
+  echo 'expected malformed Turbo JSON to fail' >&2
+  exit 1
+fi
+```
+
+Then inspect `unit-test.yml` and `lint-and-format.yml` and confirm their `else` branches write `true` to the relevant outputs.
+
+- [ ] **Step 4: Re-run one real Turbo comparison**
+
+```bash
+TURBO_SCM_BASE="$(git rev-parse HEAD^)" \
+TURBO_SCM_HEAD="$(git rev-parse HEAD)" \
+  .github/scripts/ci-affected-scope.sh unit
+```
+
+Expected: exits 0 and logs raw changed files plus affected JSON.
+
+- [ ] **Step 5: Validate every changed workflow**
+
+```bash
+actionlint \
+  .github/workflows/unit-test.yml \
+  .github/workflows/lint-and-format.yml \
+  .github/workflows/e2e-test.yml \
+  .github/workflows/desktop-e2e-test.yml \
+  .github/workflows/tauri-rust-ci.yml \
+  .github/workflows/desktop-build-deploy.yml \
+  .github/workflows/codeql.yml
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Verify required checks and release entry points stayed deterministic**
+
+```bash
+grep -n '^  test:' .github/workflows/unit-test.yml
+grep -n '^  lint-and-format:' .github/workflows/lint-and-format.yml
+grep -n 'preview\|main\|v\*\|workflow_dispatch' .github/workflows/desktop-build-deploy.yml
+```
+
+Expected: required job ids unchanged; release entry points retained.
+
+- [ ] **Step 7: Verify no PR packaging remains**
+
+```bash
+if grep -n 'pull_request' .github/workflows/desktop-build-deploy.yml; then
+  echo 'ordinary PR packaging reference remains' >&2
+  exit 1
+fi
+```
+
+Expected: no match.
+
+- [ ] **Step 8: Verify Codecov routing without policy drift**
+
+```bash
+grep -n 'target: 90%\|threshold: 0%' codecov.yml
+grep -n 'typescript:\|tauri-rust:\|desktop-e2e-rust:\|carryforward: true' codecov.yml
+```
+
+Expected: 90%/0% policy unchanged and all three flags present.
+
+- [ ] **Step 9: Run repository formatting validation for the changed docs/config**
+
+```bash
+bunx prettier --check \
+  .github/workflows/unit-test.yml \
+  .github/workflows/lint-and-format.yml \
+  .github/workflows/e2e-test.yml \
+  .github/workflows/desktop-e2e-test.yml \
+  .github/workflows/tauri-rust-ci.yml \
+  .github/workflows/desktop-build-deploy.yml \
+  .github/workflows/codeql.yml \
+  codecov.yml \
+  CLAUDE.md
+
 git diff --check
 ```
 
-Expected: clean.
+Expected: pass.
 
-- [ ] **Step 3: Re-check the active required status contexts**
-
-With authenticated `gh`:
-
-```bash
-gh api repos/cwchanap/DTXWeb/rulesets/6439239 \
-  --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context'
-```
-
-Expected output contains exactly:
-
-```text
-test
-lint-and-format
-```
-
-If the live ruleset changed since planning, update the gate strategy before merging rather than assuming these contexts.
-
-- [ ] **Step 4: Review the documented dry-run matrix against every workflow**
-
-For each row in `CLAUDE.md`, point to the corresponding PR `paths` list or required-job scope condition. Specifically verify `packages/common/**` and `packages/ui-components/**` fan out to both web and desktop validation, and a docs-only PR reaches only the two cheap required gates.
-
-- [ ] **Step 5: Confirm release behavior is unchanged for non-PR events**
-
-Inspect `desktop-build-deploy.yml` and verify all of these remain present:
-
-```text
-preview branch push
-main branch push
-v* tag push
-workflow_dispatch
-```
-
-Inspect `unit-test.yml`, `lint-and-format.yml`, `e2e-test.yml`, `tauri-rust-ci.yml`, and `codeql.yml` and verify push-to-`main` remains full rather than affected-only.
-
-- [ ] **Step 6: Commit the contributor documentation**
+- [ ] **Step 10: Commit documentation**
 
 ```bash
 git add CLAUDE.md
-git commit -m "docs: explain affected-area CI matrix"
+git commit -m "docs: document affected CI matrix"
 ```
 
-- [ ] **Step 7: Final branch verification**
+- [ ] **Step 11: Final implementation-PR proof before declaring HPA-613 complete**
 
-```bash
-git status --short
-git log --oneline main..HEAD
-git diff --stat main...HEAD
-actionlint .github/workflows/*.yml
-git diff --check main...HEAD
-```
+On the implementation PR, inspect the scope step log for a commit that changes `packages/dtx-web/**` (the implementation branch may include such a fixture/tested comparison rather than manufacturing a product change). The detector must show the web package in raw Turbo JSON and resolve unit coverage to `true`.
 
-Expected: clean worktree, only the seven workflow files plus `CLAUDE.md` changed, and every workflow passes `actionlint`.
+Do not accept `actionlint` alone as proof of scope correctness.
 
-## Implementation PR verification notes
+---
 
-When the implementation branch is marked ready for review, record which jobs actually ran/skipped for the branch's changed paths. The branch itself changes workflows and `CLAUDE.md`, so it is not a pure docs-only example; use the matrix above as the acceptance artifact rather than creating throwaway test infrastructure solely to manufacture every path combination.
+## Expected implementation commit sequence
+
+1. `ci: add affected scope detector`
+2. `ci: gate root unit coverage by affected scope`
+3. `ci: gate generated lint work by affected scope`
+4. `ci: scope e2e and rust checks by path`
+5. `ci: stop packaging desktop apps on pull requests`
+6. `ci: scope PR CodeQL by changed language`
+7. `ci: carry forward partial coverage suites`
+8. `docs: document affected CI matrix`
+
+Each commit is independently reviewable after the detector seam exists. Do not start relying on path filters or packaging reductions until Task 1 has executed successfully against both fixture JSON and one real Turborepo comparison.

--- a/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
@@ -1,1076 +1,334 @@
 # HPA-613 Affected CI Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
 
-**Goal:** Reduce ready-PR GitHub Actions cost by running expensive validation only for affected application/native areas while preserving the required `test` and `lint-and-format` status contexts, repo-wide formatting/lint coverage, Codecov's 90% policy, and all current `main`/release behavior.
+**Goal:** Reduce ready-PR GitHub Actions cost while preserving deterministic required checks, repo-wide lint/format coverage, Codecov policy, and current release behavior.
 
-**Architecture:** Keep the current workflow boundaries. Add one small tested fail-open scope script that uses Git diff plus Turborepo's affected-package JSON; the required unit job uses it as a binary coverage gate, the required lint job gates only schema/codegen/typecheck work while always running install/ESLint/Prettier, and CodeQL reuses it for PR language selection. Non-required E2E/Rust workflows use native path filters, ordinary PR packaging is removed, and Codecov uses carryforward flags for intentionally skipped suites.
+**Sequence:** PR A low-risk savings -> measure -> PR B required-check gates -> PR C CodeQL language selection. The measurement checkpoint can justify revising HPA-613, but PR A alone does not satisfy the current ticket.
 
-**Tech Stack:** GitHub Actions, Bun 1.3.9, Turborepo 2.10.x, Bash/jq, CodeQL, Codecov, Tauri/Rust 1.95.
+## Global constraints
 
-## Global Constraints
-
-- Keep job ids `test` in `.github/workflows/unit-test.yml` and `lint-and-format` in `.github/workflows/lint-and-format.yml` unchanged; the active `Main` ruleset requires those exact contexts.
-- Do not add `pull_request.paths` to either required workflow.
-- Keep checkout `fetch-depth: 0` for affected-scope jobs; do not add a second Git-history scheme.
-- On any missing ref, Git diff failure, Turbo failure, unexpected Turbo JSON, jq failure, or wrapper failure, run the existing expensive validation rather than silently skipping it.
-- Root `bun run test:coverage` remains one all-or-nothing Turborepo command; do not split it into package-specific coverage commands.
-- `lint-and-format` always runs dependency installation, repo ESLint, and repo Prettier on ready PRs.
-- Keep GraphQL schema generation before generated-client verification.
-- Keep Codecov project/patch targets at 90% with `threshold: 0%`; carryforward flags are routing support, not a threshold change.
-- Keep `preview`, `main`, `v*`, and `workflow_dispatch` desktop packaging/release entry points.
-- Keep CodeQL full on `main` and schedule; PR scans remain language-specific because HPA-613 explicitly requires it.
-- No new CI service, dependency graph implementation, remote cache, generic classifier framework, or monolithic CI workflow.
-
----
-
-## File structure
-
-**Create**
-
-- `.github/scripts/ci-affected-scope.sh` — one fail-open scope implementation for `unit`, `lint`, and `codeql` modes.
-- `.github/scripts/fixtures/turbo-ls-web.json` — recorded Turbo JSON with `dtx-web` affected.
-- `.github/scripts/fixtures/turbo-ls-empty.json` — recorded Turbo JSON with zero affected packages.
-- `.github/scripts/fixtures/turbo-ls-malformed.json` — intentionally invalid/unexpected payload for failure coverage.
-
-**Modify**
-
-- `.github/workflows/unit-test.yml` — preserve required `test`; gate full root coverage.
-- `.github/workflows/lint-and-format.yml` — preserve required `lint-and-format`; always lint/format, gate workspace/generated work.
-- `.github/workflows/e2e-test.yml` — add web-stack PR paths.
-- `.github/workflows/desktop-e2e-test.yml` — add Codecov flag and non-blocking uploader transport behavior only.
-- `.github/workflows/tauri-rust-ci.yml` — add narrow native PR paths and Codecov flag/transport behavior.
-- `.github/workflows/desktop-build-deploy.yml` — remove ordinary PR packaging and PR-only unsigned branches.
-- `.github/workflows/codeql.yml` — add PR source paths and reuse the shared script for language selection.
-- `codecov.yml` — define three carryforward flags; keep existing 90% statuses.
-- `CLAUDE.md` — document the ready-PR affected-area matrix and fail-open rule.
+- Required GitHub Actions contexts stay `test` and `lint-and-format`.
+- Never add event-level PR `paths` to `unit-test.yml` or `lint-and-format.yml`.
+- Rename the Playwright check before path-filtering it; unit and Playwright currently both publish `test`.
+- Root `bun run test:coverage` remains all-or-nothing.
+- `lint-and-format` always runs install, ESLint, and Prettier.
+- Detector failures run more validation, never less.
+- Use merge-base changed-file semantics.
+- Treat `turbo ls --output=json` as experimental: exact version, tests, real execution, fail-open.
+- Keep Codecov project/patch targets at 90% and `threshold: 0%`.
+- HPA-613 explicitly requires Codecov uploader failures to be informational, so use `fail_ci_if_error: false`.
+- Preserve `preview`, `main`, `v*`, and `workflow_dispatch` packaging/release paths.
+- Keep CodeQL full on `main`/schedule and preserve `build-mode: none`.
 
 ---
 
-### Task 1: Add and execute the fail-open scope script
+# PR A — low-risk savings first
 
-**Files:**
-- Create: `.github/scripts/ci-affected-scope.sh`
-- Create: `.github/scripts/fixtures/turbo-ls-web.json`
-- Create: `.github/scripts/fixtures/turbo-ls-empty.json`
-- Create: `.github/scripts/fixtures/turbo-ls-malformed.json`
+## A1. Disambiguate the Playwright check
 
-**Interfaces:**
-- Consumes: `TURBO_SCM_BASE`, `TURBO_SCM_HEAD`; optional fixture-only `CI_CHANGED_FILES_FILE` and `CI_AFFECTED_JSON_FILE`.
-- Produces: stdout is exactly `true`/`false` for `unit`/`lint`, or a non-empty compact JSON language array for `codeql`; diagnostics go to stderr. Unexpected runtime failures exit non-zero so workflow wrappers can fail open.
+**Modify:** `.github/workflows/e2e-test.yml`
 
-- [ ] **Step 1: Record representative Turbo JSON fixtures using the live `turbo ls --affected --output=json` schema**
+- [ ] Add `name: playwright` to `jobs.test`.
+- [ ] Keep the unit job unchanged so it continues publishing `test`.
+- [ ] Run `actionlint .github/workflows/e2e-test.yml`.
+- [ ] On one ready PR verify GitHub shows `test` from `Run Unit Tests` and `playwright` from `Playwright Tests`.
+- [ ] Confirm the ruleset still requires only `test` and `lint-and-format`.
 
-`turbo-ls-web.json`:
+Commit: `ci: disambiguate playwright check`
 
-```json
-{
-  "packageManager": "bun",
-  "packages": {
-    "count": 1,
-    "items": [
-      {
-        "name": "dtx-web",
-        "path": "packages/dtx-web"
-      }
-    ]
-  }
-}
+## A2. Remove ordinary PR packaging
+
+**Modify:** `.github/workflows/desktop-build-deploy.yml`
+
+- [ ] Remove the `pull_request` trigger.
+- [ ] Remove PR-only unsigned packaging branches/conditions.
+- [ ] Keep `preview`, `main`, `v*`, `workflow_dispatch`, signing, and deployment behavior.
+- [ ] Do not add a replacement packaging workflow.
+- [ ] Document the accepted risk: Windows/macOS packaging failures may first appear after merge; use `workflow_dispatch` before merge for risky packaging changes.
+- [ ] Run `actionlint` and grep the retained triggers.
+
+Commit: `ci: stop packaging desktop apps on pull requests`
+
+## A3. Path-filter non-required validation
+
+**Modify:**
+- `.github/workflows/e2e-test.yml`
+- `.github/workflows/desktop-e2e-test.yml`
+- `.github/workflows/tauri-rust-ci.yml`
+
+### Web E2E PR paths
+
+Include at least:
+
+```yaml
+- 'packages/dtx-web/**'
+- 'packages/dtx-api/**'
+- 'packages/common/**'
+- 'packages/ui-components/**'
+- 'packages/e2e-web/**'
+- 'supabase/**'
+- '.github/workflows/e2e-test.yml'
+- 'package.json'
+- 'bun.lock'
+- 'turbo.json'
+- 'tsconfig.base.json'
 ```
 
-`turbo-ls-empty.json`:
+Keep push behavior full.
 
-```json
-{
-  "packageManager": "bun",
-  "packages": {
-    "count": 0,
-    "items": []
-  }
-}
+### Desktop E2E
+
+- [ ] Keep the existing shared-package filters.
+- [ ] Add `tsconfig.base.json` to the existing path lists.
+
+### Tauri Rust PR paths
+
+Use only:
+
+```yaml
+- 'packages/dtx-desktop/**'
+- 'packages/e2e-desktop/**'
+- '.github/workflows/tauri-rust-ci.yml'
+- 'package.json'
+- 'bun.lock'
+- 'turbo.json'
 ```
 
-`turbo-ls-malformed.json`:
+Do not add `packages/common/**` or `packages/ui-components/**` solely because desktop E2E needs them.
 
-```text
-{"packages":{"count":1,"items":"not-an-array"}}
-```
+- [ ] Run `actionlint` on all three workflows.
 
-The exact recorded non-package metadata may differ from the fixture above when the implementation is started. If the checked-in Turbo command emits a different real schema, update these fixtures and the parser together **before** wiring any workflow. Do not preserve a parser contradicted by live output.
+Commit: `ci: filter non-required validation by affected paths`
 
-- [ ] **Step 2: Implement the small shared script**
+## A4. Fix shared TypeScript invalidation
 
-Create `.github/scripts/ci-affected-scope.sh` with this shape:
+**Modify:** `turbo.json`
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
+- [ ] Add `tsconfig.base.json` to `globalDependencies`.
+- [ ] Do **not** add `.eslintrc.cjs`, `.prettierrc`, `.eslintignore`, or `.prettierignore` merely to force unit coverage; ESLint/Prettier are unconditional.
 
-mode="${1:-}"
-all_codeql='["actions","javascript-typescript","python","rust"]'
+Commit: `ci: include shared tsconfig in turbo invalidation`
 
-case "$mode" in
-  unit|lint|codeql) ;;
-  *)
-    echo "usage: $0 <unit|lint|codeql>" >&2
-    exit 2
-    ;;
-esac
+## A5. Add CodeQL's cheap PR source filter
 
-read_changed_files() {
-  if [[ -n "${CI_CHANGED_FILES_FILE:-}" ]]; then
-    cat "$CI_CHANGED_FILES_FILE"
-    return
-  fi
+**Modify:** `.github/workflows/codeql.yml`
 
-  : "${TURBO_SCM_BASE:?TURBO_SCM_BASE is required}"
-  : "${TURBO_SCM_HEAD:?TURBO_SCM_HEAD is required}"
-  git diff --name-only "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD"
-}
+- [ ] Keep `main` and schedule unchanged.
+- [ ] Add PR `paths` for workflow files plus JS/TS/Svelte, `scripts/**/*.py`, and desktop Rust source.
+- [ ] Do not change the language matrix yet.
+- [ ] Run `actionlint`.
 
-read_affected_json() {
-  if [[ -n "${CI_AFFECTED_JSON_FILE:-}" ]]; then
-    cat "$CI_AFFECTED_JSON_FILE"
-    return
-  fi
+Commit: `ci: skip codeql for non-source pull requests`
 
-  : "${TURBO_SCM_BASE:?TURBO_SCM_BASE is required}"
-  : "${TURBO_SCM_HEAD:?TURBO_SCM_HEAD is required}"
-  TURBO_SCM_BASE="$TURBO_SCM_BASE" \
-    TURBO_SCM_HEAD="$TURBO_SCM_HEAD" \
-    bunx turbo ls --affected --output=json
-}
+## A6. Add Codecov flags + carryforward
 
-changed_files="$(read_changed_files)"
-printf '%s\n' '--- changed files ---' "$changed_files" >&2
+**Modify:**
+- `codecov.yml`
+- `.github/workflows/unit-test.yml`
+- `.github/workflows/tauri-rust-ci.yml`
+- `.github/workflows/desktop-e2e-test.yml`
 
-if [[ "$mode" == "codeql" ]]; then
-  languages=()
+- [ ] Keep 90% project/patch targets unchanged.
+- [ ] Define carryforward flags `typescript`, `tauri-rust`, and `desktop-e2e-rust`.
+- [ ] Pass the matching flag from each upload action.
+- [ ] Use `fail_ci_if_error: false` on all three uploads because HPA-613 explicitly asks transport failures to be informational.
+- [ ] Update comments so Codecov is described as coverage reporting/policy, not a branch-protection gate.
+- [ ] Run `actionlint` and grep the flags/targets.
 
-  grep -Eq '^\.github/workflows/' <<<"$changed_files" && languages+=(actions)
-  grep -Eq '(^|/)[^/]+\.(js|jsx|cjs|mjs|ts|tsx|svelte)$' <<<"$changed_files" \
-    && languages+=(javascript-typescript)
-  grep -Eq '^scripts/.*\.py$' <<<"$changed_files" && languages+=(python)
-  grep -Eq '^packages/dtx-desktop/src-tauri/.*\.rs$' <<<"$changed_files" \
-    && languages+=(rust)
+Commit: `ci: carry forward partial coverage streams`
 
-  if [[ ${#languages[@]} -eq 0 ]]; then
-    printf '%s\n' "$all_codeql"
-  else
-    printf '%s\n' "${languages[@]}" | jq -R . | jq -sc .
-  fi
-  exit 0
-fi
+## A7. Measure before adding detector machinery
 
-affected_json="$(read_affected_json)"
-printf '%s\n' '--- turbo affected json ---' "$affected_json" >&2
+- [ ] Compare workflow duration/usage for docs-only, web-only, desktop-renderer, desktop-Rust, and shared/common PRs.
+- [ ] Record the observed savings in the implementation PR or HPA-613 comment.
 
-jq -e '
-  (.packages | type) == "object" and
-  (.packages.count | type) == "number" and
-  (.packages.items | type) == "array" and
-  .packages.count == (.packages.items | length) and
-  all(.packages.items[]; (.name | type) == "string" and (.path | type) == "string")
-' <<<"$affected_json" >/dev/null
+Expected after PR A:
 
-if [[ "$mode" == "unit" ]]; then
-  if grep -Eq '^(\.github/workflows/unit-test\.yml|\.github/scripts/ci-affected-scope\.sh|package\.json|bun\.lock|turbo\.json|codecov\.yml)$' \
-    <<<"$changed_files"; then
-    echo true
-    exit 0
-  fi
+| Change | Result |
+| --- | --- |
+| docs only | required unit/lint still full; packaging/E2E/Rust/CodeQL skip |
+| web-only | web E2E runs; desktop/Rust/packaging skip |
+| desktop renderer | desktop E2E + Rust CI run; web E2E skips unless shared/web input changed |
+| desktop Rust | Rust CI + desktop E2E run; packaging skips |
+| common/shared | web E2E + desktop E2E run; Rust CI stays skipped without native changes |
 
-  if jq -e '
-    [.packages.items[].name]
-    | any(
-        . == "@dtx/common" or
-        . == "@dtx/ui-components" or
-        . == "dtx-web" or
-        . == "dtx-api" or
-        . == "dtx-desktop"
-      )
-  ' <<<"$affected_json" >/dev/null; then
-    echo true
-  else
-    echo false
-  fi
-  exit 0
-fi
-
-if grep -Eq '^(\.github/workflows/lint-and-format\.yml|\.github/scripts/ci-affected-scope\.sh|package\.json|bun\.lock|turbo\.json)$' \
-  <<<"$changed_files"; then
-  echo true
-elif jq -e '.packages.count > 0' <<<"$affected_json" >/dev/null; then
-  echo true
-else
-  echo false
-fi
-```
-
-Keep the literal rules here. Do not introduce config files, reusable workflow abstractions, or a generic rule DSL.
-
-- [ ] **Step 3: Make the script executable and syntax-check it**
-
-Run:
-
-```bash
-chmod +x .github/scripts/ci-affected-scope.sh
-bash -n .github/scripts/ci-affected-scope.sh
-```
-
-Expected: exit 0.
-
-- [ ] **Step 4: Verify the package parser against fixtures before any YAML wiring**
-
-Create an empty changed-files fixture temporarily:
-
-```bash
-empty_changed="$(mktemp)"
-: > "$empty_changed"
-```
-
-Run:
-
-```bash
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-web.json \
-  .github/scripts/ci-affected-scope.sh unit
-```
-
-Expected stdout:
-
-```text
-true
-```
-
-Run:
-
-```bash
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
-  .github/scripts/ci-affected-scope.sh unit
-```
-
-Expected stdout:
-
-```text
-false
-```
-
-Run:
-
-```bash
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
-  .github/scripts/ci-affected-scope.sh lint
-```
-
-Expected stdout:
-
-```text
-false
-```
-
-Run:
-
-```bash
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-malformed.json \
-  .github/scripts/ci-affected-scope.sh unit
-```
-
-Expected: non-zero. This is intentional; the workflow wrapper added in Tasks 2/3 turns it into full validation.
-
-- [ ] **Step 5: Verify force-full root changes**
-
-```bash
-changed="$(mktemp)"
-printf '%s\n' 'codecov.yml' > "$changed"
-CI_CHANGED_FILES_FILE="$changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
-  .github/scripts/ci-affected-scope.sh unit
-```
-
-Expected stdout: `true`.
-
-- [ ] **Step 6: Execute the script with a real Git/Turborepo comparison**
-
-Run from a branch with at least one parent commit:
-
-```bash
-TURBO_SCM_BASE="$(git rev-parse HEAD^)" \
-TURBO_SCM_HEAD="$(git rev-parse HEAD)" \
-  .github/scripts/ci-affected-scope.sh unit
-```
-
-Expected: exit 0 and stderr contains the raw `turbo ls --affected --output=json` payload. The boolean result depends on the actual last commit.
-
-This step is load-bearing. Do not proceed to workflow gating if the live Turbo JSON contradicts the fixture/parser.
-
-- [ ] **Step 7: Verify a dtx-web fixture still turns coverage on**
-
-Re-run the web fixture from Step 4 immediately before committing. Expected: `true`.
-
-- [ ] **Step 8: Commit the detector seam**
-
-```bash
-git add .github/scripts/ci-affected-scope.sh .github/scripts/fixtures/
-git commit -m "ci: add affected scope detector"
-```
+**Decision rule:** measurement can justify editing HPA-613, but do not silently mark the issue done. As written, the ticket still requires cheap docs-only required jobs and relevant-language PR CodeQL.
 
 ---
 
-### Task 2: Gate the required root unit-coverage job
+# PR B — required-check gates
 
-**Files:**
-- Modify: `.github/workflows/unit-test.yml`
+## B1. Add one tested fail-open detector
 
-**Interfaces:**
-- Consumes: `.github/scripts/ci-affected-scope.sh unit`.
-- Produces: existing required job id `test`; output `steps.scope.outputs.run_expensive` controls the existing coverage stack.
+**Create:**
+- `.github/scripts/ci-affected-scope.sh`
+- `.github/scripts/ci-affected-scope.test.sh`
+- minimal Turbo JSON fixtures under `.github/scripts/fixtures/`
 
-- [ ] **Step 1: Give checkout full history**
+Initial modes:
 
-Change checkout to:
+- `unit` -> stdout exactly `true`/`false`
+- `lint` -> stdout exactly `true`/`false`
 
-```yaml
-- name: Checkout code
-  uses: actions/checkout@v7
-  with:
-    fetch-depth: 0
-```
+Rules:
 
-Keep the existing draft job guard.
-
-- [ ] **Step 2: Add the fail-open scope wrapper after Bun setup and before install**
-
-```yaml
-- name: Determine unit coverage scope
-  id: scope
-  shell: bash
-  env:
-    TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-    TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
-  run: |
-    if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
-
-    if run_expensive="$(.github/scripts/ci-affected-scope.sh unit)"; then
-      echo "run_expensive=$run_expensive" >> "$GITHUB_OUTPUT"
-    else
-      echo "Affected-scope detection failed; running full unit coverage." >&2
-      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
-    fi
-```
-
-Do not use a bare `git diff` in the YAML. Git/Turbo/jq failures belong behind the wrapper and must resolve to `true`.
-
-- [ ] **Step 3: Condition the existing expensive steps, not the job**
-
-Add:
-
-```yaml
-if: steps.scope.outputs.run_expensive == 'true'
-```
-
-to the existing steps for:
-
-- `bun install --frozen-lockfile`;
-- SvelteKit type preparation;
-- `@dtx/common` build;
-- `bun run test:coverage`;
-- Codecov upload.
-
-Do not change root `bun run test:coverage` itself.
-
-- [ ] **Step 4: Validate workflow syntax and required context**
-
-Run:
+- [ ] Require `TURBO_SCM_BASE` and `TURBO_SCM_HEAD`.
+- [ ] Changed files use:
 
 ```bash
-actionlint .github/workflows/unit-test.yml
-grep -n '^  test:' .github/workflows/unit-test.yml
-grep -n 'paths:' .github/workflows/unit-test.yml || true
+git diff --name-only --merge-base "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD"
 ```
 
-Expected:
-
-- actionlint passes;
-- job id remains `test`;
-- no PR event-level `paths` was introduced.
-
-- [ ] **Step 5: Re-run the detector web fixture before accepting the workflow gate**
+- [ ] Run the exact initial tool version:
 
 ```bash
-empty_changed="$(mktemp)"
-: > "$empty_changed"
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-web.json \
-  .github/scripts/ci-affected-scope.sh unit
+bunx turbo@2.10.9 ls --affected --output=json
 ```
 
-Expected: `true`. If not, stop; a green required `test` would be unsafe.
+- [ ] Record the live JSON shape, parse `packages.items`, and validate `packages.count`.
+- [ ] Unexpected JSON/Git/Turbo/jq errors exit non-zero.
+- [ ] When Turborepo is intentionally upgraded, update the explicit version and fixture/test together.
 
-- [ ] **Step 6: Commit**
+Checked-in test cases:
 
-```bash
-git add .github/workflows/unit-test.yml
-git commit -m "ci: gate root unit coverage by affected scope"
-```
+- web affected -> `unit=true`
+- empty affected -> `unit=false`, `lint=false`
+- E2E-only -> `unit=false`, `lint=true`
+- malformed JSON -> non-zero
+- invalid refs -> wrapper runs full validation
+- `tsconfig.base.json` -> full/affected behavior through Turbo global invalidation
+- merge-base comparison excludes unrelated commits added to base after branch-off
+
+- [ ] Run `bash -n` on both scripts.
+- [ ] Run `.github/scripts/ci-affected-scope.test.sh`.
+- [ ] Run the real detector once against an actual base/head pair before wiring required checks.
+
+Commit: `ci: add tested affected scope detector`
+
+## B2. Gate root unit coverage
+
+**Modify:** `.github/workflows/unit-test.yml`
+
+- [ ] Keep job id `test`; no PR `paths`.
+- [ ] Checkout with `fetch-depth: 0`.
+- [ ] After Bun setup, call `ci-affected-scope.sh unit` for PRs.
+- [ ] Script failure -> `run_expensive=true`.
+- [ ] Pushes to `main`/`master` -> `run_expensive=true`.
+- [ ] Gate the existing install/preparation/root coverage/TypeScript Codecov steps.
+- [ ] Do not split `bun run test:coverage`.
+- [ ] Verify a docs-only PR still publishes a successful `test` context.
+
+Commit: `ci: skip root coverage when unaffected`
+
+## B3. Gate only heavy lint/codegen work
+
+**Modify:** `.github/workflows/lint-and-format.yml`
+
+- [ ] Keep job id `lint-and-format`; no PR `paths`.
+- [ ] Checkout with `fetch-depth: 0`.
+- [ ] Always run install, `.github/scripts/ci-affected-scope.test.sh`, ESLint, and Prettier.
+- [ ] Call `ci-affected-scope.sh lint` for PRs.
+- [ ] Script failure -> run the full heavy block.
+- [ ] Gate only SvelteKit/common prep, common build, GraphQL schema/drift, generated client verification, and E2E typechecks.
+- [ ] Keep push behavior full.
+- [ ] Verify docs-only skips the heavy block but still runs the always-on tier.
+
+Commit: `ci: gate generated lint work by affected scope`
+
+## B4. Prove fail-open behavior
+
+Before merging PR B:
+
+- [ ] malformed Turbo output -> full unit/lint work
+- [ ] invalid Git refs -> full unit/lint work
+- [ ] real web change -> `unit=true`
+- [ ] real docs-only change -> `unit=false`, `lint=false`
+- [ ] the checked-in detector regression test runs in `lint-and-format`
+- [ ] `actionlint` passes, but is not treated as detector proof
 
 ---
 
-### Task 3: Keep repo lint/format always-on and gate only heavy lint work
+# PR C — CodeQL relevant-language selection
 
-**Files:**
-- Modify: `.github/workflows/lint-and-format.yml`
+## C1. Extend the proven detector
 
-**Interfaces:**
-- Consumes: `.github/scripts/ci-affected-scope.sh lint`.
-- Produces: existing required job id `lint-and-format`; `steps.scope.outputs.run_workspace_checks` controls only build/schema/codegen/E2E typecheck steps.
+**Modify:** both scope scripts.
 
-- [ ] **Step 1: Give checkout full history**
+Add `codeql` mode mapping:
 
-```yaml
-- name: Checkout code
-  uses: actions/checkout@v7
-  with:
-    fetch-depth: 0
-```
+- `.github/workflows/**` -> `actions`
+- JS/TS/Svelte source/config -> `javascript-typescript`
+- `scripts/**/*.py` -> `python`
+- `packages/dtx-desktop/src-tauri/**/*.rs` -> `rust`
 
-- [ ] **Step 2: Add the fail-open heavy-work wrapper after Bun setup**
+- [ ] Reuse the same merge-base changed-file list.
+- [ ] Detector/mapping failure -> all four languages.
+- [ ] Add single-language and mixed-language tests.
 
-```yaml
-- name: Determine workspace lint scope
-  id: scope
-  shell: bash
-  env:
-    TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-    TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
-  run: |
-    if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-      echo "run_workspace_checks=true" >> "$GITHUB_OUTPUT"
-      exit 0
-    fi
+Commit: `ci: add codeql language scope mode`
 
-    if run_workspace_checks="$(.github/scripts/ci-affected-scope.sh lint)"; then
-      echo "run_workspace_checks=$run_workspace_checks" >> "$GITHUB_OUTPUT"
-    else
-      echo "Affected-scope detection failed; running full workspace lint checks." >&2
-      echo "run_workspace_checks=true" >> "$GITHUB_OUTPUT"
-    fi
-```
+## C2. Wire CodeQL without dropping build mode
 
-- [ ] **Step 3: Leave install, ESLint, and Prettier unconditional**
+**Modify:** `.github/workflows/codeql.yml`
 
-These steps must have **no** `if: steps.scope...` condition:
-
-```yaml
-- name: Install dependencies
-  run: bun install --frozen-lockfile
-
-- name: Run linting
-  run: bun run lint
-
-- name: Run formatting check
-  run: bunx prettier --check .
-```
-
-This is what keeps a docs-only PR from merging Markdown that fails the repo format check.
-
-- [ ] **Step 4: Gate only the workspace/generated sequence**
-
-Add:
-
-```yaml
-if: steps.scope.outputs.run_workspace_checks == 'true'
-```
-
-to the existing steps that:
-
-- generate SvelteKit types / prepare the web package;
-- build `@dtx/common`;
-- generate and verify the API GraphQL schema;
-- verify the generated web GraphQL client;
-- typecheck `dtx-e2e-web` and `dtx-e2e-desktop`.
-
-Keep schema generation before `lint:codegen`.
-
-- [ ] **Step 5: Verify docs-only still reaches repo-wide checks**
-
-Run:
-
-```bash
-actionlint .github/workflows/lint-and-format.yml
-grep -n 'Run linting\|Run formatting check' .github/workflows/lint-and-format.yml
-grep -n '^  lint-and-format:' .github/workflows/lint-and-format.yml
-```
-
-Inspect the two repo-wide steps and confirm they have no affected-scope `if`.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add .github/workflows/lint-and-format.yml
-git commit -m "ci: gate generated lint work by affected scope"
-```
-
----
-
-### Task 4: Add native PR path filters to non-required validation
-
-**Files:**
-- Modify: `.github/workflows/e2e-test.yml`
-- Modify: `.github/workflows/tauri-rust-ci.yml`
-
-**Interfaces:**
-- Consumes: GitHub Actions native event path matching.
-- Produces: web E2E starts only for web/shared/E2E/root-test inputs; Rust CI starts only for native/generated-contract/root-build inputs. `main`/`master` pushes remain full.
-
-- [ ] **Step 1: Add web E2E PR paths**
-
-Under `pull_request` in `e2e-test.yml`, keep the existing branches/types and add:
-
-```yaml
-paths:
-  - 'packages/dtx-web/**'
-  - 'packages/dtx-api/**'
-  - 'packages/common/**'
-  - 'packages/ui-components/**'
-  - 'packages/e2e-web/**'
-  - 'supabase/**'
-  - '.github/workflows/e2e-test.yml'
-  - 'package.json'
-  - 'bun.lock'
-  - 'turbo.json'
-```
-
-Do not add this path filter to the push trigger; `main`/`master` web E2E stays full.
-
-- [ ] **Step 2: Add a narrower Tauri Rust PR path set**
-
-Under `pull_request` in `tauri-rust-ci.yml`, add:
-
-```yaml
-paths:
-  - 'packages/dtx-desktop/**'
-  - 'packages/e2e-desktop/**'
-  - '.github/workflows/tauri-rust-ci.yml'
-  - 'package.json'
-  - 'bun.lock'
-  - 'turbo.json'
-```
-
-Do **not** include `packages/common/**` or `packages/ui-components/**`. The Rust workflow's generated drift outputs live under desktop/E2E-desktop, while the existing desktop E2E workflow already covers renderer/shared changes.
-
-Do not path-filter the Rust push trigger; `main`/`master` remains full.
-
-- [ ] **Step 3: Leave desktop E2E's existing shared paths intact**
-
-Do not narrow `desktop-e2e-test.yml` in this task. It should continue to include `packages/common/**` and `packages/ui-components/**` because those are real desktop-renderer/E2E dependencies.
-
-- [ ] **Step 4: Validate syntax**
-
-```bash
-actionlint .github/workflows/e2e-test.yml .github/workflows/tauri-rust-ci.yml
-git diff --check
-```
-
-Expected: pass.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add .github/workflows/e2e-test.yml .github/workflows/tauri-rust-ci.yml
-git commit -m "ci: scope e2e and rust checks by path"
-```
-
----
-
-### Task 5: Remove ordinary PR desktop packaging
-
-**Files:**
-- Modify: `.github/workflows/desktop-build-deploy.yml`
-
-**Interfaces:**
-- Consumes: existing `preview`, `main`, `v*`, and `workflow_dispatch` entry points.
-- Produces: no Windows/macOS packaging for ordinary PRs; current release/preview paths remain.
-
-- [ ] **Step 1: Remove the pull-request trigger**
-
-Delete the `pull_request` block from `on:`. Keep:
-
-```yaml
-on:
-  push:
-    branches:
-      - preview
-      - main
-    tags:
-      - 'v*'
-  workflow_dispatch:
-```
-
-Preserve existing manual inputs below `workflow_dispatch`.
-
-- [ ] **Step 2: Remove job conditions that only filtered PRs**
-
-Delete/simplify conditions such as:
-
-```yaml
-if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.head_ref != 'preview')
-```
-
-They are unnecessary once the workflow has no PR event.
-
-- [ ] **Step 3: Remove both unsigned PR build steps**
-
-Delete Windows/macOS steps whose only branch is:
-
-```yaml
-if: github.event_name == 'pull_request'
-```
-
-Keep the existing non-PR signed build commands and their signing secrets.
-
-- [ ] **Step 4: Simplify preproduction/production configuration conditions without changing preview semantics**
-
-Change preproduction Google Drive configuration from PR-or-preview to preview only.
-
-Keep production configuration for non-preview release paths.
-
-Do not change updater versioning, artifact layout, signing, R2 deployment, release manifests, or target architectures.
-
-- [ ] **Step 5: Validate release entry points and syntax**
-
-```bash
-actionlint .github/workflows/desktop-build-deploy.yml
-grep -n 'pull_request' .github/workflows/desktop-build-deploy.yml || true
-grep -n 'preview\|main\|v\*\|workflow_dispatch' .github/workflows/desktop-build-deploy.yml
-```
-
-Expected: no executable PR trigger/PR-only build branches remain; release entry points remain present.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add .github/workflows/desktop-build-deploy.yml
-git commit -m "ci: stop packaging desktop apps on pull requests"
-```
-
----
-
-### Task 6: Keep PR CodeQL language-scoped without a third classifier
-
-**Files:**
-- Modify: `.github/workflows/codeql.yml`
-- Reuse: `.github/scripts/ci-affected-scope.sh`
-
-**Interfaces:**
-- Consumes: `.github/scripts/ci-affected-scope.sh codeql` and GitHub PR source path filtering.
-- Produces: non-empty JSON language matrix; main/schedule always use all four existing languages.
-
-- [ ] **Step 1: Add PR-level source/workflow paths**
-
-Keep push-to-main and schedule unchanged. Under `pull_request`, add paths matching at least one CodeQL language:
-
-```yaml
-paths:
-  - '.github/workflows/**'
-  - '**/*.js'
-  - '**/*.jsx'
-  - '**/*.cjs'
-  - '**/*.mjs'
-  - '**/*.ts'
-  - '**/*.tsx'
-  - '**/*.svelte'
-  - 'scripts/**/*.py'
-  - 'packages/dtx-desktop/src-tauri/**/*.rs'
-```
-
-This is the cheap docs-only filter. It does not replace per-language PR selection.
-
-- [ ] **Step 2: Add a selector job that reuses the shared script**
-
-Add before `analyze`:
-
-```yaml
-select-languages:
-  runs-on: ubuntu-latest
-  permissions:
-    contents: read
-  outputs:
-    languages: ${{ steps.scope.outputs.languages }}
-  steps:
-    - name: Checkout repository
-      if: github.event_name == 'pull_request'
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-
-    - name: Select CodeQL languages
-      id: scope
-      shell: bash
-      env:
-        TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-        TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
-      run: |
-        all='["actions","javascript-typescript","python","rust"]'
-
-        if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-          echo "languages=$all" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        if languages="$(.github/scripts/ci-affected-scope.sh codeql)"; then
-          echo "languages=$languages" >> "$GITHUB_OUTPUT"
-        else
-          echo "CodeQL scope detection failed; analyzing all languages." >&2
-          echo "languages=$all" >> "$GITHUB_OUTPUT"
-        fi
-```
-
-The script returns all four on an unexpected empty mapping after the workflow has triggered, so the matrix is never empty.
-
-- [ ] **Step 3: Replace the static analyze matrix source**
-
-Add:
-
-```yaml
-needs: select-languages
-```
-
-and change the matrix to:
-
-```yaml
-strategy:
-  fail-fast: false
-  matrix:
-    language: ${{ fromJSON(needs.select-languages.outputs.languages) }}
-```
-
-Retain the existing runner selection, permissions, CodeQL init, and analysis steps.
-
-- [ ] **Step 4: Fixture-check language mapping**
-
-```bash
-changed="$(mktemp)"
-printf '%s\n' \
-  '.github/workflows/unit-test.yml' \
-  'packages/dtx-web/src/lib/example.ts' \
-  'packages/dtx-desktop/src-tauri/src/api.rs' > "$changed"
-
-CI_CHANGED_FILES_FILE="$changed" \
-  .github/scripts/ci-affected-scope.sh codeql
-```
-
-Expected JSON contains exactly:
-
-```json
-["actions", "javascript-typescript", "rust"]
-```
-
-(order may be compacted but stays deterministic from the script).
-
-- [ ] **Step 5: Validate workflow syntax**
-
-```bash
-actionlint .github/workflows/codeql.yml
-```
-
-Expected: pass.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add .github/workflows/codeql.yml
-git commit -m "ci: scope PR CodeQL by changed language"
-```
-
----
-
-### Task 7: Make partial coverage uploads compatible with Codecov policy
-
-**Files:**
-- Modify: `codecov.yml`
-- Modify: `.github/workflows/unit-test.yml`
-- Modify: `.github/workflows/tauri-rust-ci.yml`
-- Modify: `.github/workflows/desktop-e2e-test.yml`
-
-**Interfaces:**
-- Produces three named coverage streams: `typescript`, `tauri-rust`, and `desktop-e2e-rust`, each with carryforward enabled.
-
-- [ ] **Step 1: Add carryforward flag definitions without touching thresholds**
-
-Extend `codecov.yml`:
-
-```yaml
-coverage:
-  status:
-    project:
-      default:
-        target: 90%
-        threshold: 0%
-        informational: false
-        if_not_found: failure
-    patch:
-      default:
-        target: 90%
-        threshold: 0%
-        informational: false
-        if_not_found: failure
-
-flags:
-  typescript:
-    carryforward: true
-  tauri-rust:
-    carryforward: true
-  desktop-e2e-rust:
-    carryforward: true
-```
-
-Do not change the 90% values, threshold, or informational settings.
-
-- [ ] **Step 2: Flag root TypeScript coverage and make uploader transport informational**
-
-In `unit-test.yml`:
+- [ ] Add a selector job that calls the shared script for PRs; main/schedule return all four languages.
+- [ ] Replace only the language matrix source.
+- [ ] If using a flat language array, hardcode CodeQL init:
 
 ```yaml
 with:
-  token: ${{ secrets.CODECOV_TOKEN }}
-  flags: typescript
-  fail_ci_if_error: false
+  languages: ${{ matrix.language }}
+  build-mode: none
 ```
 
-Keep the upload step under the Task 2 `run_expensive` gate.
+Do not leave `build-mode: ${{ matrix.build-mode }}` after removing the current `matrix.include` structure.
 
-- [ ] **Step 3: Flag Tauri Rust unit coverage**
+- [ ] Verify a Rust-only PR runs Rust CodeQL with `build-mode: none`, not autobuild.
+- [ ] Verify mixed workflow + TypeScript changes select only `actions` and `javascript-typescript`.
+- [ ] Verify main/schedule remain all-language scans.
+- [ ] Run `actionlint` and the scope regression test.
 
-In `tauri-rust-ci.yml`:
-
-```yaml
-with:
-  token: ${{ secrets.CODECOV_TOKEN }}
-  files: packages/dtx-desktop/src-tauri/lcov.info
-  flags: tauri-rust
-  fail_ci_if_error: false
-```
-
-- [ ] **Step 4: Flag desktop E2E Rust coverage**
-
-In `desktop-e2e-test.yml`:
-
-```yaml
-with:
-  token: ${{ secrets.CODECOV_TOKEN }}
-  files: packages/dtx-desktop/src-tauri/e2e-lcov.info
-  flags: desktop-e2e-rust
-  fail_ci_if_error: false
-```
-
-- [ ] **Step 5: Verify the implementation PR establishes all three flags**
-
-Because this implementation changes `unit-test.yml`, `tauri-rust-ci.yml`, `desktop-e2e-test.yml`, and `codecov.yml`, all three coverage-producing workflows should be selected on the implementation PR. Confirm Codecov receives one upload for each flag before relying on carryforward on later PRs.
-
-- [ ] **Step 6: Validate thresholds and upload settings**
-
-```bash
-grep -n 'target: 90%\|threshold: 0%\|carryforward: true' codecov.yml
-grep -R -n 'flags: \|fail_ci_if_error:' \
-  .github/workflows/unit-test.yml \
-  .github/workflows/tauri-rust-ci.yml \
-  .github/workflows/desktop-e2e-test.yml
-actionlint \
-  .github/workflows/unit-test.yml \
-  .github/workflows/tauri-rust-ci.yml \
-  .github/workflows/desktop-e2e-test.yml
-```
-
-Expected: three carryforward flags, three matching uploader flags, all uploader transport failures non-blocking, 90% policy unchanged.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add codecov.yml \
-  .github/workflows/unit-test.yml \
-  .github/workflows/tauri-rust-ci.yml \
-  .github/workflows/desktop-e2e-test.yml
-git commit -m "ci: carry forward partial coverage suites"
-```
+Commit: `ci: scope codeql by changed language`
 
 ---
 
-### Task 8: Document and verify the complete affected-area matrix
+# Final documentation and verification
 
-**Files:**
-- Modify: `CLAUDE.md`
-- Verify: every HPA-613 workflow/script/config change
+## D1. Update `CLAUDE.md`
 
-**Interfaces:**
-- Produces: contributor-visible CI rules and final evidence that scope reduction cannot silently suppress required validation.
+Document the final matrix and invariants:
 
-- [ ] **Step 1: Add the ready-PR matrix to `CLAUDE.md`**
-
-Document these cases:
-
-| Change | Unit coverage | ESLint/Prettier | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
+| Change | Unit | ESLint/Prettier | Heavy lint | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | docs only | skip | run | skip | skip | skip | skip | skip | skip |
-| `dtx-web` | run | run | run | run | skip | skip | skip | JS/TS |
-| `dtx-api` | run | run | run | run | skip | skip | skip | JS/TS |
-| `common` | run | run | run | run | run | skip | skip | JS/TS |
-| `ui-components` | run | run | run | run | run | skip | skip | JS/TS |
+| web/API | run | run | run | run | skip | skip | skip | JS/TS |
+| common/ui | run | run | run | run | run | skip | skip | JS/TS |
 | desktop renderer | run | run | run | skip | run | run | skip | JS/TS |
 | desktop Rust | run | run | run | skip | run | run | skip | Rust |
-| web E2E only | skip | run | run | run | skip | skip | skip | JS/TS when source matches |
-| desktop E2E only | skip | run | run | skip | run | run | skip | JS/TS when source matches |
+| `tsconfig.base.json` | run | run | run | run | run | skip | skip | JS/TS |
 
-Also state:
+Also document:
 
-- `test` and `lint-and-format` must remain event-visible required contexts;
-- scope-detection failures run more CI, never less;
-- ordinary PR packaging is intentionally absent;
-- `main` and scheduled CodeQL remain full;
-- skipped coverage suites use Codecov carryforward flags.
+- required `test` belongs to the unit workflow;
+- Playwright check is `playwright`;
+- required workflows are never event-level path-skipped;
+- detector errors fail open;
+- Codecov upload transport is informational by ticket design;
+- manual packaging is available for risky pre-merge desktop changes.
 
-- [ ] **Step 2: Re-run script verification**
+## D2. Final evidence
 
-```bash
-bash -n .github/scripts/ci-affected-scope.sh
+- [ ] `actionlint` all changed workflows.
+- [ ] Run `.github/scripts/ci-affected-scope.test.sh`.
+- [ ] Run one real detector base/head comparison.
+- [ ] Verify the active ruleset still requires `test` and `lint-and-format`.
+- [ ] Verify one ready PR has exactly the intended `test` and `playwright` checks.
+- [ ] Verify Rust CodeQL stays `build-mode: none`.
+- [ ] Verify `preview`, `main`, `v*`, and `workflow_dispatch` packaging paths remain.
+- [ ] Verify 90% Codecov targets plus all three carryforward flags and informational uploader behavior.
+- [ ] Record observed workflow usage after the full change.
 
-empty_changed="$(mktemp)"
-: > "$empty_changed"
+## Definition of done
 
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-web.json \
-  .github/scripts/ci-affected-scope.sh unit | grep -qx true
-
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
-  .github/scripts/ci-affected-scope.sh unit | grep -qx false
-
-CI_CHANGED_FILES_FILE="$empty_changed" \
-CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-empty.json \
-  .github/scripts/ci-affected-scope.sh lint | grep -qx false
-```
-
-Expected: all pass.
-
-- [ ] **Step 3: Prove the malformed detector path fails open at wrapper level**
-
-Run the script directly and require failure:
-
-```bash
-if CI_CHANGED_FILES_FILE="$empty_changed" \
-  CI_AFFECTED_JSON_FILE=.github/scripts/fixtures/turbo-ls-malformed.json \
-  .github/scripts/ci-affected-scope.sh unit; then
-  echo 'expected malformed Turbo JSON to fail' >&2
-  exit 1
-fi
-```
-
-Then inspect `unit-test.yml` and `lint-and-format.yml` and confirm their `else` branches write `true` to the relevant outputs.
-
-- [ ] **Step 4: Re-run one real Turbo comparison**
-
-```bash
-TURBO_SCM_BASE="$(git rev-parse HEAD^)" \
-TURBO_SCM_HEAD="$(git rev-parse HEAD)" \
-  .github/scripts/ci-affected-scope.sh unit
-```
-
-Expected: exits 0 and logs raw changed files plus affected JSON.
-
-- [ ] **Step 5: Validate every changed workflow**
-
-```bash
-actionlint \
-  .github/workflows/unit-test.yml \
-  .github/workflows/lint-and-format.yml \
-  .github/workflows/e2e-test.yml \
-  .github/workflows/desktop-e2e-test.yml \
-  .github/workflows/tauri-rust-ci.yml \
-  .github/workflows/desktop-build-deploy.yml \
-  .github/workflows/codeql.yml
-```
-
-Expected: pass.
-
-- [ ] **Step 6: Verify required checks and release entry points stayed deterministic**
-
-```bash
-grep -n '^  test:' .github/workflows/unit-test.yml
-grep -n '^  lint-and-format:' .github/workflows/lint-and-format.yml
-grep -n 'preview\|main\|v\*\|workflow_dispatch' .github/workflows/desktop-build-deploy.yml
-```
-
-Expected: required job ids unchanged; release entry points retained.
-
-- [ ] **Step 7: Verify no PR packaging remains**
-
-```bash
-if grep -n 'pull_request' .github/workflows/desktop-build-deploy.yml; then
-  echo 'ordinary PR packaging reference remains' >&2
-  exit 1
-fi
-```
-
-Expected: no match.
-
-- [ ] **Step 8: Verify Codecov routing without policy drift**
-
-```bash
-grep -n 'target: 90%\|threshold: 0%' codecov.yml
-grep -n 'typescript:\|tauri-rust:\|desktop-e2e-rust:\|carryforward: true' codecov.yml
-```
-
-Expected: 90%/0% policy unchanged and all three flags present.
-
-- [ ] **Step 9: Run repository formatting validation for the changed docs/config**
-
-```bash
-bunx prettier --check \
-  .github/workflows/unit-test.yml \
-  .github/workflows/lint-and-format.yml \
-  .github/workflows/e2e-test.yml \
-  .github/workflows/desktop-e2e-test.yml \
-  .github/workflows/tauri-rust-ci.yml \
-  .github/workflows/desktop-build-deploy.yml \
-  .github/workflows/codeql.yml \
-  codecov.yml \
-  CLAUDE.md
-
-git diff --check
-```
-
-Expected: pass.
-
-- [ ] **Step 10: Commit documentation**
-
-```bash
-git add CLAUDE.md
-git commit -m "docs: document affected CI matrix"
-```
-
-- [ ] **Step 11: Final implementation-PR proof before declaring HPA-613 complete**
-
-On the implementation PR, inspect the scope step log for a commit that changes `packages/dtx-web/**` (the implementation branch may include such a fixture/tested comparison rather than manufacturing a product change). The detector must show the web package in raw Turbo JSON and resolve unit coverage to `true`.
-
-Do not accept `actionlint` alone as proof of scope correctness.
-
----
-
-## Expected implementation commit sequence
-
-1. `ci: add affected scope detector`
-2. `ci: gate root unit coverage by affected scope`
-3. `ci: gate generated lint work by affected scope`
-4. `ci: scope e2e and rust checks by path`
-5. `ci: stop packaging desktop apps on pull requests`
-6. `ci: scope PR CodeQL by changed language`
-7. `ci: carry forward partial coverage suites`
-8. `docs: document affected CI matrix`
-
-Each commit is independently reviewable after the detector seam exists. Do not start relying on path filters or packaging reductions until Task 1 has executed successfully against both fixture JSON and one real Turborepo comparison.
+HPA-613 is complete when the final affected-area behavior is implemented and verified. If PR A's measurement shows PR B/C are not worth maintaining, change the Linear issue scope/acceptance criteria explicitly before stopping.

--- a/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
@@ -1,0 +1,681 @@
+# HPA-613 Affected CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce ready-PR GitHub Actions cost by running expensive validation only for affected application/native areas while preserving the required `test` and `lint-and-format` status contexts and all current `main`/release behavior.
+
+**Architecture:** Keep the current workflow boundaries. The two required jobs perform a cheap Turborepo affected-package query inside the existing job and conditionally skip expensive steps; non-required workflows use PR path filters; packaging stops running on ordinary PRs; CodeQL dynamically selects relevant languages on PRs while remaining full on `main` and schedule.
+
+**Tech Stack:** GitHub Actions, Bun 1.3.9, Turborepo 2.10.x, Bash/jq, CodeQL, Codecov, Tauri/Rust 1.95.
+
+## Global Constraints
+
+- Keep job ids `test` in `.github/workflows/unit-test.yml` and `lint-and-format` in `.github/workflows/lint-and-format.yml` unchanged; the active `Main` ruleset requires those exact contexts.
+- Do not add `pull_request.paths` to either required workflow.
+- On any scope-detection error, run the existing expensive validation rather than silently skipping it.
+- Pushes to `main` keep full validation behavior.
+- Keep GraphQL schema generation before generated-client verification.
+- Keep Codecov project/patch targets in `codecov.yml` unchanged; only uploader failures become non-blocking.
+- Keep `preview`, `main`, `v*`, and `workflow_dispatch` desktop packaging/release entry points.
+- No new CI service, dependency graph implementation, remote cache, or monolithic CI workflow.
+
+---
+
+## File map
+
+- `.github/workflows/unit-test.yml` — required `test` context and TypeScript coverage upload.
+- `.github/workflows/lint-and-format.yml` — required lint/codegen/typecheck/format context.
+- `.github/workflows/e2e-test.yml` — web/Supabase/Playwright E2E path gate.
+- `.github/workflows/desktop-e2e-test.yml` — existing desktop path gate and Codecov uploader behavior.
+- `.github/workflows/tauri-rust-ci.yml` — Rust PR path gate and Codecov uploader behavior.
+- `.github/workflows/desktop-build-deploy.yml` — release-only cross-platform packaging after this change.
+- `.github/workflows/codeql.yml` — PR path gate, changed-language selector, and dynamic matrix.
+- `CLAUDE.md` — contributor-facing affected-area matrix and required-check explanation.
+
+---
+
+### Task 1: Make the two required jobs cheap on unrelated PRs
+
+**Files:**
+- Modify: `.github/workflows/unit-test.yml`
+- Modify: `.github/workflows/lint-and-format.yml`
+
+**Interfaces:**
+- Consumes: PR base/head SHAs from `github.event.pull_request`, the repository workspace graph from Turborepo, and the existing job ids.
+- Produces: `steps.scope.outputs.run_expensive` (`true` or `false`) used only by later steps in the same required job.
+
+- [ ] **Step 1: Preserve full git history in the required workflows**
+
+In both workflows, keep `actions/checkout@v7` but add:
+
+```yaml
+with:
+  fetch-depth: 0
+```
+
+The scope query needs both PR SHAs locally. Do not add workflow-level path filters.
+
+- [ ] **Step 2: Add the unit-test scope step before dependency installation**
+
+After `Setup Bun`, add this step to `unit-test.yml`:
+
+```yaml
+- name: Detect affected unit-test packages
+  id: scope
+  shell: bash
+  env:
+    EVENT_NAME: ${{ github.event_name }}
+    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  run: |
+    set -euo pipefail
+
+    if [[ "$EVENT_NAME" != "pull_request" ]]; then
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+    if grep -Eq '^(\.github/workflows/unit-test\.yml|package\.json|bun\.lock|turbo\.json|codecov\.yml)$' <<<"$changed_files"; then
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    if ! affected="$(
+      TURBO_SCM_BASE="$BASE_SHA" \
+      TURBO_SCM_HEAD="$HEAD_SHA" \
+      bunx turbo@2.10.9 ls --affected --output=json
+    )"; then
+      echo "::warning::Affected-package detection failed; running full unit coverage."
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    if jq -e '
+      [.packages[].name]
+      | any(
+          . == "@dtx/common"
+          or . == "@dtx/ui-components"
+          or . == "dtx-api"
+          or . == "dtx-web"
+          or . == "dtx-desktop"
+        )
+    ' <<<"$affected" >/dev/null; then
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "run_expensive=false" >> "$GITHUB_OUTPUT"
+      echo "No unit-test-bearing workspace package is affected; required test context will finish after the cheap gate."
+    fi
+```
+
+Keep the full `bun run test:coverage` command when the gate is true. Do not switch to partial-package coverage in this task.
+
+- [ ] **Step 3: Condition all expensive unit-test steps on the scope output**
+
+Add this condition to the existing steps from `Install dependencies` through `Upload coverage to Codecov`:
+
+```yaml
+if: steps.scope.outputs.run_expensive == 'true'
+```
+
+The required job itself must still run and finish successfully when the condition is false.
+
+- [ ] **Step 4: Make the TypeScript Codecov uploader non-blocking**
+
+Change only the uploader transport behavior:
+
+```yaml
+with:
+  token: ${{ secrets.CODECOV_TOKEN }}
+  fail_ci_if_error: false
+```
+
+Do not edit `codecov.yml`.
+
+- [ ] **Step 5: Add the broader lint/codegen scope step**
+
+After `Setup Bun` in `lint-and-format.yml`, add:
+
+```yaml
+- name: Detect affected lint/codegen scope
+  id: scope
+  shell: bash
+  env:
+    EVENT_NAME: ${{ github.event_name }}
+    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  run: |
+    set -euo pipefail
+
+    if [[ "$EVENT_NAME" != "pull_request" ]]; then
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+    if grep -Eq '^(\.editorconfig|\.eslintignore|\.eslintrc\.cjs|\.prettierignore|\.prettierrc|\.github/workflows/lint-and-format\.yml|package\.json|bun\.lock|turbo\.json)$' <<<"$changed_files"; then
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    if ! affected="$(
+      TURBO_SCM_BASE="$BASE_SHA" \
+      TURBO_SCM_HEAD="$HEAD_SHA" \
+      bunx turbo@2.10.9 ls --affected --output=json
+    )"; then
+      echo "::warning::Affected-package detection failed; running full lint/codegen validation."
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+
+    if jq -e '.packages | length > 0' <<<"$affected" >/dev/null; then
+      echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "run_expensive=false" >> "$GITHUB_OUTPUT"
+      echo "No workspace package is affected; required lint-and-format context will finish after the cheap gate."
+    fi
+```
+
+- [ ] **Step 6: Condition the existing full lint/codegen sequence without reordering it**
+
+Add:
+
+```yaml
+if: steps.scope.outputs.run_expensive == 'true'
+```
+
+to every existing step after scope detection:
+
+- `Install dependencies`
+- `Generate SvelteKit types`
+- `Build packages`
+- `Generate and verify GraphQL schema`
+- `Verify generated GraphQL client`
+- `Typecheck e2e packages`
+- `Run linting`
+- `Run formatting check`
+
+Do not split schema generation and client drift into separate gates.
+
+- [ ] **Step 7: Validate the required-job YAML and status names**
+
+Run:
+
+```bash
+actionlint .github/workflows/unit-test.yml .github/workflows/lint-and-format.yml
+grep -n '^  test:' .github/workflows/unit-test.yml
+grep -n '^  lint-and-format:' .github/workflows/lint-and-format.yml
+git diff --check
+```
+
+Expected: `actionlint` and `git diff --check` are clean; the existing job ids are unchanged.
+
+- [ ] **Step 8: Commit the required-job gate**
+
+```bash
+git add .github/workflows/unit-test.yml .github/workflows/lint-and-format.yml
+git commit -m "ci: gate required checks by affected workspace"
+```
+
+---
+
+### Task 2: Add PR path gates to the non-required web/native test workflows
+
+**Files:**
+- Modify: `.github/workflows/e2e-test.yml`
+- Modify: `.github/workflows/desktop-e2e-test.yml`
+- Modify: `.github/workflows/tauri-rust-ci.yml`
+
+**Interfaces:**
+- Consumes: GitHub's native `pull_request.paths` evaluation.
+- Produces: web E2E, desktop E2E, and Tauri Rust workflows that are not created for unrelated PRs; push behavior remains unchanged.
+
+- [ ] **Step 1: Gate web E2E by the web/API/shared path set**
+
+Keep the existing `push` trigger broad. Add only this PR path list under `pull_request` in `e2e-test.yml`:
+
+```yaml
+paths:
+  - 'packages/dtx-web/**'
+  - 'packages/dtx-api/**'
+  - 'packages/common/**'
+  - 'packages/ui-components/**'
+  - 'packages/e2e-web/**'
+  - 'supabase/**'
+  - '.github/workflows/e2e-test.yml'
+  - 'package.json'
+  - 'bun.lock'
+  - 'turbo.json'
+```
+
+Do not add desktop paths.
+
+- [ ] **Step 2: Keep the existing desktop E2E path set and make its Codecov uploader non-blocking**
+
+Verify `desktop-e2e-test.yml` still includes:
+
+```yaml
+paths:
+  - 'packages/dtx-desktop/**'
+  - 'packages/e2e-desktop/**'
+  - 'packages/common/**'
+  - 'packages/ui-components/**'
+  - '.github/workflows/desktop-e2e-test.yml'
+  - 'package.json'
+  - 'bun.lock'
+  - 'turbo.json'
+```
+
+Then change its Codecov action to:
+
+```yaml
+fail_ci_if_error: false
+```
+
+Do not change coverage generation or artifact upload behavior.
+
+- [ ] **Step 3: Add the desktop/shared PR path set to Tauri Rust CI**
+
+Keep `push` on `main`/`master` unchanged. Add under `pull_request`:
+
+```yaml
+paths:
+  - 'packages/dtx-desktop/**'
+  - 'packages/e2e-desktop/**'
+  - 'packages/common/**'
+  - 'packages/ui-components/**'
+  - '.github/workflows/tauri-rust-ci.yml'
+  - 'package.json'
+  - 'bun.lock'
+  - 'turbo.json'
+```
+
+Keep both existing Rust jobs and the generated-TypeScript drift check unchanged.
+
+- [ ] **Step 4: Make the Tauri Rust Codecov uploader non-blocking**
+
+Change:
+
+```yaml
+fail_ci_if_error: true
+```
+
+to:
+
+```yaml
+fail_ci_if_error: false
+```
+
+Only for the Codecov upload action. Test/coverage generation failures still fail the job.
+
+- [ ] **Step 5: Validate workflow syntax**
+
+Run:
+
+```bash
+actionlint \
+  .github/workflows/e2e-test.yml \
+  .github/workflows/desktop-e2e-test.yml \
+  .github/workflows/tauri-rust-ci.yml
+git diff --check
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit the non-required test gates**
+
+```bash
+git add \
+  .github/workflows/e2e-test.yml \
+  .github/workflows/desktop-e2e-test.yml \
+  .github/workflows/tauri-rust-ci.yml
+git commit -m "ci: skip unaffected web and desktop validation"
+```
+
+---
+
+### Task 3: Remove ordinary PR packaging while preserving release channels
+
+**Files:**
+- Modify: `.github/workflows/desktop-build-deploy.yml`
+
+**Interfaces:**
+- Consumes: existing `preview`, `main`, tag, and manual-dispatch events.
+- Produces: Windows/macOS packaging only for those release/preproduction entry points; no ordinary PR packaging runs.
+
+- [ ] **Step 1: Remove the PR trigger**
+
+Delete only the `pull_request` event block. The top-level trigger must remain equivalent to:
+
+```yaml
+on:
+  push:
+    branches:
+      - preview
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver version (MAJOR.MINOR.PATCH) written to the updater manifest. Must exceed the currently installed version to be offered as an update.'
+        required: true
+        type: string
+```
+
+- [ ] **Step 2: Remove job conditions that only existed to admit/skip PR builds**
+
+Delete the Windows/macOS job-level conditions shaped like:
+
+```yaml
+if: github.event_name != 'pull_request' || (...)
+```
+
+All remaining triggers are intended packaging events.
+
+- [ ] **Step 3: Retarget Google Drive environment conditions to `preview` vs release only**
+
+For both Windows and macOS jobs, change preproduction selection to:
+
+```yaml
+if: github.ref == 'refs/heads/preview'
+```
+
+and production selection to:
+
+```yaml
+if: github.ref != 'refs/heads/preview'
+```
+
+Do not change the validation scripts or environment variable names.
+
+- [ ] **Step 4: Delete unsigned PR build steps and make the existing signed build the single build step**
+
+Remove both platform steps named like:
+
+```text
+Build Tauri App for ... (PR, unsigned)
+```
+
+Rename the signed steps to normal platform build names and remove their now-always-true `if: github.event_name != 'pull_request'` conditions. Keep the signing-key environment variables exactly as they are.
+
+- [ ] **Step 5: Remove stale PR-only comments and prove no PR condition remains**
+
+Run:
+
+```bash
+grep -n "pull_request" .github/workflows/desktop-build-deploy.yml
+```
+
+Expected: no matches.
+
+Do not rewrite unrelated release/version/signing comments.
+
+- [ ] **Step 6: Validate and commit**
+
+```bash
+actionlint .github/workflows/desktop-build-deploy.yml
+git diff --check
+git add .github/workflows/desktop-build-deploy.yml
+git commit -m "ci: reserve desktop packaging for release flows"
+```
+
+---
+
+### Task 4: Select only relevant CodeQL languages on pull requests
+
+**Files:**
+- Modify: `.github/workflows/codeql.yml`
+
+**Interfaces:**
+- Consumes: changed PR file paths.
+- Produces: `select-languages.outputs.matrix` and `select-languages.outputs.should_run`; the existing `analyze` job consumes the dynamic matrix.
+
+- [ ] **Step 1: Add a combined PR source-path trigger without changing push/schedule**
+
+Under `pull_request`, add:
+
+```yaml
+paths:
+  - '.github/workflows/**'
+  - '.github/actions/**'
+  - '**/*.js'
+  - '**/*.cjs'
+  - '**/*.mjs'
+  - '**/*.ts'
+  - '**/*.svelte'
+  - '**/package.json'
+  - 'bun.lock'
+  - 'scripts/**/*.py'
+  - 'scripts/**/requirements*.txt'
+  - 'packages/dtx-desktop/src-tauri/**'
+```
+
+CodeQL is not a required context, so workflow-level path filtering is safe here.
+
+- [ ] **Step 2: Add a `select-languages` job before `analyze`**
+
+Add:
+
+```yaml
+select-languages:
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+  outputs:
+    matrix: ${{ steps.select.outputs.matrix }}
+    should_run: ${{ steps.select.outputs.should_run }}
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Select CodeQL languages
+      id: select
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -euo pipefail
+
+        languages='[]'
+        add_language() {
+          local language="$1"
+          languages="$(jq -c --arg language "$language" '. + [{language: $language, "build-mode": "none"}]' <<<"$languages")"
+        }
+
+        if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          add_language actions
+          add_language javascript-typescript
+          add_language python
+          add_language rust
+        else
+          if ! changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "::warning::Could not calculate PR diff; scanning all CodeQL languages."
+            add_language actions
+            add_language javascript-typescript
+            add_language python
+            add_language rust
+          else
+            if grep -Eq '^\.github/(workflows|actions)/' <<<"$changed_files"; then
+              add_language actions
+            fi
+
+            if grep -Eq '(^|/)(package\.json)$|^bun\.lock$|\.(js|cjs|mjs|ts|svelte)$' <<<"$changed_files"; then
+              add_language javascript-typescript
+            fi
+
+            if grep -Eq '^scripts/.*\.py$|^scripts/.*/requirements[^/]*\.txt$|^scripts/requirements[^/]*\.txt$' <<<"$changed_files"; then
+              add_language python
+            fi
+
+            if grep -Eq '^packages/dtx-desktop/src-tauri/' <<<"$changed_files"; then
+              add_language rust
+            fi
+          fi
+        fi
+
+        matrix="$(jq -cn --argjson include "$languages" '{include: $include}')"
+        echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+        if [[ "$(jq 'length' <<<"$languages")" -gt 0 ]]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+        fi
+```
+
+The failure fallback is intentionally all languages.
+
+- [ ] **Step 3: Feed the selector into the existing analyze job**
+
+Add:
+
+```yaml
+needs: select-languages
+if: >-
+  ${{
+    (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    && needs.select-languages.outputs.should_run == 'true'
+  }}
+```
+
+Replace the static matrix `include` block with:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix: ${{ fromJSON(needs.select-languages.outputs.matrix) }}
+```
+
+Keep the existing dynamic job name, runner choice, permissions, CodeQL init, and analyze steps unchanged.
+
+- [ ] **Step 4: Validate the four mapping cases directly**
+
+Before committing, copy the selector shell into a temporary local shell function or inspect it with representative newline-separated paths and verify:
+
+```text
+.github/workflows/unit-test.yml                     -> actions
+packages/dtx-web/src/routes/+page.svelte           -> javascript-typescript
+scripts/cli.py                                      -> python
+packages/dtx-desktop/src-tauri/src/api.rs           -> rust
+```
+
+A path list containing both renderer TypeScript and Rust must emit both languages exactly once.
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+actionlint .github/workflows/codeql.yml
+git diff --check
+git add .github/workflows/codeql.yml
+git commit -m "ci: scope CodeQL PR analysis by language"
+```
+
+---
+
+### Task 5: Document the affected-area matrix and perform final verification
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: the final workflow path/gate behavior from Tasks 1-4.
+- Produces: one contributor-facing matrix that future workflow edits can compare against.
+
+- [ ] **Step 1: Add an `Affected-area CI` subsection near the development/testing commands**
+
+Document these invariants:
+
+```markdown
+### Affected-area CI
+
+The `Main` ruleset requires the `test` and `lint-and-format` job contexts. Those two workflows always start for a ready PR and perform a cheap Turborepo affected-package gate inside the existing required job; do not add PR-level `paths` filters to them.
+
+| PR change | `test` | `lint-and-format` | Web E2E | Desktop E2E | Tauri Rust | PR packaging | CodeQL |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| docs only | cheap gate | cheap gate | no | no | no | no | no |
+| `dtx-web` | full | full | yes | no | no | no | JS/TS |
+| `dtx-api` | full | full | yes | no | no | no | JS/TS |
+| `dtx-desktop` renderer | full | full | no | yes | yes | no | JS/TS |
+| `dtx-desktop/src-tauri` | full | full | no | yes | yes | no | Rust (+ JS/TS only when JS/TS files also change) |
+| `common` | full | full | yes | yes | yes | no | JS/TS |
+| `ui-components` | full | full | yes | yes | yes | no | JS/TS |
+| `e2e-web` | cheap/no unit work | full | yes | no | no | no | JS/TS |
+| `e2e-desktop` | cheap/no unit work | full | no | yes | yes | no | JS/TS |
+| `package.json` / `bun.lock` / `turbo.json` | full | full | yes | yes | yes | no | JS/TS |
+
+Windows/macOS packaging runs only from `preview`, `main`, `v*` tags, or manual dispatch. `main`/scheduled CodeQL remains a full language scan.
+```
+
+Keep the wording concise; this is an operational matrix, not a second design document.
+
+- [ ] **Step 2: Run final workflow lint and diff checks**
+
+```bash
+actionlint .github/workflows/*.yml
+git diff --check
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Re-check the active required status contexts**
+
+With authenticated `gh`:
+
+```bash
+gh api repos/cwchanap/DTXWeb/rulesets/6439239 \
+  --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+Expected output contains exactly:
+
+```text
+test
+lint-and-format
+```
+
+If the live ruleset changed since planning, update the gate strategy before merging rather than assuming these contexts.
+
+- [ ] **Step 4: Review the documented dry-run matrix against every workflow**
+
+For each row in `CLAUDE.md`, point to the corresponding PR `paths` list or required-job scope condition. Specifically verify `packages/common/**` and `packages/ui-components/**` fan out to both web and desktop validation, and a docs-only PR reaches only the two cheap required gates.
+
+- [ ] **Step 5: Confirm release behavior is unchanged for non-PR events**
+
+Inspect `desktop-build-deploy.yml` and verify all of these remain present:
+
+```text
+preview branch push
+main branch push
+v* tag push
+workflow_dispatch
+```
+
+Inspect `unit-test.yml`, `lint-and-format.yml`, `e2e-test.yml`, `tauri-rust-ci.yml`, and `codeql.yml` and verify push-to-`main` remains full rather than affected-only.
+
+- [ ] **Step 6: Commit the contributor documentation**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: explain affected-area CI matrix"
+```
+
+- [ ] **Step 7: Final branch verification**
+
+```bash
+git status --short
+git log --oneline main..HEAD
+git diff --stat main...HEAD
+actionlint .github/workflows/*.yml
+git diff --check main...HEAD
+```
+
+Expected: clean worktree, only the seven workflow files plus `CLAUDE.md` changed, and every workflow passes `actionlint`.
+
+## Implementation PR verification notes
+
+When the implementation branch is marked ready for review, record which jobs actually ran/skipped for the branch's changed paths. The branch itself changes workflows and `CLAUDE.md`, so it is not a pure docs-only example; use the matrix above as the acceptance artifact rather than creating throwaway test infrastructure solely to manufacture every path combination.

--- a/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
@@ -4,132 +4,237 @@
 
 Reduce ready-PR CI cost and feedback time without replacing the repository's current GitHub Actions structure.
 
-Use a hybrid model:
+Use the repository's existing seams:
 
-- keep the two required status-check jobs (`test` and `lint-and-format`) present on every non-draft PR, but let them stop after a cheap Turborepo affected-package check when no relevant workspace/configuration changed;
+- keep the two required status-check jobs (`test` and `lint-and-format`) present on every non-draft PR;
+- put one small, tested fail-open scope script under `.github/scripts/` so the required jobs and CodeQL do not each grow their own Bash classifier;
+- use Turborepo's affected workspace graph for package-aware decisions;
+- keep repo-wide formatting and ESLint on every ready PR, while gating only the expensive generated/schema/typecheck portion of `lint-and-format`;
 - use native `pull_request.paths` filters for non-required web E2E, desktop E2E, and Tauri Rust workflows;
 - remove ordinary pull-request packaging from the Windows/macOS build workflow while preserving `preview`, `main`, release-tag, and manual release behavior;
-- keep CodeQL on `main` and the weekly schedule, but on pull requests build a dynamic language matrix from changed source/workflow paths;
-- make Codecov upload transport failures non-blocking while leaving the existing Codecov project/patch coverage policy unchanged.
+- keep CodeQL full on `main` and its weekly schedule, but on pull requests select only languages touched by relevant source/workflow paths;
+- flag the three Codecov upload streams and enable carryforward so partial CI runs keep the existing 90% coverage policy meaningful;
+- make Codecov uploader/service failures non-blocking without weakening project or patch targets.
 
-This is deliberately a CI-routing change, not a new CI framework or dependency-graph service.
+This is deliberately a CI-routing change, not a new CI framework, dependency-graph service, or workflow consolidation.
 
 Linear: HPA-613
 
 ## Why HPA-613 is the next slice
 
-HPA-613 is the only medium-priority item in the DTXWeb backlog and has no blockers. HPA-614 and HPA-615 are complete, so HPA-616 is now available but remains a low-priority behavior-preserving refactor; HPA-617 is downstream cleanup and HPA-193 is low-priority test hardening.
+HPA-613 is unblocked and is the current medium-priority DTXWeb backlog item. It targets repeated runner cost on ready PRs without changing product behavior.
 
-The current workflows make HPA-613 immediately valuable:
+The repository already has the pieces needed for a small solution:
 
-- `unit-test.yml` runs full repository coverage for any ready PR;
-- `lint-and-format.yml` installs the full workspace, builds common, regenerates schema/client output, typechecks both E2E packages, lints, and formats for any ready PR;
-- `e2e-test.yml` starts Supabase, Playwright, API, and web infrastructure for any ready PR;
-- `tauri-rust-ci.yml` runs two Linux Rust jobs for any ready PR;
-- `desktop-build-deploy.yml` builds both Windows and macOS packages for any ready PR;
-- `codeql.yml` starts four language jobs for any ready PR.
+- Turborepo already owns the workspace dependency graph;
+- `desktop-e2e-test.yml` already demonstrates native GitHub Actions path filtering;
+- the active `Main` ruleset requires only the `test` and `lint-and-format` contexts;
+- draft PR jobs are already skipped;
+- release/deploy workflows already distinguish PR, `preview`, `main`, tag, and manual behavior.
 
-The live `Main` repository ruleset currently requires only the GitHub Actions contexts `test` and `lint-and-format`. That distinction is load-bearing: GitHub documents that a required workflow skipped by event-level path filtering can remain pending, while a job that completes or intentionally skips inside a triggered workflow can satisfy its status context.
+The design should extend those seams rather than add a CI platform.
+
+## Current problem
+
+### Required jobs cannot be path-skipped at the workflow event
+
+The active `Main` ruleset requires exactly:
+
+- `test`
+- `lint-and-format`
+
+If either required workflow is excluded at the `pull_request` event through `paths`, GitHub may never create the required context for the PR. Therefore both workflows must continue to start for ready PRs and finish successfully even when their expensive work is unnecessary.
+
+### Unit coverage currently means the whole Turborepo coverage task
+
+`unit-test.yml` runs root `bun run test:coverage`, which is one Turborepo task over every workspace that defines `test:coverage`.
+
+HPA-613 does not split that command package-by-package. The gate is binary:
+
+- relevant coverage-producing workspace/config changed -> run the existing root coverage command;
+- no relevant workspace/config changed -> skip dependency installation, tests, and upload while preserving the `test` job context.
+
+The five coverage-producing workspaces are:
+
+- `@dtx/common`
+- `@dtx/ui-components`
+- `dtx-web`
+- `dtx-api`
+- `dtx-desktop`
+
+Changes only to `dtx-e2e-web` or `dtx-e2e-desktop` do not make the root unit coverage task useful.
+
+### Lint is not one all-or-nothing expense
+
+`lint-and-format.yml` mixes two kinds of work.
+
+Repository-wide checks:
+
+- `bun install --frozen-lockfile`
+- ESLint
+- Prettier
+
+Workspace/generated checks:
+
+- SvelteKit/common build preparation
+- GraphQL schema generation
+- generated web client drift verification
+- web and desktop E2E package typechecks
+
+A docs-only PR still needs Prettier because Markdown is included by the repo-wide format check. Skipping the entire lint job would allow formatting failures to merge and only surface on `main`.
+
+Therefore `lint-and-format` always installs dependencies and runs ESLint + Prettier on a ready PR. Only the workspace/generated block is gated.
+
+### The affected query itself is safety-critical
+
+A green required check produced by a broken detector is worse than running too much CI.
+
+The current plan originally duplicated scope Bash in two YAML files and did not execute it before relying on it. It also assumed the wrong `turbo ls --output=json` traversal and did not fail open if `git diff` failed.
+
+The revised design gives the risky logic one ownership seam and requires executable verification before workflow wiring.
+
+## Reuse decisions
+
+| Proposed work | Existing seam |
+| --- | --- |
+| Affected workspace calculation | Turborepo `turbo ls --affected --output=json` |
+| Comparison refs | `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` with full checkout history |
+| Required-job scope logic | new small `.github/scripts/ci-affected-scope.sh`; no existing equivalent |
+| Web/native workflow path filtering | existing `desktop-e2e-test.yml` `paths` pattern |
+| Unit coverage command | existing root `bun run test:coverage`; do not split |
+| GraphQL/codegen drift | existing `lint-and-format.yml` sequence |
+| Packaging reduction | existing `desktop-build-deploy.yml` event/PR branches |
+| CodeQL languages | existing static four-language matrix, narrowed only on PR |
+| Coverage streams | existing three Codecov upload steps, now named by flags |
+| Workflow documentation | existing `CLAUDE.md` CI guidance |
 
 ## Goals
 
-- Make docs-only and unrelated PRs avoid expensive application/native CI.
-- Preserve deterministic required contexts `test` and `lint-and-format`.
-- Keep shared changes capable of triggering both web and desktop validation.
-- Keep GraphQL schema generation and generated-client drift checks intact.
-- Keep all current validation/release behavior on pushes to `main` unless HPA-613 explicitly changes PR-only behavior.
-- Stop routine PRs from building Windows/macOS installers.
-- Reduce CodeQL PR work to languages that can be affected by the changed paths.
-- Keep the implementation understandable from the workflow files and contributor documentation.
+- Keep required check names deterministic.
+- Make scope-detection failure conservative: run more CI, never silently less.
+- Skip the full unit-coverage stack on docs-only and E2E-only changes.
+- Keep repo-wide lint/format coverage on every ready PR.
+- Skip generated/schema/E2E-typecheck lint work when no workspace can be affected.
+- Skip web E2E for unrelated PRs.
+- Skip Rust CI for changes that cannot affect Rust/native generated contracts.
+- Preserve common/shared changes as triggers for desktop E2E and web validation where they matter.
+- Stop Windows/macOS packaging on ordinary PRs.
+- Keep CodeQL full on `main`/schedule and language-scoped on PRs.
+- Keep Codecov's 90% project/patch targets while making partial suite execution compatible with coverage aggregation.
+- Document a concrete affected-area matrix.
 
 ## Non-goals
 
-- No new CI SaaS, custom dependency graph, or long-lived CI service.
-- No merge of all workflows into one monolithic `ci.yml`.
-- No removal of unit tests, web E2E, desktop E2E, Rust tests/clippy/fmt, CodeQL, schema generation, or generated-client drift checks.
-- No remote Turborepo cache project.
-- No coverage-threshold redesign. `codecov.yml` remains authoritative for project and patch targets.
-- No release-channel redesign, signing redesign, or Tauri packaging refactor beyond removing ordinary PR packaging.
-- No attempt to infer every possible dependency from file extensions when Turborepo already models workspace dependencies.
+- No monolithic `ci.yml`.
+- No external classifier service.
+- No handwritten package dependency graph.
+- No remote Turborepo cache.
+- No package-by-package rewrite of root `test:coverage`.
+- No removal of unit, E2E, Rust, CodeQL, schema, codegen, or formatting coverage.
+- No Codecov threshold change.
+- No product/application code changes.
+- No general release workflow rewrite.
 
-## Alternatives considered
+## Chosen architecture
 
-### A. Add `paths` to every workflow
+### 1. One small fail-open scope script
 
-This is the smallest YAML diff, but it is wrong for `unit-test.yml` and `lint-and-format.yml`: those jobs back the required `test` and `lint-and-format` contexts. If GitHub filters the whole workflow before it starts, a required check can remain pending and block merge.
+Create:
 
-Reject this for required workflows.
+` .github/scripts/ci-affected-scope.sh`
 
-### B. Replace all CI with one workflow and one central classifier
+The script has three explicit modes:
 
-One scope job could feed every test/build job, but it would combine six independently understandable workflows and the release workflow into a larger orchestration file. That is more migration risk and maintenance work than the ticket justifies.
+- `unit` -> prints `true` when root unit coverage must run, otherwise `false`;
+- `lint` -> prints `true` when the expensive workspace/generated lint block must run, otherwise `false`;
+- `codeql` -> prints a non-empty JSON array of CodeQL languages for the PR.
 
-Reject this as over-engineering.
+Diagnostics, including the raw affected-package JSON and changed-file list, go to stderr so the machine-readable stdout stays stable.
 
-### C. Hybrid required-job gate + native path filters
+The script is intentionally not a generic rules engine. Package and path lists stay literal and close to the workflows they serve.
 
-Keep required workflows triggered, detect workspace impact cheaply inside their existing required jobs, and use event-level path filters only where missing workflow checks cannot block branch protection. Handle CodeQL separately because its unit of work is language rather than package.
+For `unit` and `lint` it:
 
-Choose this option.
+1. requires `TURBO_SCM_BASE` and `TURBO_SCM_HEAD`;
+2. obtains changed files with `git diff --name-only "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD"`;
+3. runs `bunx turbo ls --affected --output=json` using the same refs;
+4. validates the JSON shape before reading package names;
+5. reads names from `packages.items` and validates the reported package count;
+6. applies the mode's small allowlist/force-full rules.
 
-## Chosen design
+Any missing ref, Git failure, Turbo failure, malformed/unexpected JSON, or jq failure exits non-zero. Each workflow wrapper converts that failure to the conservative result (`true` or all CodeQL languages).
 
-### 1. Required `test` stays present, but expensive coverage runs only for relevant workspace changes
+`fetch-depth: 0` is the only git-history mechanism. Do not add a second merge-base/fetch scheme.
 
-Keep `unit-test.yml` triggered on ready pull requests exactly as today. Do not add a PR `paths` filter.
+### 2. Execute the detector before trusting it
 
-Before `bun install`, add a small scope step after checkout/setup-Bun:
+The implementation includes recorded Turbo JSON fixtures representing:
 
-1. on `push`, set `run_expensive=true` so `main` behavior stays full;
-2. on `pull_request`, check out enough Git history and set `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` from the PR base/head SHAs;
-3. run Turborepo's package query (`turbo ls --affected --output=json`);
-4. set `run_expensive=true` when one of the unit-test-bearing packages is affected:
-   - `@dtx/common`
-   - `@dtx/ui-components`
-   - `dtx-api`
-   - `dtx-web`
-   - `dtx-desktop`
-5. also force the full job when `unit-test.yml`, `package.json`, `bun.lock`, `turbo.json`, or `codecov.yml` changes.
+- a web workspace affected;
+- no workspace affected;
+- malformed/unexpected output.
 
-All current expensive steps (`bun install`, SvelteKit sync, common build, `bun run test:coverage`, Codecov upload) receive the same step-level condition. A docs-only PR therefore still gets a successful `test` job/context, but the job exits after checkout/setup/scope detection.
+Fixture assertions verify the actual jq traversal used by the script. In addition, the script is run against one real local Git base/head pair so the checked-in Turborepo version, Git refs, and JSON parsing are exercised together.
 
-Do **not** change `bun run test:coverage` to partial package coverage in this ticket. The current Codecov project/patch policy expects one coherent TypeScript coverage upload; package-selective coverage is a separate problem and could make the coverage signal harder to interpret.
+A `packages/dtx-web/**` case must resolve `unit=true` before any YAML gate is considered complete.
 
-### 2. Required `lint-and-format` uses the same cheap package query, with a broader relevant set
+### 3. Required `test` keeps one binary coverage gate
 
-Keep `lint-and-format.yml` triggered on every ready PR and keep job id `lint-and-format` unchanged.
+`unit-test.yml` keeps job id `test` and stays event-visible for every ready PR.
 
-The scope step uses the same Turborepo base/head comparison. Run the existing full lint/codegen sequence when any workspace package is affected, including `dtx-e2e-web` and `dtx-e2e-desktop`, because this workflow typechecks both E2E packages.
+After checkout (`fetch-depth: 0`) and Bun setup, a scope step calls the shared script.
 
-Also force the full sequence for root lint/format/build configuration changes:
+For pull requests:
 
-- `.editorconfig`
-- `.eslintignore`
-- `.eslintrc.cjs`
-- `.prettierignore`
-- `.prettierrc`
-- `package.json`
-- `bun.lock`
-- `turbo.json`
-- `.github/workflows/lint-and-format.yml`
+- script success controls `run_expensive`;
+- script failure sets `run_expensive=true`.
 
-Keep the current schema/client order exactly:
+For pushes to `main`/`master`, `run_expensive=true` without scope reduction.
 
-1. generate SvelteKit types;
-2. build `@dtx/common`;
-3. regenerate and diff `packages/dtx-api/dist/schema.graphql`;
-4. run `dtx-web lint:codegen`;
-5. typecheck both E2E packages;
-6. lint;
-7. Prettier check.
+Only when `run_expensive=true` run:
 
-This deliberately favors one complete lint/codegen gate over trying to micro-filter every lint command.
+- dependency installation;
+- SvelteKit/common preparation;
+- root `bun run test:coverage`;
+- TypeScript Codecov upload.
 
-### 3. Web E2E gets a PR path filter
+Do not split the root coverage task into per-package test commands.
 
-`e2e-test.yml` is not a required context, so use native `pull_request.paths` and avoid starting a runner at all when the web stack cannot be affected.
+Force full unit coverage when scope infrastructure or root dependency/config files change, including the unit workflow itself, the shared scope script, `package.json`, `bun.lock`, `turbo.json`, and `codecov.yml`.
 
-Trigger web E2E for PR changes under:
+### 4. Required `lint-and-format` is two-tier
+
+`lint-and-format.yml` keeps job id `lint-and-format` and remains event-visible.
+
+Always on ready PRs:
+
+- checkout;
+- setup Bun;
+- `bun install --frozen-lockfile`;
+- repository ESLint;
+- repository Prettier check.
+
+Run the workspace/generated block when:
+
+- any workspace package is affected; or
+- root dependency/Turborepo config, lint workflow, or shared scope script changes; or
+- scope detection fails.
+
+The gated block preserves the current ordering:
+
+1. SvelteKit/common build preparation;
+2. common build;
+3. API GraphQL schema generation and tracked-schema drift check;
+4. generated web client verification;
+5. web and desktop E2E typechecks.
+
+This keeps docs formatting guarded without paying schema/codegen/typecheck cost on docs-only PRs.
+
+### 5. Non-required workflows use native path filters
+
+#### Web E2E
+
+Add PR paths for surfaces that can affect the web stack:
 
 - `packages/dtx-web/**`
 - `packages/dtx-api/**`
@@ -142,156 +247,171 @@ Trigger web E2E for PR changes under:
 - `bun.lock`
 - `turbo.json`
 
-Keep push-to-`main` behavior unchanged and keep the existing draft guard.
+Keep `main`/`master` push behavior full.
 
-This intentionally does not trigger web E2E for desktop-only or `e2e-desktop`-only changes.
+#### Desktop E2E
 
-### 4. Desktop E2E keeps its existing path gate and documents the matrix
+Keep the existing path-filter model. It already covers renderer/shared/E2E dependencies and should continue to trigger on `packages/common/**` and `packages/ui-components/**`.
 
-`desktop-e2e-test.yml` already has the correct basic shape. Keep and verify these PR-impact paths:
+#### Tauri Rust CI
 
-- `packages/dtx-desktop/**`
-- `packages/e2e-desktop/**`
-- `packages/common/**`
-- `packages/ui-components/**`
-- `.github/workflows/desktop-e2e-test.yml`
-- `package.json`
-- `bun.lock`
-- `turbo.json`
-
-Do not add web/API paths merely because the desktop app talks to the API at runtime; the native E2E harness uses its own deterministic test environment and HPA-613's scope calls out desktop/common/UI/E2E/native/shared configuration.
-
-### 5. Tauri Rust CI gets a PR path filter, while `main` remains full
-
-Add `pull_request.paths` to `tauri-rust-ci.yml` for:
+Narrow PR paths to actual native/generated-contract inputs:
 
 - `packages/dtx-desktop/**`
 - `packages/e2e-desktop/**`
-- `packages/common/**`
-- `packages/ui-components/**`
 - `.github/workflows/tauri-rust-ci.yml`
 - `package.json`
 - `bun.lock`
 - `turbo.json`
 
-Keep the `push` trigger broad on `main`/`master`. The two existing Rust jobs and generated-TypeScript drift verification remain unchanged when the workflow runs.
+Do not add `packages/common/**` or `packages/ui-components/**` merely because desktop E2E needs them. Rust CI's generated-type drift files live under desktop/E2E-desktop, and desktop E2E already exercises shared renderer changes.
 
-The path set is intentionally conservative: a renderer/shared change can still affect Tauri command contracts and generated native types, so HPA-613 should not try to distinguish renderer-only from native-only changes inside `dtx-desktop`.
+Keep `main`/`master` push behavior full.
 
-### 6. Ordinary PRs stop running cross-platform packaging
+### 6. Ordinary PR packaging disappears
 
 Remove the `pull_request` trigger from `desktop-build-deploy.yml`.
 
-Preserve these existing entry points:
+Delete PR-only unsigned build branches and simplify conditions/env setup that existed only for ordinary PR packaging.
+
+Keep:
 
 - push to `preview`;
 - push to `main`;
 - `v*` tags;
-- `workflow_dispatch`.
+- `workflow_dispatch`;
+- signed release behavior and deployment semantics.
 
-Because PRs no longer invoke this workflow, remove PR-only dead branches from the workflow where they become unreachable (for example unsigned PR build steps and `github.event_name == 'pull_request'` conditions), but do not redesign release signing or deployment.
+No replacement packaging-validation workflow is added in HPA-613.
 
-Manual dispatch remains the escape hatch when a packaging-specific change needs pre-merge validation.
+### 7. CodeQL stays language-scoped on PRs
 
-### 7. CodeQL keeps full `main`/scheduled scanning and selects languages on PRs
+HPA-613 explicitly requires PR analysis to be limited to source/workflow changes relevant to each language, so the language selector remains in scope rather than being deferred.
 
-Keep push-to-`main` and weekly scheduled CodeQL behavior as a full four-language scan.
+Reduce its machinery in two ways:
 
-For pull requests:
+1. add a PR-level `paths` filter so docs-only PRs never start CodeQL;
+2. use the same tested scope script's `codeql` mode rather than another inline Bash classifier.
 
-1. add a combined source/workflow `paths` filter so docs-only PRs do not start CodeQL at all;
-2. add one lightweight selector job that diffs PR base/head files and emits a JSON matrix;
-3. map changed paths to the existing CodeQL languages:
-   - `actions`: `.github/workflows/**` (and `.github/actions/**` if that directory is introduced);
-   - `javascript-typescript`: JS/TS/Svelte source/config/package-manifest changes;
-   - `python`: `scripts/**/*.py` and Python dependency/config files;
-   - `rust`: `packages/dtx-desktop/src-tauri/**`;
-4. feed only selected languages into the existing `analyze` matrix.
+PR language mapping:
 
-Do not split CodeQL into four duplicated jobs. The current `analyze` implementation remains one matrix job; only matrix construction changes.
+- `actions` for `.github/workflows/**`;
+- `javascript-typescript` for JS/TS/Svelte source/config files;
+- `python` for `scripts/**/*.py`;
+- `rust` for `packages/dtx-desktop/src-tauri/**/*.rs`.
 
-CodeQL is not a required status context in the current ruleset, so omitted language jobs do not need placeholder checks.
+Unexpected/no mapping after a triggered PR is conservative: analyze all four languages.
 
-### 8. Codecov upload outages stop failing otherwise-green test jobs
+Pushes to `main` and scheduled scans always analyze all four languages.
 
-Change `fail_ci_if_error: true` to `false` for every current Codecov upload action:
+### 8. Codecov uses three carryforward flags
 
-- TypeScript coverage in `unit-test.yml`;
-- Rust coverage in `tauri-rust-ci.yml`;
-- desktop E2E Rust coverage in `desktop-e2e-test.yml`.
+Keep current project and patch targets at 90% with `threshold: 0%` and current status behavior.
 
-Do **not** change `codecov.yml` targets or make Codecov's project/patch statuses informational. HPA-613 only prevents uploader/network/service failures from turning a successful test suite red.
+Name the existing upload streams:
 
-### 9. Document one affected-area matrix in `CLAUDE.md`
+- root TypeScript/Vitest coverage -> `typescript`;
+- Tauri Rust unit coverage -> `tauri-rust`;
+- desktop E2E Rust coverage -> `desktop-e2e-rust`.
 
-Add a concise CI section explaining:
+Set `carryforward: true` for all three flags in `codecov.yml` and pass the matching flag from each upload action.
 
-| Change | Unit `test` | `lint-and-format` | Web E2E | Desktop E2E | Tauri Rust | PR packaging | CodeQL PR |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| docs only | cheap gate only | cheap gate only | no | no | no | no | no |
-| `dtx-web` | full | full | yes | no | no | no | JS/TS |
-| `dtx-api` | full | full | yes | no | no | no | JS/TS |
-| `dtx-desktop` | full | full | no | yes | yes | no | JS/TS and/or Rust by path |
-| `common` | full | full | yes | yes | yes | no | JS/TS |
-| `ui-components` | full | full | yes | yes | yes | no | JS/TS |
-| `e2e-web` | cheap/no unit work | full | yes | no | no | no | JS/TS |
-| `e2e-desktop` | cheap/no unit work | full | no | yes | yes | no | JS/TS |
-| shared root package config | full | full | yes | yes | yes | no | relevant language(s) |
-| workflow-only | workflow-specific | workflow-specific | workflow-specific | workflow-specific | workflow-specific | no ordinary PR packaging | Actions |
+This lets Codecov reuse the previous flag's coverage when that suite is intentionally skipped on the current commit, instead of treating affected CI as an incomplete coverage model.
 
-Also document that `test` and `lint-and-format` are the two required status contexts, which is why those workflows gate *inside* the job instead of using PR-level path filtering.
+Set `fail_ci_if_error: false` on all three uploads. This only makes uploader/service transport failures informational; coverage policy remains enforced by `codecov.yml`.
 
-## Error handling and safety
+The implementation PR changes all three upload/workflow surfaces plus `codecov.yml`, so it should run all three streams and establish a flagged baseline before later PRs rely on carryforward.
 
-- If Turborepo cannot determine the PR diff (missing ref/history, malformed output, query failure), required jobs must fail open to **run the existing expensive validation**, not silently skip it.
-- Root dependency/config changes should be conservative and run more validation, not less.
-- `main`, scheduled, tag, preview, and manual release events must not depend on PR-only scope outputs.
-- The CodeQL selector should emit all four languages if its PR diff calculation fails.
-- No secrets or release signing material move into new jobs.
+### 9. Documentation records the matrix, not implementation history
 
-## Validation
+Update `CLAUDE.md` with the resulting ready-PR matrix and fail-open rule.
+
+Document behavior such as:
+
+| Change | Required unit coverage | Repo lint/format | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| docs only | skip | run | skip | skip | skip | skip | skip | skip |
+| `dtx-web` | run | run | run | run | skip | skip | skip | JS/TS |
+| `dtx-api` | run | run | run | run | skip | skip | skip | JS/TS |
+| `common` | run | run | run | run | run | skip | skip | JS/TS |
+| `ui-components` | run | run | run | run | run | skip | skip | JS/TS |
+| desktop renderer | run | run | run | skip | run | run | skip | JS/TS |
+| desktop Rust | run | run | run | skip | run | run | skip | Rust |
+| web E2E only | skip | run | run | run | skip | skip | skip | JS/TS if source changes |
+| desktop E2E only | skip | run | run | skip | run | run | skip | JS/TS if source changes |
+| shared/root CI config | conservative full where relevant | run | run | according to path filters | according to path filters | according to path filters | no PR packaging | mapped/all on failure |
+
+## Error handling
+
+Scope reduction is an optimization, never a correctness dependency.
+
+- missing `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` -> full relevant validation;
+- `git diff` failure -> full relevant validation;
+- `turbo ls` failure -> full relevant validation;
+- malformed or unexpected Turbo JSON -> full relevant validation;
+- jq failure -> full relevant validation;
+- CodeQL mapping failure -> all four languages;
+- Codecov uploader/service failure -> informational upload failure, not a replacement for coverage policy.
+
+Raw scope inputs/results are logged so a wrong skip can be diagnosed from one workflow run.
+
+## Testing and verification
+
+### Scope script
+
+Before workflow wiring is accepted:
+
+- shell syntax check;
+- recorded web-affected JSON -> `unit=true`;
+- recorded empty-affected JSON -> `unit=false` and `lint=false`;
+- malformed JSON -> wrapper chooses full validation;
+- missing/invalid Git refs -> wrapper chooses full validation;
+- real local base/head pair executes the checked-in Turbo command successfully;
+- raw affected JSON appears in diagnostics.
 
 ### Workflow syntax
 
-Run `actionlint` over every changed workflow before implementation is considered complete.
+Run `actionlint` over every changed workflow.
 
-### Turborepo scope behavior
+### Required checks
 
-Use explicit PR base/head SHAs and inspect `turbo ls --affected --output=json` for representative changes. The important invariant is that shared package changes include their dependent application packages; no handwritten dependency graph should duplicate Turborepo's workspace graph.
+Confirm job ids remain exactly `test` and `lint-and-format` and neither required workflow has event-level PR `paths` filtering.
 
-### Dry-run matrix
+### Path matrix
 
-Document and manually verify at least these cases in the implementation PR:
+Inspect/dry-run the documented cases for docs, web, API, common, UI, desktop renderer, desktop Rust, web E2E, desktop E2E, and root CI configuration.
 
-1. docs-only;
-2. web-only;
-3. API-only;
-4. desktop renderer-only;
-5. desktop Rust-only;
-6. `packages/common/**`;
-7. `packages/ui-components/**`;
-8. `packages/e2e-web/**`;
-9. `packages/e2e-desktop/**`;
-10. root `package.json` / `bun.lock` / `turbo.json`;
-11. workflow-only changes;
-12. push to `main`;
-13. manual desktop release.
+### Release behavior
 
-### Branch-protection invariant
+Verify `desktop-build-deploy.yml` still has `preview`, `main`, `v*`, and manual entry points, and no ordinary PR trigger.
 
-Re-read the active repository ruleset after the workflow change. The required contexts must still be named exactly `test` and `lint-and-format`.
+### Codecov
 
-## Expected implementation file scope
+Verify all three uploads use their configured flags, all three flags have carryforward enabled, and 90% project/patch targets are unchanged.
+
+### Final implementation-PR gate
+
+Before treating HPA-613 implementation as complete, a PR changing `packages/dtx-web/**` must demonstrably resolve the detector to unit coverage enabled. The expensive-gate logic is not considered proven solely because `actionlint` passes.
+
+## Expected file scope
+
+New:
+
+- `.github/scripts/ci-affected-scope.sh`
+- `.github/scripts/fixtures/turbo-ls-web.json`
+- `.github/scripts/fixtures/turbo-ls-empty.json`
+- `.github/scripts/fixtures/turbo-ls-malformed.json`
 
 Modify:
 
 - `.github/workflows/unit-test.yml`
 - `.github/workflows/lint-and-format.yml`
 - `.github/workflows/e2e-test.yml`
-- `.github/workflows/desktop-e2e-test.yml`
+- `.github/workflows/desktop-e2e-test.yml` only for Codecov flag/transport handling
 - `.github/workflows/tauri-rust-ci.yml`
 - `.github/workflows/desktop-build-deploy.yml`
 - `.github/workflows/codeql.yml`
+- `codecov.yml`
 - `CLAUDE.md`
 
-No application/package source files are required.
+No application source files are changed.

--- a/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
@@ -1,0 +1,297 @@
+# HPA-613 Affected CI Design
+
+## Summary
+
+Reduce ready-PR CI cost and feedback time without replacing the repository's current GitHub Actions structure.
+
+Use a hybrid model:
+
+- keep the two required status-check jobs (`test` and `lint-and-format`) present on every non-draft PR, but let them stop after a cheap Turborepo affected-package check when no relevant workspace/configuration changed;
+- use native `pull_request.paths` filters for non-required web E2E, desktop E2E, and Tauri Rust workflows;
+- remove ordinary pull-request packaging from the Windows/macOS build workflow while preserving `preview`, `main`, release-tag, and manual release behavior;
+- keep CodeQL on `main` and the weekly schedule, but on pull requests build a dynamic language matrix from changed source/workflow paths;
+- make Codecov upload transport failures non-blocking while leaving the existing Codecov project/patch coverage policy unchanged.
+
+This is deliberately a CI-routing change, not a new CI framework or dependency-graph service.
+
+Linear: HPA-613
+
+## Why HPA-613 is the next slice
+
+HPA-613 is the only medium-priority item in the DTXWeb backlog and has no blockers. HPA-614 and HPA-615 are complete, so HPA-616 is now available but remains a low-priority behavior-preserving refactor; HPA-617 is downstream cleanup and HPA-193 is low-priority test hardening.
+
+The current workflows make HPA-613 immediately valuable:
+
+- `unit-test.yml` runs full repository coverage for any ready PR;
+- `lint-and-format.yml` installs the full workspace, builds common, regenerates schema/client output, typechecks both E2E packages, lints, and formats for any ready PR;
+- `e2e-test.yml` starts Supabase, Playwright, API, and web infrastructure for any ready PR;
+- `tauri-rust-ci.yml` runs two Linux Rust jobs for any ready PR;
+- `desktop-build-deploy.yml` builds both Windows and macOS packages for any ready PR;
+- `codeql.yml` starts four language jobs for any ready PR.
+
+The live `Main` repository ruleset currently requires only the GitHub Actions contexts `test` and `lint-and-format`. That distinction is load-bearing: GitHub documents that a required workflow skipped by event-level path filtering can remain pending, while a job that completes or intentionally skips inside a triggered workflow can satisfy its status context.
+
+## Goals
+
+- Make docs-only and unrelated PRs avoid expensive application/native CI.
+- Preserve deterministic required contexts `test` and `lint-and-format`.
+- Keep shared changes capable of triggering both web and desktop validation.
+- Keep GraphQL schema generation and generated-client drift checks intact.
+- Keep all current validation/release behavior on pushes to `main` unless HPA-613 explicitly changes PR-only behavior.
+- Stop routine PRs from building Windows/macOS installers.
+- Reduce CodeQL PR work to languages that can be affected by the changed paths.
+- Keep the implementation understandable from the workflow files and contributor documentation.
+
+## Non-goals
+
+- No new CI SaaS, custom dependency graph, or long-lived CI service.
+- No merge of all workflows into one monolithic `ci.yml`.
+- No removal of unit tests, web E2E, desktop E2E, Rust tests/clippy/fmt, CodeQL, schema generation, or generated-client drift checks.
+- No remote Turborepo cache project.
+- No coverage-threshold redesign. `codecov.yml` remains authoritative for project and patch targets.
+- No release-channel redesign, signing redesign, or Tauri packaging refactor beyond removing ordinary PR packaging.
+- No attempt to infer every possible dependency from file extensions when Turborepo already models workspace dependencies.
+
+## Alternatives considered
+
+### A. Add `paths` to every workflow
+
+This is the smallest YAML diff, but it is wrong for `unit-test.yml` and `lint-and-format.yml`: those jobs back the required `test` and `lint-and-format` contexts. If GitHub filters the whole workflow before it starts, a required check can remain pending and block merge.
+
+Reject this for required workflows.
+
+### B. Replace all CI with one workflow and one central classifier
+
+One scope job could feed every test/build job, but it would combine six independently understandable workflows and the release workflow into a larger orchestration file. That is more migration risk and maintenance work than the ticket justifies.
+
+Reject this as over-engineering.
+
+### C. Hybrid required-job gate + native path filters
+
+Keep required workflows triggered, detect workspace impact cheaply inside their existing required jobs, and use event-level path filters only where missing workflow checks cannot block branch protection. Handle CodeQL separately because its unit of work is language rather than package.
+
+Choose this option.
+
+## Chosen design
+
+### 1. Required `test` stays present, but expensive coverage runs only for relevant workspace changes
+
+Keep `unit-test.yml` triggered on ready pull requests exactly as today. Do not add a PR `paths` filter.
+
+Before `bun install`, add a small scope step after checkout/setup-Bun:
+
+1. on `push`, set `run_expensive=true` so `main` behavior stays full;
+2. on `pull_request`, check out enough Git history and set `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` from the PR base/head SHAs;
+3. run Turborepo's package query (`turbo ls --affected --output=json`);
+4. set `run_expensive=true` when one of the unit-test-bearing packages is affected:
+   - `@dtx/common`
+   - `@dtx/ui-components`
+   - `dtx-api`
+   - `dtx-web`
+   - `dtx-desktop`
+5. also force the full job when `unit-test.yml`, `package.json`, `bun.lock`, `turbo.json`, or `codecov.yml` changes.
+
+All current expensive steps (`bun install`, SvelteKit sync, common build, `bun run test:coverage`, Codecov upload) receive the same step-level condition. A docs-only PR therefore still gets a successful `test` job/context, but the job exits after checkout/setup/scope detection.
+
+Do **not** change `bun run test:coverage` to partial package coverage in this ticket. The current Codecov project/patch policy expects one coherent TypeScript coverage upload; package-selective coverage is a separate problem and could make the coverage signal harder to interpret.
+
+### 2. Required `lint-and-format` uses the same cheap package query, with a broader relevant set
+
+Keep `lint-and-format.yml` triggered on every ready PR and keep job id `lint-and-format` unchanged.
+
+The scope step uses the same Turborepo base/head comparison. Run the existing full lint/codegen sequence when any workspace package is affected, including `dtx-e2e-web` and `dtx-e2e-desktop`, because this workflow typechecks both E2E packages.
+
+Also force the full sequence for root lint/format/build configuration changes:
+
+- `.editorconfig`
+- `.eslintignore`
+- `.eslintrc.cjs`
+- `.prettierignore`
+- `.prettierrc`
+- `package.json`
+- `bun.lock`
+- `turbo.json`
+- `.github/workflows/lint-and-format.yml`
+
+Keep the current schema/client order exactly:
+
+1. generate SvelteKit types;
+2. build `@dtx/common`;
+3. regenerate and diff `packages/dtx-api/dist/schema.graphql`;
+4. run `dtx-web lint:codegen`;
+5. typecheck both E2E packages;
+6. lint;
+7. Prettier check.
+
+This deliberately favors one complete lint/codegen gate over trying to micro-filter every lint command.
+
+### 3. Web E2E gets a PR path filter
+
+`e2e-test.yml` is not a required context, so use native `pull_request.paths` and avoid starting a runner at all when the web stack cannot be affected.
+
+Trigger web E2E for PR changes under:
+
+- `packages/dtx-web/**`
+- `packages/dtx-api/**`
+- `packages/common/**`
+- `packages/ui-components/**`
+- `packages/e2e-web/**`
+- `supabase/**`
+- `.github/workflows/e2e-test.yml`
+- `package.json`
+- `bun.lock`
+- `turbo.json`
+
+Keep push-to-`main` behavior unchanged and keep the existing draft guard.
+
+This intentionally does not trigger web E2E for desktop-only or `e2e-desktop`-only changes.
+
+### 4. Desktop E2E keeps its existing path gate and documents the matrix
+
+`desktop-e2e-test.yml` already has the correct basic shape. Keep and verify these PR-impact paths:
+
+- `packages/dtx-desktop/**`
+- `packages/e2e-desktop/**`
+- `packages/common/**`
+- `packages/ui-components/**`
+- `.github/workflows/desktop-e2e-test.yml`
+- `package.json`
+- `bun.lock`
+- `turbo.json`
+
+Do not add web/API paths merely because the desktop app talks to the API at runtime; the native E2E harness uses its own deterministic test environment and HPA-613's scope calls out desktop/common/UI/E2E/native/shared configuration.
+
+### 5. Tauri Rust CI gets a PR path filter, while `main` remains full
+
+Add `pull_request.paths` to `tauri-rust-ci.yml` for:
+
+- `packages/dtx-desktop/**`
+- `packages/e2e-desktop/**`
+- `packages/common/**`
+- `packages/ui-components/**`
+- `.github/workflows/tauri-rust-ci.yml`
+- `package.json`
+- `bun.lock`
+- `turbo.json`
+
+Keep the `push` trigger broad on `main`/`master`. The two existing Rust jobs and generated-TypeScript drift verification remain unchanged when the workflow runs.
+
+The path set is intentionally conservative: a renderer/shared change can still affect Tauri command contracts and generated native types, so HPA-613 should not try to distinguish renderer-only from native-only changes inside `dtx-desktop`.
+
+### 6. Ordinary PRs stop running cross-platform packaging
+
+Remove the `pull_request` trigger from `desktop-build-deploy.yml`.
+
+Preserve these existing entry points:
+
+- push to `preview`;
+- push to `main`;
+- `v*` tags;
+- `workflow_dispatch`.
+
+Because PRs no longer invoke this workflow, remove PR-only dead branches from the workflow where they become unreachable (for example unsigned PR build steps and `github.event_name == 'pull_request'` conditions), but do not redesign release signing or deployment.
+
+Manual dispatch remains the escape hatch when a packaging-specific change needs pre-merge validation.
+
+### 7. CodeQL keeps full `main`/scheduled scanning and selects languages on PRs
+
+Keep push-to-`main` and weekly scheduled CodeQL behavior as a full four-language scan.
+
+For pull requests:
+
+1. add a combined source/workflow `paths` filter so docs-only PRs do not start CodeQL at all;
+2. add one lightweight selector job that diffs PR base/head files and emits a JSON matrix;
+3. map changed paths to the existing CodeQL languages:
+   - `actions`: `.github/workflows/**` (and `.github/actions/**` if that directory is introduced);
+   - `javascript-typescript`: JS/TS/Svelte source/config/package-manifest changes;
+   - `python`: `scripts/**/*.py` and Python dependency/config files;
+   - `rust`: `packages/dtx-desktop/src-tauri/**`;
+4. feed only selected languages into the existing `analyze` matrix.
+
+Do not split CodeQL into four duplicated jobs. The current `analyze` implementation remains one matrix job; only matrix construction changes.
+
+CodeQL is not a required status context in the current ruleset, so omitted language jobs do not need placeholder checks.
+
+### 8. Codecov upload outages stop failing otherwise-green test jobs
+
+Change `fail_ci_if_error: true` to `false` for every current Codecov upload action:
+
+- TypeScript coverage in `unit-test.yml`;
+- Rust coverage in `tauri-rust-ci.yml`;
+- desktop E2E Rust coverage in `desktop-e2e-test.yml`.
+
+Do **not** change `codecov.yml` targets or make Codecov's project/patch statuses informational. HPA-613 only prevents uploader/network/service failures from turning a successful test suite red.
+
+### 9. Document one affected-area matrix in `CLAUDE.md`
+
+Add a concise CI section explaining:
+
+| Change | Unit `test` | `lint-and-format` | Web E2E | Desktop E2E | Tauri Rust | PR packaging | CodeQL PR |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| docs only | cheap gate only | cheap gate only | no | no | no | no | no |
+| `dtx-web` | full | full | yes | no | no | no | JS/TS |
+| `dtx-api` | full | full | yes | no | no | no | JS/TS |
+| `dtx-desktop` | full | full | no | yes | yes | no | JS/TS and/or Rust by path |
+| `common` | full | full | yes | yes | yes | no | JS/TS |
+| `ui-components` | full | full | yes | yes | yes | no | JS/TS |
+| `e2e-web` | cheap/no unit work | full | yes | no | no | no | JS/TS |
+| `e2e-desktop` | cheap/no unit work | full | no | yes | yes | no | JS/TS |
+| shared root package config | full | full | yes | yes | yes | no | relevant language(s) |
+| workflow-only | workflow-specific | workflow-specific | workflow-specific | workflow-specific | workflow-specific | no ordinary PR packaging | Actions |
+
+Also document that `test` and `lint-and-format` are the two required status contexts, which is why those workflows gate *inside* the job instead of using PR-level path filtering.
+
+## Error handling and safety
+
+- If Turborepo cannot determine the PR diff (missing ref/history, malformed output, query failure), required jobs must fail open to **run the existing expensive validation**, not silently skip it.
+- Root dependency/config changes should be conservative and run more validation, not less.
+- `main`, scheduled, tag, preview, and manual release events must not depend on PR-only scope outputs.
+- The CodeQL selector should emit all four languages if its PR diff calculation fails.
+- No secrets or release signing material move into new jobs.
+
+## Validation
+
+### Workflow syntax
+
+Run `actionlint` over every changed workflow before implementation is considered complete.
+
+### Turborepo scope behavior
+
+Use explicit PR base/head SHAs and inspect `turbo ls --affected --output=json` for representative changes. The important invariant is that shared package changes include their dependent application packages; no handwritten dependency graph should duplicate Turborepo's workspace graph.
+
+### Dry-run matrix
+
+Document and manually verify at least these cases in the implementation PR:
+
+1. docs-only;
+2. web-only;
+3. API-only;
+4. desktop renderer-only;
+5. desktop Rust-only;
+6. `packages/common/**`;
+7. `packages/ui-components/**`;
+8. `packages/e2e-web/**`;
+9. `packages/e2e-desktop/**`;
+10. root `package.json` / `bun.lock` / `turbo.json`;
+11. workflow-only changes;
+12. push to `main`;
+13. manual desktop release.
+
+### Branch-protection invariant
+
+Re-read the active repository ruleset after the workflow change. The required contexts must still be named exactly `test` and `lint-and-format`.
+
+## Expected implementation file scope
+
+Modify:
+
+- `.github/workflows/unit-test.yml`
+- `.github/workflows/lint-and-format.yml`
+- `.github/workflows/e2e-test.yml`
+- `.github/workflows/desktop-e2e-test.yml`
+- `.github/workflows/tauri-rust-ci.yml`
+- `.github/workflows/desktop-build-deploy.yml`
+- `.github/workflows/codeql.yml`
+- `CLAUDE.md`
+
+No application/package source files are required.

--- a/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
@@ -4,237 +4,170 @@
 
 Reduce ready-PR CI cost and feedback time without replacing the repository's current GitHub Actions structure.
 
-Use the repository's existing seams:
+The implementation should be staged by risk:
 
-- keep the two required status-check jobs (`test` and `lint-and-format`) present on every non-draft PR;
-- put one small, tested fail-open scope script under `.github/scripts/` so the required jobs and CodeQL do not each grow their own Bash classifier;
-- use Turborepo's affected workspace graph for package-aware decisions;
-- keep repo-wide formatting and ESLint on every ready PR, while gating only the expensive generated/schema/typecheck portion of `lint-and-format`;
-- use native `pull_request.paths` filters for non-required web E2E, desktop E2E, and Tauri Rust workflows;
-- remove ordinary pull-request packaging from the Windows/macOS build workflow while preserving `preview`, `main`, release-tag, and manual release behavior;
-- keep CodeQL full on `main` and its weekly schedule, but on pull requests select only languages touched by relevant source/workflow paths;
-- flag the three Codecov upload streams and enable carryforward so partial CI runs keep the existing 90% coverage policy meaningful;
-- make Codecov uploader/service failures non-blocking without weakening project or patch targets.
+1. **PR A — low-risk savings first:** disambiguate the required `test` check, remove ordinary PR packaging, add native path filters to non-required workflows, add CodeQL's cheap PR source filter, add Codecov flags/carryforward, and teach Turborepo about the shared TypeScript config.
+2. **Measure:** inspect the actual workflow-minute/cost reduction from PR A before adding required-check routing machinery.
+3. **PR B — required-check gates:** add one tested fail-open affected-scope script for the required unit and lint jobs.
+4. **PR C — CodeQL language selection:** extend the already-proven scope seam to select PR CodeQL languages while preserving `build-mode: none`.
 
-This is deliberately a CI-routing change, not a new CI framework, dependency-graph service, or workflow consolidation.
+The measurement checkpoint changes implementation order, not the HPA-613 definition of done. PR A alone does not satisfy the ticket's docs-only required-job or per-language CodeQL scope. If measurement shows PR B/C are no longer worth doing, revise HPA-613 explicitly rather than silently declaring the ticket complete.
+
+This remains a CI-routing change, not a new CI framework, dependency-graph service, or workflow consolidation.
 
 Linear: HPA-613
 
-## Why HPA-613 is the next slice
+## Verified repository constraints
 
-HPA-613 is unblocked and is the current medium-priority DTXWeb backlog item. It targets repeated runner cost on ready PRs without changing product behavior.
+### Required contexts are exactly `test` and `lint-and-format`
 
-The repository already has the pieces needed for a small solution:
-
-- Turborepo already owns the workspace dependency graph;
-- `desktop-e2e-test.yml` already demonstrates native GitHub Actions path filtering;
-- the active `Main` ruleset requires only the `test` and `lint-and-format` contexts;
-- draft PR jobs are already skipped;
-- release/deploy workflows already distinguish PR, `preview`, `main`, tag, and manual behavior.
-
-The design should extend those seams rather than add a CI platform.
-
-## Current problem
-
-### Required jobs cannot be path-skipped at the workflow event
-
-The active `Main` ruleset requires exactly:
+The active `Main` ruleset requires these GitHub Actions contexts:
 
 - `test`
 - `lint-and-format`
 
-If either required workflow is excluded at the `pull_request` event through `paths`, GitHub may never create the required context for the PR. Therefore both workflows must continue to start for ready PRs and finish successfully even when their expensive work is unnecessary.
+Neither required workflow may use event-level `pull_request.paths`, because a skipped workflow may never create the context branch protection is waiting for.
 
-### Unit coverage currently means the whole Turborepo coverage task
+### There are currently two GitHub Actions check runs named `test`
 
-`unit-test.yml` runs root `bun run test:coverage`, which is one Turborepo task over every workspace that defines `test:coverage`.
+Both workflows use a job id of `test` with no explicit job `name`:
 
-HPA-613 does not split that command package-by-package. The gate is binary:
+- `.github/workflows/unit-test.yml`
+- `.github/workflows/e2e-test.yml`
+
+GitHub therefore publishes two check runs named `test` from the same GitHub Actions integration. Before adding paths to Playwright, PR A must give the Playwright job an explicit stable name such as `playwright` and verify on one ready PR that:
+
+- the unit workflow still publishes `test`;
+- the Playwright workflow publishes `playwright`;
+- the ruleset's required `test` resolves to the unit workflow.
+
+No ruleset edit is needed.
+
+### Root unit coverage stays all-or-nothing
+
+`unit-test.yml` runs root `bun run test:coverage`. HPA-613 does not split that command into package-specific coverage jobs.
+
+The future gate is binary:
 
 - relevant coverage-producing workspace/config changed -> run the existing root coverage command;
-- no relevant workspace/config changed -> skip dependency installation, tests, and upload while preserving the `test` job context.
+- otherwise -> preserve the required `test` context but skip the expensive coverage stack.
 
-The five coverage-producing workspaces are:
+### Repo lint/format stays unconditional
 
-- `@dtx/common`
-- `@dtx/ui-components`
-- `dtx-web`
-- `dtx-api`
-- `dtx-desktop`
+`lint-and-format.yml` mixes repo-wide formatting/lint checks with generated/schema/typecheck work.
 
-Changes only to `dtx-e2e-web` or `dtx-e2e-desktop` do not make the root unit coverage task useful.
+Always run on ready PRs:
 
-### Lint is not one all-or-nothing expense
+- `bun install --frozen-lockfile`;
+- repository ESLint;
+- repository Prettier.
 
-`lint-and-format.yml` mixes two kinds of work.
+Only the heavier workspace/generated block may be gated:
 
-Repository-wide checks:
+- SvelteKit/common preparation;
+- GraphQL schema generation and drift verification;
+- generated web client verification;
+- web and desktop E2E typechecks.
 
-- `bun install --frozen-lockfile`
-- ESLint
-- Prettier
+A docs-only PR still needs the repo-wide Prettier check.
 
-Workspace/generated checks:
+### Turborepo already owns workspace invalidation
 
-- SvelteKit/common build preparation
-- GraphQL schema generation
-- generated web client drift verification
-- web and desktop E2E package typechecks
+Use Turborepo's affected-package graph rather than adding a package dependency map.
 
-A docs-only PR still needs Prettier because Markdown is included by the repo-wide format check. Skipping the entire lint job would allow formatting failures to merge and only surface on `main`.
+`turbo.json` already has `globalDependencies`, but it currently omits `tsconfig.base.json`. That is a real invalidation hole because the shared TypeScript config can change typechecking/build behavior while producing an empty affected package set.
 
-Therefore `lint-and-format` always installs dependencies and runs ESLint + Prettier on a ready PR. Only the workspace/generated block is gated.
+Add `tsconfig.base.json` to `globalDependencies`.
 
-### The affected query itself is safety-critical
+Do **not** add `.eslintrc.cjs`, `.prettierrc`, `.eslintignore`, or `.prettierignore` merely to force unit coverage. ESLint and Prettier remain unconditional, and those files do not justify rerunning the root coverage stack.
 
-A green required check produced by a broken detector is worse than running too much CI.
+### Codecov is reporting policy, not branch protection
 
-The current plan originally duplicated scope Bash in two YAML files and did not execute it before relying on it. It also assumed the wrong `turbo ls --output=json` traversal and did not fail open if `git diff` failed.
+The active branch ruleset does not require Codecov statuses. However, HPA-613 explicitly requires uploader failures to be informational rather than turning a green test suite red.
 
-The revised design gives the risky logic one ownership seam and requires executable verification before workflow wiring.
+Therefore:
+
+- keep the existing 90% project/patch targets;
+- add named flags and carryforward for suites that are intentionally skipped;
+- set `fail_ci_if_error: false` as required by HPA-613;
+- document the accepted risk that a transport failure can leave Codecov showing carried-forward coverage until a later successful upload.
 
 ## Reuse decisions
 
-| Proposed work | Existing seam |
+| Proposed work | Decision |
 | --- | --- |
-| Affected workspace calculation | Turborepo `turbo ls --affected --output=json` |
-| Comparison refs | `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` with full checkout history |
-| Required-job scope logic | new small `.github/scripts/ci-affected-scope.sh`; no existing equivalent |
-| Web/native workflow path filtering | existing `desktop-e2e-test.yml` `paths` pattern |
-| Unit coverage command | existing root `bun run test:coverage`; do not split |
-| GraphQL/codegen drift | existing `lint-and-format.yml` sequence |
-| Packaging reduction | existing `desktop-build-deploy.yml` event/PR branches |
-| CodeQL languages | existing static four-language matrix, narrowed only on PR |
-| Coverage streams | existing three Codecov upload steps, now named by flags |
-| Workflow documentation | existing `CLAUDE.md` CI guidance |
+| Affected workspace calculation | Reuse Turborepo `turbo ls --affected --output=json` |
+| Root config invalidation | Extend existing `turbo.json` `globalDependencies` with `tsconfig.base.json` |
+| Non-required workflow filtering | Reuse native `pull_request.paths`; desktop E2E already demonstrates the pattern |
+| Root unit coverage | Reuse `bun run test:coverage`; do not split |
+| Required-job routing | New only if PR B proceeds: one small `.github/scripts/ci-affected-scope.sh` |
+| Scope regression coverage | New only with PR B: `.github/scripts/ci-affected-scope.test.sh` plus small fixtures |
+| Packaging reduction | Reuse existing release triggers; delete ordinary PR packaging branches |
+| CodeQL | PR A uses native `paths`; PR C adds language selection using the proven scope seam |
+| Coverage aggregation | Extend existing three Codecov uploads with flags/carryforward |
 
 ## Goals
 
-- Keep required check names deterministic.
-- Make scope-detection failure conservative: run more CI, never silently less.
-- Skip the full unit-coverage stack on docs-only and E2E-only changes.
-- Keep repo-wide lint/format coverage on every ready PR.
-- Skip generated/schema/E2E-typecheck lint work when no workspace can be affected.
-- Skip web E2E for unrelated PRs.
-- Skip Rust CI for changes that cannot affect Rust/native generated contracts.
-- Preserve common/shared changes as triggers for desktop E2E and web validation where they matter.
-- Stop Windows/macOS packaging on ordinary PRs.
-- Keep CodeQL full on `main`/schedule and language-scoped on PRs.
-- Keep Codecov's 90% project/patch targets while making partial suite execution compatible with coverage aggregation.
-- Document a concrete affected-area matrix.
+- Preserve deterministic required-check behavior.
+- Take the highest-value, lowest-risk CI savings first.
+- Stop Windows/macOS packaging on ordinary PRs while preserving release behavior.
+- Skip unrelated web E2E and Rust CI through native path filters.
+- Keep docs formatting guarded on every ready PR.
+- Eventually make docs-only PRs skip full unit coverage and generated/schema/typecheck work.
+- Keep all detector failures conservative: run more CI rather than silently less.
+- Keep CodeQL full on `main`/schedule and relevant-language-only on PRs.
+- Keep Codecov's 90% policy compatible with intentionally partial suite execution.
 
 ## Non-goals
 
 - No monolithic `ci.yml`.
 - No external classifier service.
-- No handwritten package dependency graph.
-- No remote Turborepo cache.
-- No package-by-package rewrite of root `test:coverage`.
-- No removal of unit, E2E, Rust, CodeQL, schema, codegen, or formatting coverage.
-- No Codecov threshold change.
-- No product/application code changes.
+- No handwritten dependency graph.
+- No remote Turborepo cache project.
+- No package-by-package rewrite of root coverage.
+- No coverage-threshold change.
 - No general release workflow rewrite.
+- No product/application code changes.
 
 ## Chosen architecture
 
-### 1. One small fail-open scope script
+## PR A — low-risk savings first
 
-Create:
+PR A contains no custom changed-file script.
 
-` .github/scripts/ci-affected-scope.sh`
+### 1. Disambiguate Playwright from the required `test` check
 
-The script has three explicit modes:
+In `.github/workflows/e2e-test.yml`, keep job id `test` if desired, but add:
 
-- `unit` -> prints `true` when root unit coverage must run, otherwise `false`;
-- `lint` -> prints `true` when the expensive workspace/generated lint block must run, otherwise `false`;
-- `codeql` -> prints a non-empty JSON array of CodeQL languages for the PR.
+```yaml
+name: playwright
+```
 
-Diagnostics, including the raw affected-package JSON and changed-file list, go to stderr so the machine-readable stdout stays stable.
+Do this before adding PR paths.
 
-The script is intentionally not a generic rules engine. Package and path lists stay literal and close to the workflows they serve.
+Verify on one ready PR that GitHub publishes exactly one GitHub Actions check named `test` from `Run Unit Tests` and one named `playwright` from `Playwright Tests`.
 
-For `unit` and `lint` it:
+### 2. Remove ordinary PR packaging
 
-1. requires `TURBO_SCM_BASE` and `TURBO_SCM_HEAD`;
-2. obtains changed files with `git diff --name-only "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD"`;
-3. runs `bunx turbo ls --affected --output=json` using the same refs;
-4. validates the JSON shape before reading package names;
-5. reads names from `packages.items` and validates the reported package count;
-6. applies the mode's small allowlist/force-full rules.
+Remove the `pull_request` trigger from `.github/workflows/desktop-build-deploy.yml` and delete PR-only unsigned packaging branches.
 
-Any missing ref, Git failure, Turbo failure, malformed/unexpected JSON, or jq failure exits non-zero. Each workflow wrapper converts that failure to the conservative result (`true` or all CodeQL languages).
+Preserve:
 
-`fetch-depth: 0` is the only git-history mechanism. Do not add a second merge-base/fetch scheme.
+- push to `preview`;
+- push to `main`;
+- `v*` tags;
+- `workflow_dispatch`;
+- signed release/deploy behavior.
 
-### 2. Execute the detector before trusting it
+No replacement cross-platform packaging job is added.
 
-The implementation includes recorded Turbo JSON fixtures representing:
-
-- a web workspace affected;
-- no workspace affected;
-- malformed/unexpected output.
-
-Fixture assertions verify the actual jq traversal used by the script. In addition, the script is run against one real local Git base/head pair so the checked-in Turborepo version, Git refs, and JSON parsing are exercised together.
-
-A `packages/dtx-web/**` case must resolve `unit=true` before any YAML gate is considered complete.
-
-### 3. Required `test` keeps one binary coverage gate
-
-`unit-test.yml` keeps job id `test` and stays event-visible for every ready PR.
-
-After checkout (`fetch-depth: 0`) and Bun setup, a scope step calls the shared script.
-
-For pull requests:
-
-- script success controls `run_expensive`;
-- script failure sets `run_expensive=true`.
-
-For pushes to `main`/`master`, `run_expensive=true` without scope reduction.
-
-Only when `run_expensive=true` run:
-
-- dependency installation;
-- SvelteKit/common preparation;
-- root `bun run test:coverage`;
-- TypeScript Codecov upload.
-
-Do not split the root coverage task into per-package test commands.
-
-Force full unit coverage when scope infrastructure or root dependency/config files change, including the unit workflow itself, the shared scope script, `package.json`, `bun.lock`, `turbo.json`, and `codecov.yml`.
-
-### 4. Required `lint-and-format` is two-tier
-
-`lint-and-format.yml` keeps job id `lint-and-format` and remains event-visible.
-
-Always on ready PRs:
-
-- checkout;
-- setup Bun;
-- `bun install --frozen-lockfile`;
-- repository ESLint;
-- repository Prettier check.
-
-Run the workspace/generated block when:
-
-- any workspace package is affected; or
-- root dependency/Turborepo config, lint workflow, or shared scope script changes; or
-- scope detection fails.
-
-The gated block preserves the current ordering:
-
-1. SvelteKit/common build preparation;
-2. common build;
-3. API GraphQL schema generation and tracked-schema drift check;
-4. generated web client verification;
-5. web and desktop E2E typechecks.
-
-This keeps docs formatting guarded without paying schema/codegen/typecheck cost on docs-only PRs.
-
-### 5. Non-required workflows use native path filters
+### 3. Add native path filters to non-required workflows
 
 #### Web E2E
 
-Add PR paths for surfaces that can affect the web stack:
+Run PR Playwright only for web/API/shared/E2E-web inputs and the small root config set that can affect the web test stack.
+
+At minimum:
 
 - `packages/dtx-web/**`
 - `packages/dtx-api/**`
@@ -246,16 +179,17 @@ Add PR paths for surfaces that can affect the web stack:
 - `package.json`
 - `bun.lock`
 - `turbo.json`
+- `tsconfig.base.json`
 
-Keep `main`/`master` push behavior full.
+Keep push-to-main behavior unchanged.
 
 #### Desktop E2E
 
-Keep the existing path-filter model. It already covers renderer/shared/E2E dependencies and should continue to trigger on `packages/common/**` and `packages/ui-components/**`.
+Keep the existing path-filter model and shared package triggers. Add `tsconfig.base.json` because the desktop E2E TypeScript surfaces inherit shared compiler behavior.
 
 #### Tauri Rust CI
 
-Narrow PR paths to actual native/generated-contract inputs:
+Use a narrower PR path list:
 
 - `packages/dtx-desktop/**`
 - `packages/e2e-desktop/**`
@@ -264,71 +198,232 @@ Narrow PR paths to actual native/generated-contract inputs:
 - `bun.lock`
 - `turbo.json`
 
-Do not add `packages/common/**` or `packages/ui-components/**` merely because desktop E2E needs them. Rust CI's generated-type drift files live under desktop/E2E-desktop, and desktop E2E already exercises shared renderer changes.
+Do not add `packages/common/**` or `packages/ui-components/**` solely because desktop E2E needs them. Rust CI's checked generated-contract outputs live under desktop/E2E-desktop; shared renderer behavior is covered by desktop E2E.
 
-Keep `main`/`master` push behavior full.
+### 4. Add CodeQL's cheap PR source filter
 
-### 6. Ordinary PR packaging disappears
+Keep push-to-main and schedule unchanged.
 
-Remove the `pull_request` trigger from `desktop-build-deploy.yml`.
+Under `pull_request.paths`, include only source/workflow paths that can map to one of the four current CodeQL languages. This removes docs-only CodeQL immediately without adding a selector job.
 
-Delete PR-only unsigned build branches and simplify conditions/env setup that existed only for ordinary PR packaging.
+Per-language selection remains for PR C because HPA-613 explicitly requires it.
+
+### 5. Add Codecov flags and carryforward
+
+Define three streams:
+
+- `typescript`
+- `tauri-rust`
+- `desktop-e2e-rust`
+
+Set `carryforward: true` for each and pass the matching `flags:` value from each existing upload action.
 
 Keep:
 
-- push to `preview`;
-- push to `main`;
-- `v*` tags;
-- `workflow_dispatch`;
-- signed release behavior and deployment semantics.
+```yaml
+fail_ci_if_error: false
+```
 
-No replacement packaging-validation workflow is added in HPA-613.
+This is an explicit HPA-613 requirement. Do not present Codecov as a branch-protection gate; it is coverage reporting/policy hygiene.
 
-### 7. CodeQL stays language-scoped on PRs
+### 6. Add the real shared-config invalidation input
 
-HPA-613 explicitly requires PR analysis to be limited to source/workflow changes relevant to each language, so the language selector remains in scope rather than being deferred.
+Add only `tsconfig.base.json` to `turbo.json` `globalDependencies` in this slice.
 
-Reduce its machinery in two ways:
+This makes a shared TypeScript compiler change affect the workspace graph used later by PR B and also improves normal Turborepo cache invalidation.
 
-1. add a PR-level `paths` filter so docs-only PRs never start CodeQL;
-2. use the same tested scope script's `codeql` mode rather than another inline Bash classifier.
+## Measurement checkpoint
 
-PR language mapping:
+After PR A lands, inspect several representative ready PRs and GitHub Actions usage:
 
-- `actions` for `.github/workflows/**`;
-- `javascript-typescript` for JS/TS/Svelte source/config files;
-- `python` for `scripts/**/*.py`;
-- `rust` for `packages/dtx-desktop/src-tauri/**/*.rs`.
+- docs-only;
+- web-only;
+- desktop renderer-only;
+- desktop Rust;
+- shared/common.
 
-Unexpected/no mapping after a triggered PR is conservative: analyze all four languages.
+Record whether the expensive packaging/E2E reductions already produce the expected cost improvement.
 
-Pushes to `main` and scheduled scans always analyze all four languages.
+This checkpoint can justify revising HPA-613, but it does not by itself remove PR B/C from the current ticket. As currently written, HPA-613 still requires cheap required-job behavior for docs-only PRs and relevant-language PR CodeQL.
 
-### 8. Codecov uses three carryforward flags
+## PR B — tested required-check gates
 
-Keep current project and patch targets at 90% with `threshold: 0%` and current status behavior.
+Only after the low-risk savings are established, add one new detector seam for the two required workflows.
 
-Name the existing upload streams:
+### Script contract
 
-- root TypeScript/Vitest coverage -> `typescript`;
-- Tauri Rust unit coverage -> `tauri-rust`;
-- desktop E2E Rust coverage -> `desktop-e2e-rust`.
+Create `.github/scripts/ci-affected-scope.sh` with only two initial modes:
 
-Set `carryforward: true` for all three flags in `codecov.yml` and pass the matching flag from each upload action.
+- `unit` -> stdout exactly `true` or `false`;
+- `lint` -> stdout exactly `true` or `false`.
 
-This lets Codecov reuse the previous flag's coverage when that suite is intentionally skipped on the current commit, instead of treating affected CI as an incomplete coverage model.
+Diagnostics go to stderr.
 
-Set `fail_ci_if_error: false` on all three uploads. This only makes uploader/service transport failures informational; coverage policy remains enforced by `codecov.yml`.
+The script:
 
-The implementation PR changes all three upload/workflow surfaces plus `codecov.yml`, so it should run all three streams and establish a flagged baseline before later PRs rely on carryforward.
+1. requires `TURBO_SCM_BASE` and `TURBO_SCM_HEAD`;
+2. gets changed files with merge-base semantics:
 
-### 9. Documentation records the matrix, not implementation history
+```bash
+git diff --name-only --merge-base "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD"
+```
 
-Update `CLAUDE.md` with the resulting ready-PR matrix and fail-open rule.
+3. runs the exact Turborepo version the implementation is written against, initially:
 
-Document behavior such as:
+```bash
+bunx turbo@2.10.9 ls --affected --output=json
+```
 
-| Change | Required unit coverage | Repo lint/format | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
+4. validates the live JSON shape before consuming `packages.items`;
+5. validates the package count;
+6. applies only the small unit/lint decisions.
+
+Any missing ref, Git failure, Turbo failure, unexpected JSON, jq failure, or wrapper failure exits non-zero. Workflow wrappers convert any error to `run_expensive=true`.
+
+`--output=json` is treated as an experimental contract: pin it, test it, and fail open.
+
+When the repo intentionally upgrades Turborepo, update the explicit script version and recorded fixture/test in the same change.
+
+### Checked-in regression test
+
+Create `.github/scripts/ci-affected-scope.test.sh` plus minimal recorded fixtures.
+
+The test covers at least:
+
+- web workspace affected -> `unit=true`;
+- empty affected set -> `unit=false`, `lint=false`;
+- shared `tsconfig.base.json` change -> affected/full behavior;
+- E2E-only change -> unit false, lint true where E2E typechecking is required;
+- malformed JSON -> non-zero;
+- Git/detector failure -> wrapper chooses full validation;
+- merge-base changed-file behavior.
+
+Run this test from the always-on tier of `lint-and-format` so a parser regression cannot silently turn into a green skipped required check.
+
+Also execute the script once against a real base/head pair before accepting the implementation PR. `actionlint` alone is not proof of detector correctness.
+
+### Required unit job
+
+Keep job id `test` and no event-level paths.
+
+For PRs, call the script and gate only the existing expensive unit stack. On detection failure, run full coverage.
+
+Pushes to `main`/`master` keep full behavior.
+
+Do not split `bun run test:coverage`.
+
+### Required lint job
+
+Keep job id `lint-and-format` and no event-level paths.
+
+Always run:
+
+- dependency installation;
+- scope regression test;
+- ESLint;
+- Prettier.
+
+Gate only the SvelteKit/common/schema/codegen/E2E-typecheck block. On detection failure, run that block.
+
+## PR C — relevant-language PR CodeQL
+
+After PR B proves the shared Git/path seam, add `codeql` mode rather than a second selector implementation.
+
+### Mapping
+
+- `.github/workflows/**` -> `actions`
+- JS/TS/Svelte source/config -> `javascript-typescript`
+- `scripts/**/*.py` -> `python`
+- `packages/dtx-desktop/src-tauri/**/*.rs` -> `rust`
+
+Unexpected or empty mapping after the workflow has triggered -> all four languages.
+
+### Preserve build mode
+
+The current CodeQL matrix sets `build-mode: none` for every language. A flat language array must not accidentally drop that behavior.
+
+Keep the selector output simple and hardcode:
+
+```yaml
+with:
+  languages: ${{ matrix.language }}
+  build-mode: none
+```
+
+Do not rely on `matrix.build-mode` after replacing the current `matrix.include` shape.
+
+Pushes to `main` and scheduled runs always analyze all four languages.
+
+## Error handling
+
+Scope reduction is an optimization, never a correctness dependency.
+
+PR B/C detector failures are conservative:
+
+- missing refs -> full relevant validation;
+- merge-base/diff failure -> full relevant validation;
+- Turbo failure -> full unit/lint validation;
+- malformed/unexpected Turbo JSON -> full unit/lint validation;
+- jq failure -> full relevant validation;
+- CodeQL mapping failure -> all four languages.
+
+Codecov is intentionally different: HPA-613 requires upload transport failure to be informational. That can temporarily leave carried-forward coverage visible for a commit; the test suite result remains authoritative for CI success.
+
+## Risks and accepted tradeoffs
+
+### Required `test` context ambiguity
+
+**Risk:** Playwright and unit jobs currently publish the same `test` check name; path-filtering Playwright first could make branch protection ambiguous.
+
+**Mitigation:** rename the Playwright check in PR A before any filter and verify the resulting check runs on a ready PR.
+
+### Cross-platform packaging regressions move later
+
+**Risk:** removing ordinary PR packaging means a Windows/macOS packaging failure may first appear after merge on the continuous `main` release channel.
+
+**Accepted tradeoff:** this repository favors CI cost and iteration speed. For a risky desktop packaging change, use the retained `workflow_dispatch` path before merge.
+
+### Experimental Turbo JSON dependency
+
+**Risk:** `turbo ls --output=json` is experimental and its schema may change.
+
+**Mitigation:** exact tool version, live recorded fixture, checked-in parser regression test, one real base/head execution, and fail-open wrappers.
+
+### Informational Codecov upload can carry stale data
+
+**Risk:** if an upload itself fails while `carryforward: true` is enabled, Codecov can continue showing an older flag's coverage.
+
+**Accepted tradeoff:** HPA-613 explicitly asks uploader failures not to fail an otherwise green suite. Coverage thresholds remain unchanged, and later successful uploads refresh the flag.
+
+## Verification
+
+### PR A
+
+- `actionlint` every changed workflow.
+- Verify one ready PR publishes `test` from `Run Unit Tests` and `playwright` from `Playwright Tests`.
+- Verify ruleset still requires only `test` and `lint-and-format`.
+- Verify docs-only no longer starts packaging, web E2E, Rust CI, or CodeQL.
+- Verify `preview`, `main`, tag, and manual packaging entry points remain.
+- Verify all three Codecov streams carry the intended flags and retain the 90% targets.
+
+### PR B
+
+- `bash -n` both scope scripts.
+- Run `.github/scripts/ci-affected-scope.test.sh` locally and in always-on lint CI.
+- Run the detector against one real PR base/head.
+- Verify invalid refs and malformed JSON produce full-validation behavior.
+- Verify `test` and `lint-and-format` remain stable required contexts.
+
+### PR C
+
+- `actionlint` CodeQL workflow.
+- Fixture-check each language mapping and mixed-language mapping.
+- Verify Rust PR analysis still uses `build-mode: none`.
+- Verify main/schedule remain all-language scans.
+
+## Resulting ready-PR matrix after all HPA-613 phases
+
+| Change | Unit coverage | ESLint/Prettier | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | docs only | skip | run | skip | skip | skip | skip | skip | skip |
 | `dtx-web` | run | run | run | run | skip | skip | skip | JS/TS |
@@ -337,81 +432,12 @@ Document behavior such as:
 | `ui-components` | run | run | run | run | run | skip | skip | JS/TS |
 | desktop renderer | run | run | run | skip | run | run | skip | JS/TS |
 | desktop Rust | run | run | run | skip | run | run | skip | Rust |
-| web E2E only | skip | run | run | run | skip | skip | skip | JS/TS if source changes |
-| desktop E2E only | skip | run | run | skip | run | run | skip | JS/TS if source changes |
-| shared/root CI config | conservative full where relevant | run | run | according to path filters | according to path filters | according to path filters | no PR packaging | mapped/all on failure |
+| web E2E only | skip | run | run | run | skip | skip | skip | JS/TS when source matches |
+| desktop E2E only | skip | run | run | skip | run | run | skip | JS/TS when source matches |
+| `tsconfig.base.json` | run | run | run | run | run | skip | skip | JS/TS |
 
-## Error handling
+## Decision
 
-Scope reduction is an optimization, never a correctness dependency.
+Ship HPA-613 in risk order rather than implementation-complexity order.
 
-- missing `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` -> full relevant validation;
-- `git diff` failure -> full relevant validation;
-- `turbo ls` failure -> full relevant validation;
-- malformed or unexpected Turbo JSON -> full relevant validation;
-- jq failure -> full relevant validation;
-- CodeQL mapping failure -> all four languages;
-- Codecov uploader/service failure -> informational upload failure, not a replacement for coverage policy.
-
-Raw scope inputs/results are logged so a wrong skip can be diagnosed from one workflow run.
-
-## Testing and verification
-
-### Scope script
-
-Before workflow wiring is accepted:
-
-- shell syntax check;
-- recorded web-affected JSON -> `unit=true`;
-- recorded empty-affected JSON -> `unit=false` and `lint=false`;
-- malformed JSON -> wrapper chooses full validation;
-- missing/invalid Git refs -> wrapper chooses full validation;
-- real local base/head pair executes the checked-in Turbo command successfully;
-- raw affected JSON appears in diagnostics.
-
-### Workflow syntax
-
-Run `actionlint` over every changed workflow.
-
-### Required checks
-
-Confirm job ids remain exactly `test` and `lint-and-format` and neither required workflow has event-level PR `paths` filtering.
-
-### Path matrix
-
-Inspect/dry-run the documented cases for docs, web, API, common, UI, desktop renderer, desktop Rust, web E2E, desktop E2E, and root CI configuration.
-
-### Release behavior
-
-Verify `desktop-build-deploy.yml` still has `preview`, `main`, `v*`, and manual entry points, and no ordinary PR trigger.
-
-### Codecov
-
-Verify all three uploads use their configured flags, all three flags have carryforward enabled, and 90% project/patch targets are unchanged.
-
-### Final implementation-PR gate
-
-Before treating HPA-613 implementation as complete, a PR changing `packages/dtx-web/**` must demonstrably resolve the detector to unit coverage enabled. The expensive-gate logic is not considered proven solely because `actionlint` passes.
-
-## Expected file scope
-
-New:
-
-- `.github/scripts/ci-affected-scope.sh`
-- `.github/scripts/fixtures/turbo-ls-web.json`
-- `.github/scripts/fixtures/turbo-ls-empty.json`
-- `.github/scripts/fixtures/turbo-ls-malformed.json`
-
-Modify:
-
-- `.github/workflows/unit-test.yml`
-- `.github/workflows/lint-and-format.yml`
-- `.github/workflows/e2e-test.yml`
-- `.github/workflows/desktop-e2e-test.yml` only for Codecov flag/transport handling
-- `.github/workflows/tauri-rust-ci.yml`
-- `.github/workflows/desktop-build-deploy.yml`
-- `.github/workflows/codeql.yml`
-- `codecov.yml`
-- `CLAUDE.md`
-
-No application source files are changed.
+The expensive non-required workflows should be reduced first. The required-check detector remains in scope because the ticket explicitly asks docs-only PRs to run only cheap repository checks; it simply should not be the first thing merged. CodeQL language selection remains in scope for the same reason: it is an explicit HPA-613 requirement, but it comes after the shared detector seam is proven.


### PR DESCRIPTION
## Summary

- restructures HPA-613 into **PR A low-risk savings → measure → PR B required-check gates → PR C CodeQL language selection**
- fixes the existing required-check ambiguity first: unit and Playwright currently both publish `test`; the implementation now renames the Playwright check to `playwright` before adding paths
- removes ordinary PR Windows/macOS packaging while preserving `preview`, `main`, release tags, manual dispatch, signing, and deployment behavior
- uses native PR path filters for non-required validation; Tauri Rust stays narrower than desktop E2E
- adds `tsconfig.base.json` to Turborepo global invalidation without forcing unit coverage for ESLint/Prettier-only config changes
- keeps root unit coverage all-or-nothing and keeps install + ESLint + Prettier unconditional in `lint-and-format`
- if PR B proceeds, uses one checked-in fail-open detector with merge-base semantics, exact `turbo@2.10.9`, fixtures, a regression test that runs in the always-on lint tier, and one real base/head proof
- keeps HPA-613's relevant-language PR CodeQL requirement for PR C and explicitly preserves `build-mode: none`
- keeps Codecov's 90% policy, adds three carryforward flags, and retains informational uploader failures because that behavior is explicit in HPA-613
- documents the accepted risk that removing ordinary PR packaging moves first Windows/macOS packaging failure detection later; `workflow_dispatch` remains the pre-merge escape hatch

## Review resolution

Accepted: F1, F2, F3, F7, F8, F9.

Partially accepted:

- **F4:** `tsconfig.base.json` is a real Turbo invalidation hole and is added to `globalDependencies`. ESLint/Prettier config files are not added just to force unit coverage because those checks remain unconditional.
- **F6:** the implementation is reordered so the highest-value/no-custom-script savings land first and are measured. PR B/C are not silently made optional because the current HPA-613 scope still requires cheap docs-only required jobs and relevant-language PR CodeQL; stopping after PR A requires an explicit Linear scope change.

Not accepted:

- **F5:** changing Codecov uploads back to blocking conflicts with HPA-613's explicit requirement to make upload failures informational. The docs now frame Codecov correctly as coverage reporting/policy rather than branch protection and call out the stale-carryforward risk.

## Documents

- `docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md`
- `docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md`

## Scope

Planning-only draft PR. No workflow, script, config, or application implementation changes are included; the branch still changes only the two planning documents.

Linear: https://linear.app/cwchanap/issue/HPA-613/dtxwebci-run-checks-only-for-affected-packages-and-release-paths