### PR TITLE
ci: reduce PR validation by affected area

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,20 @@ on:
   pull_request:
     branches: ['main']
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '**/*.js'
+      - '**/*.cjs'
+      - '**/*.mjs'
+      - '**/*.ts'
+      - '**/*.svelte'
+      - '**/package.json'
+      - 'bun.lock'
+      - 'tsconfig.base.json'
+      - 'scripts/**/*.py'
+      - 'scripts/**/requirements*.txt'
+      - 'packages/dtx-desktop/src-tauri/**'
   schedule:
     - cron: '45 14 * * 4'
 

--- a/.github/workflows/desktop-build-deploy.yml
+++ b/.github/workflows/desktop-build-deploy.yml
@@ -1,9 +1,6 @@
 name: Desktop App Cross-Platform Build and Deploy
 
 on:
-  pull_request:
-    branches: [main, master]
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - preview
@@ -47,7 +44,6 @@ jobs:
     permissions:
       contents: read
     name: Windows Tauri Build
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.head_ref != 'preview')
     runs-on: windows-latest
     # Each platform build targets its own GitHub environment so concurrent
     # build-windows / build-mac runs each get their own "active" deployment
@@ -85,7 +81,6 @@ jobs:
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: packages/dtx-desktop/src-tauri
-          save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile
@@ -94,14 +89,14 @@ jobs:
         run: bun run --filter=@dtx/common build
 
       - name: Configure Google Drive build for preproduction
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/preview'
+        if: github.ref == 'refs/heads/preview'
         shell: bash
         env:
           GOOGLE_DRIVE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_DRIVE_OAUTH_CLIENT_ID_PREPRODUCTION }}
         run: bash packages/dtx-desktop/src-tauri/scripts/validate_google_drive_build_env.sh preproduction
 
       - name: Configure Google Drive build for production
-        if: github.event_name != 'pull_request' && github.ref != 'refs/heads/preview'
+        if: github.ref != 'refs/heads/preview'
         shell: bash
         env:
           GOOGLE_DRIVE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_DRIVE_OAUTH_CLIENT_ID_PRODUCTION }}
@@ -141,8 +136,7 @@ jobs:
           awk -v v="\"$VERSION\"" '/^version = / && !done {print "version = " v; done=1; next} {print}' "$CARGO" > "$tmp" && mv "$tmp" "$CARGO"
           # Re-enable updater artifact generation for this signed release build.
           # The committed tauri.conf.json ships with createUpdaterArtifacts=false
-          # so that PR builds (which deliberately run WITHOUT the signing key)
-          # and local builds without TAURI_SIGNING_PRIVATE_KEY don't hard-fail:
+          # so local builds without TAURI_SIGNING_PRIVATE_KEY don't hard-fail:
           # Tauri errors out whenever an updater-enabled target (nsis) is built
           # with a configured pubkey but no private key. Only signed release
           # builds (tag / workflow_dispatch / push to main) flip it back on,
@@ -152,20 +146,7 @@ jobs:
           jq --tab '.bundle.createUpdaterArtifacts = true' "$CONF" > "$tmp" && mv "$tmp" "$CONF"
           echo "Baked release version $VERSION into tauri.conf.json and Cargo.toml"
 
-      # PR builds run unsigned: the updater signing key must never be exposed
-      # to PR-controlled build scripts (beforeBuildCommand runs PR-controlled
-      # Vite/Cargo code that could exfiltrate it). A leaked signing key lets an
-      # attacker ship trusted updater bundles to every installed desktop client.
-      # With createUpdaterArtifacts=false in the committed config, PR builds skip
-      # signing entirely and succeed without the private key.
-      - name: Build Tauri App for Windows (PR, unsigned)
-        if: github.event_name == 'pull_request'
-        run: bun run --filter=dtx-desktop tauri build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build Tauri App for Windows (release, signed)
-        if: github.event_name != 'pull_request'
         run: bun run --filter=dtx-desktop tauri build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -196,7 +177,6 @@ jobs:
     permissions:
       contents: read
     name: macOS Tauri Build
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && github.head_ref != 'preview')
     runs-on: macos-latest
     # See build-windows for the rationale on per-platform environments.
     environment: Desktop-macOS
@@ -225,7 +205,6 @@ jobs:
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: packages/dtx-desktop/src-tauri
-          save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile
@@ -234,14 +213,14 @@ jobs:
         run: bun run --filter=@dtx/common build
 
       - name: Configure Google Drive build for preproduction
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/preview'
+        if: github.ref == 'refs/heads/preview'
         shell: bash
         env:
           GOOGLE_DRIVE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_DRIVE_OAUTH_CLIENT_ID_PREPRODUCTION }}
         run: bash packages/dtx-desktop/src-tauri/scripts/validate_google_drive_build_env.sh preproduction
 
       - name: Configure Google Drive build for production
-        if: github.event_name != 'pull_request' && github.ref != 'refs/heads/preview'
+        if: github.ref != 'refs/heads/preview'
         shell: bash
         env:
           GOOGLE_DRIVE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_DRIVE_OAUTH_CLIENT_ID_PRODUCTION }}
@@ -275,20 +254,13 @@ jobs:
           awk -v v="\"$VERSION\"" '/^version = / && !done {print "version = " v; done=1; next} {print}' "$CARGO" > "$tmp" && mv "$tmp" "$CARGO"
           # Re-enable updater artifact generation for this signed release build.
           # See the Windows job for the full rationale: the committed config
-          # ships createUpdaterArtifacts=false so unsigned PR/local builds don't
-          # hard-fail on the missing TAURI_SIGNING_PRIVATE_KEY.
+          # ships createUpdaterArtifacts=false so local builds don't hard-fail
+          # on the missing TAURI_SIGNING_PRIVATE_KEY.
           tmp=$(mktemp)
           jq --tab '.bundle.createUpdaterArtifacts = true' "$CONF" > "$tmp" && mv "$tmp" "$CONF"
           echo "Baked release version $VERSION into tauri.conf.json and Cargo.toml"
 
-      - name: Build Tauri App for macOS (PR, unsigned)
-        if: github.event_name == 'pull_request'
-        run: bun run --filter=dtx-desktop tauri build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build Tauri App for macOS (release, signed)
-        if: github.event_name != 'pull_request'
         run: bun run --filter=dtx-desktop tauri build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/desktop-e2e-test.yml
+++ b/.github/workflows/desktop-e2e-test.yml
@@ -135,7 +135,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/dtx-desktop/src-tauri/e2e-lcov.info
-          fail_ci_if_error: true
+          flags: desktop-e2e-rust
+          fail_ci_if_error: false
 
       - name: Upload desktop e2e logs
         if: failure()

--- a/.github/workflows/desktop-e2e-test.yml
+++ b/.github/workflows/desktop-e2e-test.yml
@@ -14,6 +14,7 @@ on:
       - 'package.json'
       - 'bun.lock'
       - 'turbo.json'
+      - 'tsconfig.base.json'
   pull_request:
     branches:
       - main
@@ -28,6 +29,7 @@ on:
       - 'package.json'
       - 'bun.lock'
       - 'turbo.json'
+      - 'tsconfig.base.json'
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   test:
+    name: playwright
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,18 @@ on:
   pull_request:
     branches: [main, master]
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'packages/dtx-web/**'
+      - 'packages/dtx-api/**'
+      - 'packages/common/**'
+      - 'packages/ui-components/**'
+      - 'packages/e2e-web/**'
+      - 'supabase/**'
+      - '.github/workflows/e2e-test.yml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
 
 permissions:
   contents: read

--- a/.github/workflows/tauri-rust-ci.yml
+++ b/.github/workflows/tauri-rust-ci.yml
@@ -202,10 +202,11 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        # Codecov merges this Rust upload with the TypeScript coverage uploaded
-        # by unit-test.yml for the same commit, so overall coverage spans both.
+        # Codecov reports this named Rust stream for coverage policy and carries
+        # it forward when this workflow is skipped; it is not a branch-protection gate.
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/dtx-desktop/src-tauri/lcov.info
-          fail_ci_if_error: true
+          flags: tauri-rust
+          fail_ci_if_error: false

--- a/.github/workflows/tauri-rust-ci.yml
+++ b/.github/workflows/tauri-rust-ci.yml
@@ -7,6 +7,13 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'packages/dtx-desktop/**'
+      - 'packages/e2e-desktop/**'
+      - '.github/workflows/tauri-rust-ci.yml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'turbo.json'
 
 # Minimal permissions: this workflow only builds, lints, and tests — it never
 # pushes commits, creates releases, or deploys. Reduces blast radius if the

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,4 +41,5 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          flags: typescript
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+# Codecov provides coverage reporting and policy statuses; it is not a
+# branch-protection gate.
 coverage:
   status:
     project:
@@ -12,3 +14,12 @@ coverage:
         threshold: 0%
         informational: false
         if_not_found: failure
+
+flag_management:
+  individual_flags:
+    - name: typescript
+      carryforward: true
+    - name: tauri-rust
+      carryforward: true
+    - name: desktop-e2e-rust
+      carryforward: true

--- a/turbo.json
+++ b/turbo.json
@@ -57,6 +57,7 @@
 	"globalDependencies": [
 		"package.json",
 		"turbo.json",
+		"tsconfig.base.json",
 		".env",
 		".env.local",
 		".env.production",


### PR DESCRIPTION
## Summary

Implements HPA-613 PR A, the low-risk CI-cost reductions before affected-package gating:

- give the Playwright job a unique `playwright` check name;
- stop packaging desktop apps on ordinary pull requests while preserving release triggers;
- scope non-required web E2E, desktop E2E, Rust, and CodeQL pull-request runs by affected paths;
- include `tsconfig.base.json` in Turbo's global cache invalidation;
- configure independent Codecov flags with carryforward, while keeping coverage uploads informational.

## Why

This reduces avoidable CI work without changing the required `test` and `lint-and-format` check contracts. The ready PR provides the first live Actions evidence required by HPA-613 task A7 before proceeding to required-check and CodeQL selector work.

## Validation

- Per-slice `actionlint` and targeted configuration assertions passed during implementation.
- Post-rebase: `actionlint` across all changed workflows and `git diff --check main...HEAD` passed.
- GitHub MCP reconstructed all six reviewed commits; each remote tree hash matched its reviewed local tree exactly.

## Follow-up

Collect PR-A Actions evidence for the affected-path scenarios, then decide whether HPA-613 PR B and PR C remain required.