### PR TITLE
test: measure desktop-renderer CI selection

### DIFF
--- a/packages/dtx-desktop/src/.hpa-613-ci-measurement
+++ b/packages/dtx-desktop/src/.hpa-613-ci-measurement
@@ -1,0 +1,1 @@
+Temporary HPA-613 CI measurement fixture. Do not merge.


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture. This PR changes only a desktop renderer marker and must not be merged.