### PR TITLE
test: measure web-only CI selection

### DIFF
--- a/packages/dtx-web/.hpa-613-ci-measurement
+++ b/packages/dtx-web/.hpa-613-ci-measurement
@@ -1,0 +1,1 @@
+Temporary HPA-613 CI measurement fixture. Do not merge.


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture. This PR changes only a web-package marker and must not be merged.