### PR TITLE
test: measure docs-only CI selection

### DIFF
--- a/docs/.hpa-613-ci-measurement
+++ b/docs/.hpa-613-ci-measurement
@@ -1,0 +1,1 @@
+Temporary HPA-613 CI measurement fixture. Do not merge.


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture. This PR changes only a documentation marker and must not be merged.