### PR TITLE
test: measure shared-common CI selection

### DIFF
--- a/packages/common/.hpa-613-ci-measurement
+++ b/packages/common/.hpa-613-ci-measurement
@@ -1,0 +1,1 @@
+Temporary HPA-613 CI measurement fixture. Do not merge.


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture. This PR changes only a shared-package marker and must not be merged.