### PR TITLE
test: measure web-only CI selection on main

### DIFF
--- a/packages/dtx-web/src/lib/hpa-613-ci-measurement.ts
+++ b/packages/dtx-web/src/lib/hpa-613-ci-measurement.ts
@@ -1,0 +1,2 @@
+// Temporary HPA-613 CI measurement fixture. Do not merge.
+export {};


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture against main. Web TypeScript marker only; do not merge.