### PR TITLE
test: measure desktop-renderer CI selection on main

### DIFF
--- a/packages/dtx-desktop/src/lib/hpa-613-ci-measurement.ts
+++ b/packages/dtx-desktop/src/lib/hpa-613-ci-measurement.ts
@@ -1,0 +1,2 @@
+// Temporary HPA-613 CI measurement fixture. Do not merge.
+export {};


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture against main. Desktop renderer TypeScript marker only; do not merge.