### PR TITLE
test: measure desktop-Rust CI selection on main

### DIFF
--- a/packages/dtx-desktop/src-tauri/src/hpa_613_ci_measurement.rs
+++ b/packages/dtx-desktop/src-tauri/src/hpa_613_ci_measurement.rs
@@ -1,0 +1,1 @@
+// Temporary HPA-613 CI measurement fixture. Do not merge.


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture against main. Desktop Rust marker only; do not merge.