### PR TITLE
test: measure shared-common CI selection on main

### DIFF
--- a/packages/common/src/hpa-613-ci-measurement.ts
+++ b/packages/common/src/hpa-613-ci-measurement.ts
@@ -1,0 +1,2 @@
+// Temporary HPA-613 CI measurement fixture. Do not merge.
+export {};


### PR DESCRIPTION
Temporary HPA-613 A7 measurement fixture against main. Shared TypeScript marker only; do not merge.