### PR TITLE
ci: gate required validation by affected scope

### DIFF
--- a/.github/scripts/ci-affected-scope.sh
+++ b/.github/scripts/ci-affected-scope.sh
@@ -28,6 +28,10 @@ if ! turbo_json="$(bunx turbo@2.10.9 ls --affected --output=json)"; then
 	die 'Turbo affected-package discovery failed'
 fi
 
+if ! turbo_json="$(jq -e -s 'if length == 1 then .[0] else error("expected exactly one JSON document") end' <<<"$turbo_json")"; then
+	die 'Turbo returned more than one JSON document'
+fi
+
 if ! jq -e '
 	.packageManager == "bun" and
 	(.packages | type == "object") and
@@ -53,26 +57,27 @@ if ! affected_items="$(jq -r '.packages.items[] | [.name, .path] | @tsv' <<<"$tu
 fi
 
 unit_affected=false
-while IFS=$'\t' read -r package_name package_path; do
-	[[ -z "$package_name" && -z "$package_path" ]] && continue
+if [[ "$packages_affected" == true ]]; then
+	while IFS=$'\t' read -r package_name package_path; do
 
-	case "$package_name:$package_path" in
-		'@dtx/common:packages/common' | \
-		'@dtx/ui-components:packages/ui-components' | \
-		'dtx-api:packages/dtx-api' | \
-		'dtx-desktop:packages/dtx-desktop' | \
-		'dtx-web:packages/dtx-web' | \
-		'dtx-e2e-web:packages/e2e-web' | \
-		'dtx-e2e-desktop:packages/e2e-desktop') ;;
-		*) die "Turbo returned an unknown package: $package_name ($package_path)" ;;
-	esac
+		case "$package_name:$package_path" in
+			'@dtx/common:packages/common' | \
+			'@dtx/ui-components:packages/ui-components' | \
+			'dtx-api:packages/dtx-api' | \
+			'dtx-desktop:packages/dtx-desktop' | \
+			'dtx-web:packages/dtx-web' | \
+			'dtx-e2e-web:packages/e2e-web' | \
+			'dtx-e2e-desktop:packages/e2e-desktop') ;;
+			*) die "Turbo returned an unknown package: $package_name ($package_path)" ;;
+		esac
 
-	case "$package_name" in
-		'@dtx/common' | '@dtx/ui-components' | dtx-api | dtx-desktop | dtx-web)
-			unit_affected=true
-			;;
-	esac
-done <<<"$affected_items"
+		case "$package_name" in
+			'@dtx/common' | '@dtx/ui-components' | dtx-api | dtx-desktop | dtx-web)
+				unit_affected=true
+				;;
+		esac
+	done <<<"$affected_items"
+fi
 
 if [[ "$mode" == unit ]]; then
 	printf '%s\n' "$unit_affected"

--- a/.github/scripts/ci-affected-scope.sh
+++ b/.github/scripts/ci-affected-scope.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+die() {
+	echo "ci-affected-scope: $*" >&2
+	exit 1
+}
+
+if [[ "$#" -ne 1 ]]; then
+	die 'usage: ci-affected-scope.sh <unit|lint>'
+fi
+
+mode="$1"
+case "$mode" in
+	unit | lint) ;;
+	*) die "unsupported mode: $mode" ;;
+esac
+
+: "${TURBO_SCM_BASE:?TURBO_SCM_BASE is required}"
+: "${TURBO_SCM_HEAD:?TURBO_SCM_HEAD is required}"
+
+if ! changed_paths="$(git diff --name-only --merge-base "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD")"; then
+	die 'could not determine changed paths'
+fi
+
+if ! turbo_json="$(bunx turbo@2.10.9 ls --affected --output=json)"; then
+	die 'Turbo affected-package discovery failed'
+fi
+
+if ! jq -e '
+	.packageManager == "bun" and
+	(.packages | type == "object") and
+	(.packages.count | (type == "number" and floor == . and . >= 0)) and
+	(.packages.items | type == "array") and
+	(.packages.count == (.packages.items | length)) and
+	all(.packages.items[]; type == "object" and (.name | type == "string") and (.path | type == "string")) and
+	((.packages.items | map(.name) | length) == (.packages.items | map(.name) | unique | length))
+' <<<"$turbo_json" >/dev/null; then
+	die 'Turbo returned an unexpected JSON shape'
+fi
+
+if ! packages_affected="$(jq -er 'if .packages.count > 0 then "true" else "false" end' <<<"$turbo_json")"; then
+	die 'could not read Turbo affected-package count'
+fi
+
+if [[ -z "$changed_paths" && "$packages_affected" == true ]]; then
+	die 'Turbo reported affected packages without changed paths'
+fi
+
+if ! affected_items="$(jq -r '.packages.items[] | [.name, .path] | @tsv' <<<"$turbo_json")"; then
+	die 'could not read Turbo affected packages'
+fi
+
+unit_affected=false
+while IFS=$'\t' read -r package_name package_path; do
+	[[ -z "$package_name" && -z "$package_path" ]] && continue
+
+	case "$package_name:$package_path" in
+		'@dtx/common:packages/common' | \
+		'@dtx/ui-components:packages/ui-components' | \
+		'dtx-api:packages/dtx-api' | \
+		'dtx-desktop:packages/dtx-desktop' | \
+		'dtx-web:packages/dtx-web' | \
+		'dtx-e2e-web:packages/e2e-web' | \
+		'dtx-e2e-desktop:packages/e2e-desktop') ;;
+		*) die "Turbo returned an unknown package: $package_name ($package_path)" ;;
+	esac
+
+	case "$package_name" in
+		'@dtx/common' | '@dtx/ui-components' | dtx-api | dtx-desktop | dtx-web)
+			unit_affected=true
+			;;
+	esac
+done <<<"$affected_items"
+
+if [[ "$mode" == unit ]]; then
+	printf '%s\n' "$unit_affected"
+	else
+	printf '%s\n' "$packages_affected"
+fi

--- a/.github/scripts/ci-affected-scope.test.sh
+++ b/.github/scripts/ci-affected-scope.test.sh
@@ -177,6 +177,22 @@ if (cd "$unknown_repo" && PATH="$unknown_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REA
 fi
 echo 'PASS: unknown package fails closed'
 
+empty_identity_repo="$TEST_ROOT/empty-package-identity"
+create_repo "$empty_identity_repo" packages/dtx-web/src/change.ts web
+printf '%s\n' '{"packageManager":"bun","packages":{"count":1,"items":[{"name":"","path":""}]}}' >"$TEST_ROOT/empty-package-identity.json"
+if (cd "$empty_identity_repo" && PATH="$empty_identity_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$TEST_ROOT/empty-package-identity.json" TURBO_SCM_BASE=main TURBO_SCM_HEAD=feature "$DETECTOR" unit >/dev/null 2>"$empty_identity_repo/stderr.log"); then
+	fail 'empty package identity unexpectedly passed'
+fi
+echo 'PASS: empty package identity fails closed'
+
+multi_document_repo="$TEST_ROOT/multi-document-json"
+create_repo "$multi_document_repo" packages/dtx-web/src/change.ts web
+printf '%s\n%s\n' '{"packageManager":"bun","packages":{"count":0,"items":[]}}' '{"packageManager":"bun","packages":{"count":1,"items":[{"name":"dtx-web","path":"packages/dtx-web"}]}}' >"$TEST_ROOT/multi-document-json.json"
+if (cd "$multi_document_repo" && PATH="$multi_document_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$TEST_ROOT/multi-document-json.json" TURBO_SCM_BASE=main TURBO_SCM_HEAD=feature "$DETECTOR" unit >/dev/null 2>"$multi_document_repo/stderr.log"); then
+	fail 'multiple JSON documents unexpectedly passed'
+fi
+echo 'PASS: multiple JSON documents fail'
+
 invalid_refs_repo="$TEST_ROOT/invalid-refs"
 create_repo "$invalid_refs_repo" packages/dtx-web/src/change.ts web
 if run_detector "$invalid_refs_repo" unit turbo-web.json missing-ref feature >/dev/null; then

--- a/.github/scripts/ci-affected-scope.test.sh
+++ b/.github/scripts/ci-affected-scope.test.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DETECTOR="$SCRIPT_DIR/ci-affected-scope.sh"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ci-affected-scope.XXXXXX")"
+REAL_GIT="$(command -v git)"
+ORIGINAL_PATH="$PATH"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+assert_equals() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+
+	if [[ "$actual" != "$expected" ]]; then
+		fail "$description (expected '$expected', got '$actual')"
+	fi
+}
+
+create_fake_bunx() {
+	local fake_bunx="$1"
+
+	cat >"$fake_bunx" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 4 || "$1" != "turbo@2.10.9" || "$2" != "ls" || "$3" != "--affected" || "$4" != "--output=json" ]]; then
+	echo "fake bunx received an unexpected command: $*" >&2
+	exit 91
+fi
+
+if [[ "${FAKE_BUNX_FAIL:-false}" == "true" ]]; then
+	echo "fake turbo failed" >&2
+	exit 92
+fi
+
+if [[ -n "${FAKE_BUNX_EXPECTED_CHANGED_PATH:-}" ]]; then
+	actual_changed_paths="$("$REAL_GIT" diff --name-only --merge-base "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD")"
+	if [[ "$actual_changed_paths" != "$FAKE_BUNX_EXPECTED_CHANGED_PATH" ]]; then
+		echo "merge-base changed paths were unexpected: $actual_changed_paths" >&2
+		exit 93
+	fi
+fi
+
+cat "$FAKE_TURBO_FIXTURE"
+EOF
+	chmod +x "$fake_bunx"
+}
+
+create_fake_git() {
+	local fake_git="$1"
+
+	cat >"$fake_git" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ge 1 && "$1" == "diff" ]]; then
+	if [[ "$#" -ne 5 || "$1" != "diff" || "$2" != "--name-only" || "$3" != "--merge-base" || "$4" != "$TURBO_SCM_BASE" || "$5" != "$TURBO_SCM_HEAD" ]]; then
+		echo "detector did not use the required merge-base diff command: $*" >&2
+		exit 94
+	fi
+
+	actual_changed_paths="$("$REAL_GIT" "$@")"
+	if [[ -n "${FAKE_GIT_EXPECTED_CHANGED_PATH:-}" && "$actual_changed_paths" != "$FAKE_GIT_EXPECTED_CHANGED_PATH" ]]; then
+		echo "merge-base changed paths were unexpected: $actual_changed_paths" >&2
+		exit 95
+	fi
+fi
+
+exec "$REAL_GIT" "$@"
+EOF
+	chmod +x "$fake_git"
+}
+
+create_repo() {
+	local repo="$1"
+	local change_path="$2"
+	local change_contents="$3"
+
+	mkdir -p "$(dirname -- "$repo/$change_path")" "$repo/bin"
+	"$REAL_GIT" -C "$repo" init -q
+	"$REAL_GIT" -C "$repo" config user.email ci-affected-scope@example.invalid
+	"$REAL_GIT" -C "$repo" config user.name ci-affected-scope-test
+	printf 'base\n' >"$repo/README.md"
+	"$REAL_GIT" -C "$repo" add README.md
+	"$REAL_GIT" -C "$repo" commit -q -m base
+	"$REAL_GIT" -C "$repo" branch -M main
+	"$REAL_GIT" -C "$repo" switch -q -c feature
+	printf '%s\n' "$change_contents" >"$repo/$change_path"
+	"$REAL_GIT" -C "$repo" add "$change_path"
+	"$REAL_GIT" -C "$repo" commit -q -m change
+
+	create_fake_bunx "$repo/bin/bunx"
+	create_fake_git "$repo/bin/git"
+}
+
+run_detector() {
+	local repo="$1"
+	local mode="$2"
+	local fixture="$3"
+	local base="$4"
+	local head="$5"
+	local stderr_file="$repo/stderr.log"
+
+	(
+		cd "$repo"
+		PATH="$repo/bin:$ORIGINAL_PATH" \
+		REAL_GIT="$REAL_GIT" \
+		FAKE_TURBO_FIXTURE="$FIXTURES_DIR/$fixture" \
+		TURBO_SCM_BASE="$base" \
+		TURBO_SCM_HEAD="$head" \
+		"$DETECTOR" "$mode" 2>"$stderr_file"
+	)
+}
+
+run_expected() {
+	local test_name="$1"
+	local mode="$2"
+	local fixture="$3"
+	local expected="$4"
+	local change_path="$5"
+	local change_contents="$6"
+	local repo="$TEST_ROOT/$test_name"
+
+	create_repo "$repo" "$change_path" "$change_contents"
+	local output
+	output="$(run_detector "$repo" "$mode" "$fixture" main feature)" || fail "$test_name unexpectedly failed: $(<"$repo/stderr.log")"
+	assert_equals "$expected" "$output" "$test_name"
+	echo "PASS: $test_name"
+}
+
+run_expected web-unit unit turbo-web.json true packages/dtx-web/src/change.ts web
+
+run_expected empty-unit unit turbo-empty.json false docs/change.md docs
+run_expected empty-lint lint turbo-empty.json false docs/change.md docs
+
+run_expected e2e-only-unit unit turbo-e2e-web.json false packages/e2e-web/tests/change.ts e2e
+run_expected e2e-only-lint lint turbo-e2e-web.json true packages/e2e-web/tests/change.ts e2e
+
+run_expected tsconfig-global-invalidation unit turbo-tsconfig.json true tsconfig.base.json tsconfig
+run_expected tsconfig-global-invalidation-lint lint turbo-tsconfig.json true tsconfig.base.json tsconfig
+
+malformed_repo="$TEST_ROOT/malformed-json"
+create_repo "$malformed_repo" packages/dtx-web/src/change.ts web
+printf '{ malformed json\n' >"$TEST_ROOT/malformed-json.json"
+if (cd "$malformed_repo" && PATH="$malformed_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$TEST_ROOT/malformed-json.json" TURBO_SCM_BASE=main TURBO_SCM_HEAD=feature "$DETECTOR" unit >/dev/null 2>"$malformed_repo/stderr.log"); then
+	fail 'malformed JSON unexpectedly passed'
+fi
+echo 'PASS: malformed JSON fails'
+
+turbo_failure_repo="$TEST_ROOT/turbo-failure"
+create_repo "$turbo_failure_repo" packages/dtx-web/src/change.ts web
+if (cd "$turbo_failure_repo" && PATH="$turbo_failure_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$FIXTURES_DIR/turbo-web.json" FAKE_BUNX_FAIL=true TURBO_SCM_BASE=main TURBO_SCM_HEAD=feature "$DETECTOR" unit >/dev/null 2>"$turbo_failure_repo/stderr.log"); then
+	fail 'Turbo failure unexpectedly passed'
+fi
+echo 'PASS: Turbo failure fails'
+
+unknown_repo="$TEST_ROOT/unknown-package"
+create_repo "$unknown_repo" packages/unknown/src/change.ts unknown
+printf '%s\n' '{"packageManager":"bun","packages":{"count":1,"items":[{"name":"future-package","path":"packages/unknown"}]}}' >"$TEST_ROOT/unknown-package.json"
+if (cd "$unknown_repo" && PATH="$unknown_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$TEST_ROOT/unknown-package.json" TURBO_SCM_BASE=main TURBO_SCM_HEAD=feature "$DETECTOR" unit >/dev/null 2>"$unknown_repo/stderr.log"); then
+	fail 'unknown package unexpectedly passed'
+fi
+echo 'PASS: unknown package fails closed'
+
+invalid_refs_repo="$TEST_ROOT/invalid-refs"
+create_repo "$invalid_refs_repo" packages/dtx-web/src/change.ts web
+if run_detector "$invalid_refs_repo" unit turbo-web.json missing-ref feature >/dev/null; then
+	fail 'invalid refs unexpectedly passed'
+fi
+echo 'PASS: invalid refs fail'
+
+merge_base_repo="$TEST_ROOT/merge-base"
+create_repo "$merge_base_repo" packages/dtx-web/src/change.ts web
+"$REAL_GIT" -C "$merge_base_repo" switch -q main
+mkdir -p "$merge_base_repo/packages/dtx-api/src"
+printf 'base-only\n' >"$merge_base_repo/packages/dtx-api/src/base-only.ts"
+"$REAL_GIT" -C "$merge_base_repo" add packages/dtx-api/src/base-only.ts
+"$REAL_GIT" -C "$merge_base_repo" commit -q -m 'unrelated base change'
+"$REAL_GIT" -C "$merge_base_repo" switch -q feature
+expected_feature_path='packages/dtx-web/src/change.ts'
+if output="$(cd "$merge_base_repo" && PATH="$merge_base_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$FIXTURES_DIR/turbo-web.json" FAKE_GIT_EXPECTED_CHANGED_PATH="$expected_feature_path" FAKE_BUNX_EXPECTED_CHANGED_PATH="$expected_feature_path" TURBO_SCM_BASE=main TURBO_SCM_HEAD=feature "$DETECTOR" unit 2>"$merge_base_repo/stderr.log")"; then
+	assert_equals true "$output" 'merge-base comparison'
+else
+	fail "merge-base comparison failed: $(<"$merge_base_repo/stderr.log")"
+fi
+echo 'PASS: merge-base excludes unrelated base commits'
+
+missing_env_repo="$TEST_ROOT/missing-env"
+create_repo "$missing_env_repo" packages/dtx-web/src/change.ts web
+if (cd "$missing_env_repo" && PATH="$missing_env_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$FIXTURES_DIR/turbo-web.json" env -u TURBO_SCM_BASE -u TURBO_SCM_HEAD "$DETECTOR" unit >/dev/null 2>"$missing_env_repo/stderr.log"); then
+	fail 'missing SCM variables unexpectedly passed'
+fi
+echo 'PASS: missing SCM variables fail'
+
+echo 'All affected-scope detector tests passed.'

--- a/.github/scripts/fixtures/turbo-e2e-web.json
+++ b/.github/scripts/fixtures/turbo-e2e-web.json
@@ -1,0 +1,12 @@
+{
+	"packageManager": "bun",
+	"packages": {
+		"count": 1,
+		"items": [
+			{
+				"name": "dtx-e2e-web",
+				"path": "packages/e2e-web"
+			}
+		]
+	}
+}

--- a/.github/scripts/fixtures/turbo-empty.json
+++ b/.github/scripts/fixtures/turbo-empty.json
@@ -1,0 +1,7 @@
+{
+	"packageManager": "bun",
+	"packages": {
+		"count": 0,
+		"items": []
+	}
+}

--- a/.github/scripts/fixtures/turbo-tsconfig.json
+++ b/.github/scripts/fixtures/turbo-tsconfig.json
@@ -1,0 +1,36 @@
+{
+	"packageManager": "bun",
+	"packages": {
+		"count": 7,
+		"items": [
+			{
+				"name": "@dtx/common",
+				"path": "packages/common"
+			},
+			{
+				"name": "@dtx/ui-components",
+				"path": "packages/ui-components"
+			},
+			{
+				"name": "dtx-api",
+				"path": "packages/dtx-api"
+			},
+			{
+				"name": "dtx-desktop",
+				"path": "packages/dtx-desktop"
+			},
+			{
+				"name": "dtx-e2e-desktop",
+				"path": "packages/e2e-desktop"
+			},
+			{
+				"name": "dtx-e2e-web",
+				"path": "packages/e2e-web"
+			},
+			{
+				"name": "dtx-web",
+				"path": "packages/dtx-web"
+			}
+		]
+	}
+}

--- a/.github/scripts/fixtures/turbo-web.json
+++ b/.github/scripts/fixtures/turbo-web.json
@@ -1,0 +1,12 @@
+{
+	"packageManager": "bun",
+	"packages": {
+		"count": 1,
+		"items": [
+			{
+				"name": "dtx-web",
+				"path": "packages/dtx-web"
+			}
+		]
+	}
+}

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -19,34 +19,62 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.9'
 
+      - name: Select lint scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if run_expensive="$(.github/scripts/ci-affected-scope.sh lint)"; then
+            echo "run_expensive=$run_expensive" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Test affected-scope detector
+        run: .github/scripts/ci-affected-scope.test.sh
+
       - name: Generate SvelteKit types
+        if: steps.scope.outputs.run_expensive == 'true'
         run: |
           bun run --filter=dtx-web build -- --mode types-only \
             || (cd packages/dtx-web && bunx svelte-kit sync)
         working-directory: ${{ github.workspace }}
 
       - name: Build packages
+        if: steps.scope.outputs.run_expensive == 'true'
         run: bun run --filter=@dtx/common build
 
       - name: Generate and verify GraphQL schema
+        if: steps.scope.outputs.run_expensive == 'true'
         run: |
           bun run --filter=dtx-api gen-schema
           git ls-files --error-unmatch -- packages/dtx-api/dist/schema.graphql
           git diff --exit-code -- packages/dtx-api/dist/schema.graphql
 
       - name: Verify generated GraphQL client
+        if: steps.scope.outputs.run_expensive == 'true'
         run: bun run --filter=dtx-web lint:codegen
 
       - name: Typecheck e2e packages
+        if: steps.scope.outputs.run_expensive == 'true'
         run: |
           bun run --filter=dtx-e2e-web check
           bun run --filter=dtx-e2e-desktop check

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,25 +19,50 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.9'
 
+      - name: Select unit test scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if run_expensive="$(.github/scripts/ci-affected-scope.sh unit)"; then
+            echo "run_expensive=$run_expensive" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install dependencies
+        if: steps.scope.outputs.run_expensive == 'true'
         run: bun install --frozen-lockfile
 
       - name: Generate SvelteKit types
+        if: steps.scope.outputs.run_expensive == 'true'
         run: cd packages/dtx-web && bunx svelte-kit sync
 
       - name: Build packages
+        if: steps.scope.outputs.run_expensive == 'true'
         run: bun run --filter=@dtx/common build
 
       - name: Run unit tests with coverage
+        if: steps.scope.outputs.run_expensive == 'true'
         run: bun run test:coverage
 
       - name: Upload coverage to Codecov
+        if: steps.scope.outputs.run_expensive == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## HPA-613 — PR B

Implements the reviewed affected-scope detector and wires it inside the required `test` and `lint-and-format` jobs.

- Required contexts remain present; no workflow-level PR path filters were added.
- Detector errors fail open to the existing full validation paths.
- `test` gates only root coverage preparation/coverage/upload.
- `lint-and-format` always runs install, detector regression tests, ESLint, and Prettier; only heavy generation/typecheck steps are gated.

Hosted B4 verification will exercise docs-only and web changes before this PR is considered ready to merge.