### PR TITLE
test: HPA-613 B4 docs-only fixture

### DIFF
--- a/docs/.hpa-613-b4-docs-fixture
+++ b/docs/.hpa-613-b4-docs-fixture
@@ -1,0 +1,1 @@
+Temporary docs-only fixture for HPA-613 CI verification.


### PR DESCRIPTION
Temporary B4 verification fixture. It changes only a docs marker to prove the required workflows stay successful while their expensive blocks skip. Close unmerged after evidence capture.