### PR TITLE
test: HPA-613 B4 web fixture

### DIFF
--- a/packages/dtx-web/src/lib/hpa-613-b4-web-fixture.ts
+++ b/packages/dtx-web/src/lib/hpa-613-b4-web-fixture.ts
@@ -1,0 +1,1 @@
+export const HPA_613_B4_WEB_FIXTURE = true;


### PR DESCRIPTION
Temporary B4 verification fixture. It changes one dtx-web source marker to prove unit and heavy-lint scopes run. Close unmerged after evidence capture.