### PR TITLE
test: HPA-613 B4 invalid-ref fail-open fixture

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -31,7 +31,7 @@ jobs:
         id: scope
         env:
           EVENT_NAME: ${{ github.event_name }}
-          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_BASE: invalid-hpa-613-fixture-ref
           TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           if [[ "$EVENT_NAME" != "pull_request" ]]; then

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,7 @@ jobs:
         id: scope
         env:
           EVENT_NAME: ${{ github.event_name }}
-          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_BASE: invalid-hpa-613-fixture-ref
           TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           if [[ "$EVENT_NAME" != "pull_request" ]]; then


### PR DESCRIPTION
Temporary B4 verification fixture. It forces invalid SCM base refs in the two selector steps to prove errors run full unit and heavy-lint validation. Close unmerged after evidence capture.