### PR TITLE
test: HPA-613 B4 malformed-Turbo fail-open fixture

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -39,6 +39,11 @@ jobs:
             exit 0
           fi
 
+          function bunx() {
+            printf '{malformed JSON\\n'
+          }
+          export -f bunx
+
           if run_expensive="$(.github/scripts/ci-affected-scope.sh lint)"; then
             echo "run_expensive=$run_expensive" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -39,6 +39,11 @@ jobs:
             exit 0
           fi
 
+          function bunx() {
+            printf '{malformed JSON\\n'
+          }
+          export -f bunx
+
           if run_expensive="$(.github/scripts/ci-affected-scope.sh unit)"; then
             echo "run_expensive=$run_expensive" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Temporary B4 verification fixture. It shadows `bunx` only inside the two selector steps with malformed JSON output to prove errors run full unit and heavy-lint validation. Close unmerged after evidence capture.