### PR TITLE
docs: plan Pulumi-managed Cloudflare Zero Trust access

### DIFF
--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -334,9 +334,9 @@ export function normalizeDevicePostureRuleId(rawValue: string): string {
 }
 ```
 
-Hostnames/destinations must remain internal constants, not function parameters.
+Hostnames/destinations must remain internal constants, not parameters.
 
-- [ ] **Step 9: Run the package and CI contract checks**
+- [ ] **Step 9: Run package and CI contract checks**
 
 ```bash
 bun run --filter=@dtx/infrastructure test:coverage
@@ -346,7 +346,7 @@ bun run --filter=@dtx/infrastructure check
 
 Expected: PASS.
 
-- [ ] **Step 10: Commit the independently testable workspace/CI slice**
+- [ ] **Step 10: Commit the workspace/CI slice**
 
 ```bash
 git add package.json bun.lock .github/scripts packages/infrastructure
@@ -371,7 +371,7 @@ git commit -m "feat: scaffold DTXWeb Access infrastructure"
 
 - [ ] **Step 1: Write failing tests for the policy and application shape**
 
-Extend the import in `access.test.ts`:
+Extend the existing import:
 
 ```ts
 import {
@@ -440,7 +440,7 @@ it('rejects a blank Cloudflare account ID', () => {
 bun run --filter=@dtx/infrastructure test
 ```
 
-Expected: FAIL because the Access builders/constants do not exist.
+Expected: FAIL because the builders/constants do not exist.
 
 - [ ] **Step 3: Implement the policy/application builders**
 
@@ -551,9 +551,9 @@ const accessApplication = createAccessApplication({
 export const accessApplicationId = accessApplication.id;
 ```
 
-Stack validation must happen before `createAccessApplication`.
+Stack validation must happen before resource creation.
 
-- [ ] **Step 5: Run focused and package-wide verification**
+- [ ] **Step 5: Run focused/package verification**
 
 ```bash
 bun run --filter=@dtx/infrastructure test:coverage
@@ -563,21 +563,20 @@ bun run --filter=@dtx/infrastructure build
 
 Expected: PASS.
 
-If the selected Cloudflare provider typings differ from the working Perseus shape, verify the current provider API before adapting names; do not redesign the policy semantics.
+If provider typings differ from the working Perseus shape, verify the current provider API before adapting names; do not redesign policy semantics.
 
-- [ ] **Step 6: Run the existing root unit-coverage command**
+- [ ] **Step 6: Prove root coverage includes the new workspace**
 
 ```bash
 bun run test:coverage
 ```
 
-Expected: the existing workspace coverage suite runs and includes `@dtx/infrastructure` rather than silently skipping it.
+Expected: the existing workspace coverage suite runs `@dtx/infrastructure`'s `test:coverage` task rather than silently skipping it.
 
 - [ ] **Step 7: Commit the Access resource slice**
 
 ```bash
 git add packages/infrastructure
-
 git commit -m "feat: define DTXWeb Cloudflare Access apps"
 ```
 
@@ -592,7 +591,7 @@ git commit -m "feat: define DTXWeb Cloudflare Access apps"
 
 **Interfaces:**
 
-- Consumes the implemented `@dtx/infrastructure` package and the already rewritten operator runbook.
+- Consumes the implemented infrastructure package and the already Pulumi-native operator runbook.
 - Produces repository-local setup documentation plus pre-prod/production preview evidence.
 - Produces **no live Cloudflare mutation**.
 
@@ -600,22 +599,22 @@ git commit -m "feat: define DTXWeb Cloudflare Access apps"
 
 Document:
 
-- this package owns only DTXWeb Access applications;
+- package owns only DTXWeb Access applications;
 - Workers/API/storage remain on Wrangler;
 - supported stacks are exactly `pre-prod` and `production`;
 - DTXWeb consumes the Perseus `adminAccessDevicePostureRuleId` as config;
 - `pulumi login --local` defaults to state under `~/.pulumi`;
 - stack config files are local/ignored;
-- Cloudflare token requires `Access: Apps and Policies Write` for application lifecycle;
+- Cloudflare token needs `Access: Apps and Policies Write` for application lifecycle;
 - package scripts are test/build/check only;
-- live commands are taken from the operator runbook and always specify `--stack`;
+- live commands live in the operator runbook and always specify `--stack`;
 - emergency provider-side deletion is documented only in the runbook.
 
-Do not duplicate the full route matrices from the runbook.
+Do not duplicate the route matrices.
 
-- [ ] **Step 2: Validate the runbook against the implemented package**
+- [ ] **Step 2: Validate the runbook against implemented config keys**
 
-Review `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` and confirm its config keys exactly match code:
+Confirm the runbook uses exactly:
 
 ```text
 cloudflareAccountId
@@ -624,11 +623,11 @@ devicePostureRuleId
 accessSessionDuration
 ```
 
-Confirm it remains marked operator-executed and owns every `pulumi up`, `pulumi destroy`, browser/device check, and dashboard emergency fallback.
+Confirm it remains marked operator-executed and owns every `pulumi up`, `pulumi destroy`, browser/device check, and emergency dashboard fallback.
 
-If the implementation changed no interface, make no gratuitous runbook edit.
+If implementation changed no interface, make no gratuitous runbook edit.
 
-- [ ] **Step 3: Run the complete non-live repository verification**
+- [ ] **Step 3: Run complete non-live repository verification**
 
 ```bash
 bun install --frozen-lockfile
@@ -641,9 +640,9 @@ bun run test:coverage
 
 Expected: PASS.
 
-- [ ] **Step 4: Run Pulumi previews only when authenticated local config is available**
+- [ ] **Step 4: Run Pulumi previews only when authenticated config already exists**
 
-If the operator/development environment already has the Cloudflare API token plus DTXWeb stack config, run:
+If the environment already has the Cloudflare API token and DTXWeb stack config:
 
 ```bash
 cd packages/infrastructure
@@ -665,7 +664,7 @@ Expected production preview:
 - no hostname-wide production destination;
 - no API/list/posture/token/Worker/storage resource.
 
-If authenticated config is unavailable, record the previews as `NOT RUN — operator credentials/config required`; do not manufacture config values or ask for secrets in PR comments.
+If authenticated config is unavailable, record `NOT RUN — operator credentials/config required`; do not invent config or request secrets in PR comments.
 
 **Do not run `pulumi up` or `pulumi destroy`.**
 
@@ -682,7 +681,7 @@ If the runbook did not change, commit only the README.
 
 ## Operator Handoff — Not Agent Plan Tasks
 
-After Tasks 1–3 are complete, stop implementation and hand the operator to:
+After Tasks 1–3, stop implementation and hand the operator to:
 
 `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
 
@@ -697,11 +696,11 @@ The operator performs, in order:
 7. stack-specific rollback if required;
 8. dashboard disable/delete only if Pulumi state/backend is unavailable during an emergency.
 
-These are deliberately outside the `For agentic workers` task list.
+These operations are deliberately outside the `For agentic workers` task list.
 
 ## Final Implementation Verification
 
-Before claiming the implementation branch complete, verify:
+Before claiming the implementation branch complete:
 
 ```bash
 git diff --check
@@ -718,6 +717,6 @@ packages/dtx-api/
 packages/dtx-desktop/
 ```
 
-Confirm no committed file contains real operator email, API token, device serial, Access cookie/JWT, Pulumi stack config, or Pulumi state export.
+Confirm no committed file contains a real operator email, API token, device serial, Access cookie/JWT, Pulumi stack config, or state export.
 
-Confirm the Access code contains no `ZeroTrustList`, `ZeroTrustDevicePostureRule`, `ZeroTrustAccessServiceToken`, Service Auth policy, or hostname-configurable production destination.
+Confirm Access code contains no `ZeroTrustList`, `ZeroTrustDevicePostureRule`, `ZeroTrustAccessServiceToken`, Service Auth policy, or hostname-configurable production destination.

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -98,7 +98,7 @@ Before rollout, inspect a known protected Perseus route and identify its actual 
   For the normal Cloudflare Access login page, a suitable value is:
 
   ```bash
-  export ACCESS_REDIRECT_RE='^location: https://[^/]+\\.cloudflareaccess\\.com/cdn-cgi/access/'
+  export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
   ```
 
 - If it returns HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers, leave `ACCESS_REDIRECT_RE` unset. The helpers below recognize that Access-denial signal directly.
@@ -132,13 +132,13 @@ has_access_interception() {
   headers="$1"
 
   if [ -n "${ACCESS_REDIRECT_RE:-}" ] &&
-    printf '%s\\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+    printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
     return 0
   fi
 
-  if printf '%s\\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
-    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
-    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
+  if printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
+    printf '%s\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
+    printf '%s\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
     return 0
   fi
 
@@ -148,7 +148,7 @@ has_access_interception() {
 assert_access_intercepted() {
   url="$1"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\(aud\|domain\):/Ip'
   has_access_interception "$headers" || {
     echo "FAIL: Access did not intercept $url" >&2
     return 1
@@ -158,7 +158,7 @@ assert_access_intercepted() {
 assert_no_access_interception() {
   url="$1"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\(aud\|domain\):/Ip'
   if has_access_interception "$headers"; then
     echo "FAIL: Access unexpectedly intercepted $url" >&2
     return 1

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -2,40 +2,30 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a CI-covered, Access-only Pulumi package that declaratively defines DTXWeb pre-production and production Cloudflare Access applications while reusing the existing Perseus device-posture rule.
+**Goal:** Add an Access-only Pulumi workspace that can safely preview DTXWeb pre-production and production Cloudflare Access applications, reuses the existing Perseus posture rule, and is fully covered by the repository's existing CI gates.
 
-**Architecture:** Add `@dtx/infrastructure` as a normal Drumery workspace, wire it into the existing fail-closed affected-scope and coverage CI, and model the security-sensitive Access shape with pure TypeScript builders plus one Pulumi resource factory. Stack name owns immutable scope: `pre-prod` is hostname-wide and `production` is exactly `/app` plus `/app/*`. This implementation plan stops at tested code, rewritten operator docs, and Pulumi preview evidence; live `pulumi up`, browser/device acceptance, and `pulumi destroy` are operator-only runbook actions.
+**Architecture:** One Pulumi program serves exactly `pre-prod` and `production`. Stack name owns hostname/path scope; config supplies only account ID, secret operator email, existing posture-rule ID, and optional session duration. Agents implement/test/build/preview only; live Cloudflare mutation is operator-executed from the runbook.
 
-**Tech Stack:** Bun workspaces/Turborepo, TypeScript `^5.8.3`, Vitest `^3.1.4`, `@vitest/coverage-v8` `^3.0.0`, `@types/node` `^20.11.25`, Pulumi `@pulumi/pulumi` `^3.144.0`, Pulumi Cloudflare provider `@pulumi/cloudflare` `^6.13.0`, Cloudflare Zero Trust Access, Wrangler for existing Worker/API deployment.
+**Tech Stack:** Bun workspaces/Turborepo, TypeScript `^5.8.3`, Vitest `^3.1.4`, `@vitest/coverage-v8` `^3.0.0`, `@types/node` `^20.11.25`, Pulumi `@pulumi/pulumi` `^3.144.0`, `@pulumi/cloudflare` `^6.13.0`.
 
 **Spec:** `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
 
 ## Global Constraints
 
-- Pulumi owns only DTXWeb Cloudflare Access applications in this slice; Wrangler keeps ownership of Workers, API deployment, D1, R2, service bindings, routes, runtime variables, and application secrets.
-- Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
-- Reuse the existing Perseus device-posture rule by Cloudflare resource ID; do not create a DTXWeb serial list or posture rule.
-- Do not add a Pulumi `StackReference` to Perseus.
-- Supported stack names are exactly `pre-prod` and `production`; any other stack must fail before resource registration.
-- Pre-production scope is code-owned and hostname-wide: `pre-prod.dtx.hapadona.com`.
-- Production scope is code-owned and exactly `dtx.hapadona.com/app` plus `dtx.hapadona.com/app/*`; hostname/path destinations are not Pulumi config.
-- Keep both API hostnames and all intended public production routes outside Access.
-- The Access policy has one `allow` decision with configured email in `includes` and the existing posture-rule ID in `requires`; default session duration is `12h`.
-- Reuse the hardened browser-application flags proven in Perseus: `appLauncherVisible: false`, `allowAuthenticateViaWarp: false`, `enableBindingCookie: true`, `httpOnlyCookieAttribute: true`, `pathCookieAttribute: false`.
-- Do not add service tokens, Service Auth, CLI Access applications, Managed OAuth, Worker-side Access JWT validation, or unattended pre-production E2E credentials.
-- `accessEmail` is Pulumi secret config. `devicePostureRuleId` is plain config pointing to the Perseus-managed rule.
-- Do not commit Pulumi stack config, Pulumi state exports, API tokens, operator email, device serials, Access cookies/JWTs, or sensitive screenshots.
-- Keep deployment operator-executed and local-backend-based; do not add GitHub Actions deployment.
-- Do not add unscoped `pulumi:up`, `pulumi:destroy`, or `pulumi:preview` package scripts.
-- Every operational Pulumi command in docs names its stack explicitly.
-- Run/prove pre-production before production.
-- The checked-in runbook is the single live operator source of truth; do not duplicate its route matrices in this plan.
-- **Do not execute `pulumi up` or `pulumi destroy` from this implementation plan.**
-- If runtime verification requires application/API/desktop code changes, stop and create a separate follow-up.
+- Pulumi owns only DTXWeb Access applications; Wrangler keeps runtime infrastructure.
+- No runtime changes under `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
+- One test-only change under `packages/dtx-web/src/routes/(app)` is allowed to enforce the private-route boundary.
+- Reuse the existing Perseus `devicePostureRuleId`; do not create another posture list/rule and do not add `StackReference`.
+- Supported stacks are exactly `pre-prod` and `production`.
+- Production destinations are code constants: `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` only.
+- Do not add service tokens, Service Auth, CLI Access apps, Managed OAuth, or Worker-side Access JWT validation.
+- Use explicit stack names on every Pulumi preview documented by this plan.
+- Do not run `pulumi up` or `pulumi destroy` from this implementation plan.
+- Production live apply remains blocked until the queued Better Auth/D1 cutover reconciles PR #221's production acceptance procedure.
 
 ---
 
-### Task 1: Add The Infrastructure Workspace And Wire It Into Fail-Closed CI
+### Task 1: Add The CI-Covered Infrastructure Workspace And Route Boundary Guard
 
 **Files:**
 
@@ -44,516 +34,232 @@
 - Modify: `.github/scripts/ci-affected-scope.sh`
 - Modify: `.github/scripts/ci-affected-scope.test.sh`
 - Create: `.github/scripts/fixtures/turbo-infrastructure.json`
+- Modify: `.github/workflows/lint-and-format.yml`
+- Create: `packages/dtx-web/src/routes/(app)/private-route-boundary.test.ts`
 - Create: `packages/infrastructure/.gitignore`
 - Create: `packages/infrastructure/Pulumi.yaml`
 - Create: `packages/infrastructure/package.json`
 - Create: `packages/infrastructure/tsconfig.json`
 - Create: `packages/infrastructure/vitest.config.ts`
-- Create: `packages/infrastructure/src/access.ts`
-- Create: `packages/infrastructure/src/access.test.ts`
 
 **Interfaces:**
 
-- Produces workspace `@dtx/infrastructure` with `build`, `check`, `test`, `test:coverage`, and `test:watch` scripts.
-- Produces CI identity `@dtx/infrastructure:packages/infrastructure` and marks that package as unit-test-affecting.
-- Produces `AccessStackDefinition`, `getAccessStackDefinition(stackName)`, `normalizeAccessEmail(rawValue)`, and `normalizeDevicePostureRuleId(rawValue)` in `src/access.ts`.
+- Produces the `@dtx/infrastructure` workspace with `build`, `check`, `test`, `test:coverage`, and `test:watch` scripts.
+- Produces a CI invariant that every route-bearing file inside SvelteKit's `(app)` route group emits `/app` or `/app/...`.
+- Produces affected-scope support so infrastructure-only changes run the existing unit/coverage gate instead of failing as an unknown package.
 
-- [ ] **Step 1: Add a failing affected-scope fixture/test for infrastructure-only changes**
+- [ ] **Step 1: Scaffold the workspace using DTXWeb's current JS toolchain**
 
-Create `.github/scripts/fixtures/turbo-infrastructure.json`:
+Add `packages/infrastructure` to root workspaces.
 
-```json
-{"packageManager":"bun","packages":{"count":1,"items":[{"name":"@dtx/infrastructure","path":"packages/infrastructure"}]}}
-```
+Create the package with:
 
-Add these cases beside the existing web/e2e cases in `.github/scripts/ci-affected-scope.test.sh`:
+- dependencies: `@pulumi/pulumi ^3.144.0`, `@pulumi/cloudflare ^6.13.0`;
+- dev dependencies: `typescript ^5.8.3`, `vitest ^3.1.4`, `@vitest/coverage-v8 ^3.0.0`, `@types/node ^20.11.25`;
+- scripts: `build`, `check`, `test`, `test:coverage`, `test:watch` only for build/test lifecycle; do **not** add unscoped `pulumi:up`, `pulumi:destroy`, or `pulumi:preview` scripts.
 
-```bash
-run_expected infrastructure-only-unit unit turbo-infrastructure.json true packages/infrastructure/src/change.ts infrastructure
-run_expected infrastructure-only-lint lint turbo-infrastructure.json true packages/infrastructure/src/change.ts infrastructure
-```
+`Pulumi.yaml` must set `main: dist/index.js` and project name `dtxweb-infrastructure`.
 
-- [ ] **Step 2: Run the affected-scope contract and verify it fails closed**
+`tsconfig.json` must extend `../../tsconfig.base.json`, emit `src/**` to `dist/**`, use NodeNext module/moduleResolution, and exclude tests from build output.
 
-Run:
-
-```bash
-.github/scripts/ci-affected-scope.test.sh
-```
-
-Expected: FAIL at the new infrastructure case with the detector reporting an unknown package.
-
-- [ ] **Step 3: Extend the detector allowlist and unit gate**
-
-In `.github/scripts/ci-affected-scope.sh`, extend the package allowlist with:
-
-```bash
-'@dtx/infrastructure:packages/infrastructure' | \
-```
-
-Add `@dtx/infrastructure` to the `unit_affected=true` package-name case:
-
-```bash
-case "$package_name" in
-  '@dtx/common' | '@dtx/ui-components' | '@dtx/infrastructure' | dtx-api | dtx-desktop | dtx-web)
-    unit_affected=true
-    ;;
-esac
-```
-
-Do not weaken the unknown-package fail-closed branch.
-
-- [ ] **Step 4: Re-run the detector tests**
-
-```bash
-.github/scripts/ci-affected-scope.test.sh
-```
-
-Expected: all affected-scope tests pass, including infrastructure `unit => true` and `lint => true`.
-
-- [ ] **Step 5: Add workspace/package scaffolding using Drumery's JS test toolchain**
-
-Add `packages/infrastructure` to root `workspaces`.
-
-Create `packages/infrastructure/package.json`:
-
-```json
-{
-  "name": "@dtx/infrastructure",
-  "version": "0.0.1",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "build": "tsc",
-    "check": "tsc --noEmit",
-    "test": "vitest --run",
-    "test:coverage": "vitest --run --coverage",
-    "test:watch": "vitest"
-  },
-  "dependencies": {
-    "@pulumi/cloudflare": "^6.13.0",
-    "@pulumi/pulumi": "^3.144.0"
-  },
-  "devDependencies": {
-    "@types/node": "^20.11.25",
-    "@vitest/coverage-v8": "^3.0.0",
-    "typescript": "^5.8.3",
-    "vitest": "^3.1.4"
-  }
-}
-```
-
-Do not copy Perseus's Vitest 4, TypeScript 5.9, Node types 22, or unscoped Pulumi scripts.
-
-Create `packages/infrastructure/Pulumi.yaml`:
-
-```yaml
-name: dtxweb-infrastructure
-runtime: nodejs
-description: DTXWeb Cloudflare Access infrastructure managed by Pulumi
-main: dist/index.js
-```
-
-Create `packages/infrastructure/.gitignore`:
-
-```text
-Pulumi.*.yaml
-.pulumi/
-node_modules/
-dist/
-.env
-.env.local
-```
-
-Create `packages/infrastructure/tsconfig.json`:
-
-```json
-{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "resolveJsonModule": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
-}
-```
-
-Create `packages/infrastructure/vitest.config.ts`:
-
-```ts
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    requireAssertions: true
-  }
-});
-```
+`.gitignore` must ignore `Pulumi.*.yaml`, `.pulumi/`, `node_modules/`, `dist/`, `.env`, and `.env.local`. The `.pulumi/` entry is defensive for explicitly project-local backends; normal `pulumi login --local` state defaults under the operator home directory.
 
 Run:
 
 ```bash
 bun install
-```
-
-Expected: `bun.lock` updates and Bun recognizes `@dtx/infrastructure` as a workspace.
-
-- [ ] **Step 6: Write failing tests for immutable stack scope and config validation**
-
-Create `packages/infrastructure/src/access.test.ts`:
-
-```ts
-import { describe, expect, it } from 'vitest';
-import {
-  getAccessStackDefinition,
-  normalizeAccessEmail,
-  normalizeDevicePostureRuleId
-} from './access.js';
-
-describe('getAccessStackDefinition', () => {
-  it('makes pre-prod hostname-wide', () => {
-    expect(getAccessStackDefinition('pre-prod')).toEqual({
-      stackName: 'pre-prod',
-      applicationName: 'DTXWeb Pre-prod',
-      domain: 'pre-prod.dtx.hapadona.com',
-      destinations: [{ type: 'public', uri: 'pre-prod.dtx.hapadona.com' }]
-    });
-  });
-
-  it('makes production exactly /app plus /app/*', () => {
-    expect(getAccessStackDefinition('production')).toEqual({
-      stackName: 'production',
-      applicationName: 'DTXWeb Production App',
-      domain: 'dtx.hapadona.com/app',
-      destinations: [
-        { type: 'public', uri: 'dtx.hapadona.com/app' },
-        { type: 'public', uri: 'dtx.hapadona.com/app/*' }
-      ]
-    });
-  });
-
-  it('rejects unsupported stacks before resource creation', () => {
-    expect(() => getAccessStackDefinition('dev')).toThrow(/Unsupported DTXWeb infrastructure stack/);
-  });
-});
-
-describe('Access config validation', () => {
-  it('normalizes one email address', () => {
-    expect(normalizeAccessEmail(' operator@example.com ')).toBe('operator@example.com');
-  });
-
-  it('rejects malformed and multiple emails', () => {
-    expect(() => normalizeAccessEmail('not-an-email')).toThrow(/single email address/);
-    expect(() => normalizeAccessEmail('a@example.com,b@example.com')).toThrow(/single email address/);
-  });
-
-  it('requires an existing posture-rule ID', () => {
-    expect(normalizeDevicePostureRuleId(' posture-rule-id ')).toBe('posture-rule-id');
-    expect(() => normalizeDevicePostureRuleId('   ')).toThrow(/devicePostureRuleId must not be empty/);
-  });
-});
-```
-
-- [ ] **Step 7: Run the focused unit tests and verify they fail**
-
-```bash
-bun run --filter=@dtx/infrastructure test
-```
-
-Expected: FAIL because `src/access.ts` or its exports do not exist.
-
-- [ ] **Step 8: Implement the immutable stack model and validators**
-
-Create `packages/infrastructure/src/access.ts`:
-
-```ts
-const ACCESS_EMAIL_PATTERN = /^[^\s@,]+@[^\s@,]+\.[^\s@,]+$/;
-
-export interface AccessDestination {
-  type: 'public';
-  uri: string;
-}
-
-export interface AccessStackDefinition {
-  stackName: 'pre-prod' | 'production';
-  applicationName: string;
-  domain: string;
-  destinations: AccessDestination[];
-}
-
-const ACCESS_STACKS: Record<AccessStackDefinition['stackName'], AccessStackDefinition> = {
-  'pre-prod': {
-    stackName: 'pre-prod',
-    applicationName: 'DTXWeb Pre-prod',
-    domain: 'pre-prod.dtx.hapadona.com',
-    destinations: [{ type: 'public', uri: 'pre-prod.dtx.hapadona.com' }]
-  },
-  production: {
-    stackName: 'production',
-    applicationName: 'DTXWeb Production App',
-    domain: 'dtx.hapadona.com/app',
-    destinations: [
-      { type: 'public', uri: 'dtx.hapadona.com/app' },
-      { type: 'public', uri: 'dtx.hapadona.com/app/*' }
-    ]
-  }
-};
-
-export function getAccessStackDefinition(stackName: string): AccessStackDefinition {
-  if (stackName !== 'pre-prod' && stackName !== 'production') {
-    throw new Error(`Unsupported DTXWeb infrastructure stack: ${stackName}`);
-  }
-  return ACCESS_STACKS[stackName];
-}
-
-export function normalizeAccessEmail(rawValue: string): string {
-  const value = rawValue.trim();
-  if (!ACCESS_EMAIL_PATTERN.test(value)) {
-    throw new Error('accessEmail must be a single email address');
-  }
-  return value;
-}
-
-export function normalizeDevicePostureRuleId(rawValue: string): string {
-  const value = rawValue.trim();
-  if (!value) throw new Error('devicePostureRuleId must not be empty');
-  return value;
-}
-```
-
-Hostnames/destinations must remain internal constants, not parameters.
-
-- [ ] **Step 9: Run package and CI contract checks**
-
-```bash
-bun run --filter=@dtx/infrastructure test:coverage
 bun run --filter=@dtx/infrastructure check
+```
+
+Expected: dependency lock updates and TypeScript can load the scaffold package.
+
+- [ ] **Step 2: Add the private-route boundary test**
+
+Create `private-route-boundary.test.ts` that recursively finds route-bearing `+page*` and `+server*` files below `src/routes/(app)`, strips route-group segments such as `(app)`, derives the emitted URL directory, and asserts every derived path satisfies:
+
+```ts
+route === '/app' || route.startsWith('/app/')
+```
+
+The test must fail if a future route such as `(app)/admin/+page.svelte` or `(app)/studio/+server.ts` is added.
+
+Run:
+
+```bash
+bun run --filter=dtx-web test -- 'src/routes/(app)/private-route-boundary.test.ts'
+```
+
+Expected: PASS for the current `(app)/app/**` tree.
+
+- [ ] **Step 3: Extend the fail-closed affected-scope contract with a failing fixture first**
+
+Create `.github/scripts/fixtures/turbo-infrastructure.json` representing exactly:
+
+```json
+{
+  "packageManager": "bun",
+  "packages": {
+    "count": 1,
+    "items": [{ "name": "@dtx/infrastructure", "path": "packages/infrastructure" }]
+  }
+}
+```
+
+Format it with:
+
+```bash
+bunx prettier --write .github/scripts/fixtures/turbo-infrastructure.json
+```
+
+Add this detector case before modifying the allowlist:
+
+```bash
+run_expected infrastructure-unit unit turbo-infrastructure.json true packages/infrastructure/src/access.ts infrastructure
+```
+
+Run `.github/scripts/ci-affected-scope.test.sh` and confirm it fails because `@dtx/infrastructure` is still unknown.
+
+- [ ] **Step 4: Add infrastructure to both detector gates**
+
+In `.github/scripts/ci-affected-scope.sh`:
+
+- add `@dtx/infrastructure:packages/infrastructure` to the known package/path allowlist;
+- add `@dtx/infrastructure` to the package-name case that sets `unit_affected=true`.
+
+Run:
+
+```bash
 .github/scripts/ci-affected-scope.test.sh
 ```
 
-Expected: PASS.
+Expected: all detector tests PASS, including `infrastructure-unit`.
 
-- [ ] **Step 10: Commit the workspace/CI slice**
+- [ ] **Step 5: Add infrastructure TypeScript checking to the existing lint workflow**
+
+In `.github/workflows/lint-and-format.yml`, extend the existing typecheck step with:
 
 ```bash
-git add package.json bun.lock .github/scripts packages/infrastructure
-git commit -m "feat: scaffold DTXWeb Access infrastructure"
+bun run --filter=@dtx/infrastructure check
 ```
+
+Do not create a new workflow.
+
+- [ ] **Step 6: Verify and commit Task 1**
+
+Run:
+
+```bash
+bun run --filter=dtx-web test -- 'src/routes/(app)/private-route-boundary.test.ts'
+bun run --filter=@dtx/infrastructure check
+.github/scripts/ci-affected-scope.test.sh
+bun run lint
+bunx prettier --check .
+git diff --check
+```
+
+Expected: all PASS.
+
+Commit the workspace, CI wiring, fixture, and route-boundary test together.
 
 ---
 
-### Task 2: Build The Perseus-shaped Access Application And Pulumi Entrypoint
+### Task 2: Implement The Access Stack Definitions And Pulumi Application
 
 **Files:**
 
-- Modify: `packages/infrastructure/src/access.ts`
-- Modify: `packages/infrastructure/src/access.test.ts`
+- Create: `packages/infrastructure/src/access.ts`
+- Create: `packages/infrastructure/src/access.test.ts`
 - Create: `packages/infrastructure/src/index.ts`
 
 **Interfaces:**
 
-- Consumes: `AccessStackDefinition`, `getAccessStackDefinition`, `normalizeAccessEmail`, `normalizeDevicePostureRuleId`.
-- Produces: `DEFAULT_ACCESS_SESSION_DURATION`, `ACCESS_APPLICATION_FLAGS`, `buildAccessPolicy(...)`, `buildAccessApplicationArgs(...)`, `createAccessApplication(...)`.
-- `src/index.ts` is the only Pulumi entrypoint.
+- `AccessStackDefinition`
+- `getAccessStackDefinition(stackName: string): AccessStackDefinition`
+- `normalizeAccessEmail(rawValue: string): string`
+- `buildAccessPolicy(accessEmail: pulumi.Input<string>, devicePostureRuleId: pulumi.Input<string>)`
+- `buildAccessApplicationArgs(...)`
+- `createAccessApplication(...)`
 
-- [ ] **Step 1: Write failing tests for the policy and application shape**
+The email normalization path must always use `pulumi.output(accessEmail).apply(normalizeAccessEmail)`; do not maintain separate plain-string and `Output` branches.
 
-Extend the existing import:
+Do not add custom `normalizeAccountId` or `normalizeDevicePostureRuleId` helpers.
 
-```ts
-import {
-  ACCESS_APPLICATION_FLAGS,
-  DEFAULT_ACCESS_SESSION_DURATION,
-  buildAccessApplicationArgs,
-  buildAccessPolicy,
-  getAccessStackDefinition,
-  normalizeAccessEmail,
-  normalizeDevicePostureRuleId
-} from './access.js';
-```
+- [ ] **Step 1: Write the focused stack/policy tests**
 
-Add:
+Cover only:
 
-```ts
-it('builds one email + posture allow policy', () => {
-  expect(buildAccessPolicy(' operator@example.com ', ' posture-rule-id ')).toEqual({
-    name: 'Allow configured operator on trusted device',
-    decision: 'allow',
-    precedence: 1,
-    includes: [{ email: { email: 'operator@example.com' } }],
-    requires: [{ devicePosture: { integrationUid: 'posture-rule-id' } }]
-  });
-});
+1. `pre-prod` => `DTXWeb Pre-prod` at hostname-wide `pre-prod.dtx.hapadona.com`;
+2. `production` => exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`;
+3. no hostname-wide `dtx.hapadona.com` production destination;
+4. unsupported stack throws before resource creation;
+5. email normalization trims one email and rejects malformed/multiple values;
+6. default session duration and browser flags match the spec;
+7. policy uses email `Include` and supplied posture-rule `Require`;
+8. an async test passes `pulumi.output(' operator@example.com ')` through `buildAccessPolicy` and resolves the nested email `Output` to `operator@example.com`.
 
-it('builds production with exact destinations and hardened defaults', () => {
-  const args = buildAccessApplicationArgs({
-    accountId: 'account-id',
-    stackDefinition: getAccessStackDefinition('production'),
-    accessEmail: 'operator@example.com',
-    devicePostureRuleId: 'posture-rule-id'
-  });
+Use a small test helper that awaits a known Pulumi `Output<T>` by resolving inside `apply`; do not introduce Pulumi mocks unless the provider constructor itself forces them.
 
-  expect(args).toMatchObject({
-    accountId: 'account-id',
-    name: 'DTXWeb Production App',
-    type: 'self_hosted',
-    domain: 'dtx.hapadona.com/app',
-    destinations: [
-      { type: 'public', uri: 'dtx.hapadona.com/app' },
-      { type: 'public', uri: 'dtx.hapadona.com/app/*' }
-    ],
-    sessionDuration: DEFAULT_ACCESS_SESSION_DURATION,
-    ...ACCESS_APPLICATION_FLAGS
-  });
-
-  expect(args.destinations).not.toContainEqual({ type: 'public', uri: 'dtx.hapadona.com' });
-});
-
-it('rejects a blank Cloudflare account ID', () => {
-  expect(() =>
-    buildAccessApplicationArgs({
-      accountId: '   ',
-      stackDefinition: getAccessStackDefinition('pre-prod'),
-      accessEmail: 'operator@example.com',
-      devicePostureRuleId: 'posture-rule-id'
-    })
-  ).toThrow(/cloudflareAccountId must not be empty/);
-});
-```
-
-- [ ] **Step 2: Run tests and verify the new expectations fail**
+Run:
 
 ```bash
 bun run --filter=@dtx/infrastructure test
 ```
 
-Expected: FAIL because the builders/constants do not exist.
+Expected: FAIL because `access.ts` does not exist yet.
 
-- [ ] **Step 3: Implement the policy/application builders**
+- [ ] **Step 2: Implement immutable stack definitions and one email-normalization path**
 
-Extend `access.ts`:
+In `access.ts`:
 
-```ts
-import * as cloudflare from '@pulumi/cloudflare';
-import * as pulumi from '@pulumi/pulumi';
+- hard-code the two supported stack definitions;
+- throw for every other stack name;
+- keep production host/path values out of Pulumi config;
+- keep `normalizeAccessEmail` as the only bespoke config validator;
+- always normalize `accessEmail` via `pulumi.output(accessEmail).apply(normalizeAccessEmail)`;
+- pass account ID and posture-rule ID through from required Pulumi config without extra blank-string validators.
 
-export const DEFAULT_ACCESS_SESSION_DURATION = '12h';
+Run the focused infrastructure tests again. Expected: stack/email tests PASS.
 
-export const ACCESS_APPLICATION_FLAGS = {
-  appLauncherVisible: false,
-  allowAuthenticateViaWarp: false,
-  enableBindingCookie: true,
-  httpOnlyCookieAttribute: true,
-  pathCookieAttribute: false
-} as const;
+- [ ] **Step 3: Implement the Access application args/resource factory**
 
-type AccessPolicy = cloudflare.types.input.ZeroTrustAccessApplicationPolicy;
-type AccessApplicationArgs = cloudflare.ZeroTrustAccessApplicationArgs;
+Mirror only the browser Access shape used by Perseus:
 
-function normalizeAccountId(rawValue: string): string {
-  const value = rawValue.trim();
-  if (!value) throw new Error('cloudflareAccountId must not be empty');
-  return value;
-}
+- `cloudflare.ZeroTrustAccessApplication`;
+- type `self_hosted`;
+- one inline `allow` policy at precedence `1`;
+- email `Include`;
+- existing posture-rule ID `Require`;
+- `12h` default session;
+- `appLauncherVisible: false`;
+- `allowAuthenticateViaWarp: false`;
+- `enableBindingCookie: true`;
+- `httpOnlyCookieAttribute: true`;
+- `pathCookieAttribute: false`.
 
-function normalizeAccessEmailInput(value: pulumi.Input<string>): pulumi.Input<string> {
-  return typeof value === 'string'
-    ? normalizeAccessEmail(value)
-    : pulumi.output(value).apply(normalizeAccessEmail);
-}
+Do not add posture/list/service-token/CLI resources.
 
-export function buildAccessPolicy(
-  accessEmail: pulumi.Input<string>,
-  devicePostureRuleId: string
-): AccessPolicy {
-  return {
-    name: 'Allow configured operator on trusted device',
-    decision: 'allow',
-    precedence: 1,
-    includes: [{ email: { email: normalizeAccessEmailInput(accessEmail) } }],
-    requires: [
-      {
-        devicePosture: {
-          integrationUid: normalizeDevicePostureRuleId(devicePostureRuleId)
-        }
-      }
-    ]
-  };
-}
+Run:
 
-export interface BuildAccessApplicationArgs {
-  accountId: string;
-  stackDefinition: AccessStackDefinition;
-  accessEmail: pulumi.Input<string>;
-  devicePostureRuleId: string;
-  sessionDuration?: string;
-}
-
-export function buildAccessApplicationArgs(
-  args: BuildAccessApplicationArgs
-): AccessApplicationArgs {
-  return {
-    accountId: normalizeAccountId(args.accountId),
-    name: args.stackDefinition.applicationName,
-    type: 'self_hosted',
-    domain: args.stackDefinition.domain,
-    destinations: args.stackDefinition.destinations,
-    sessionDuration: args.sessionDuration?.trim() || DEFAULT_ACCESS_SESSION_DURATION,
-    ...ACCESS_APPLICATION_FLAGS,
-    policies: [buildAccessPolicy(args.accessEmail, args.devicePostureRuleId)]
-  };
-}
-
-export function createAccessApplication(
-  args: BuildAccessApplicationArgs
-): cloudflare.ZeroTrustAccessApplication {
-  return new cloudflare.ZeroTrustAccessApplication(
-    `dtxweb-${args.stackDefinition.stackName}-access`,
-    buildAccessApplicationArgs(args)
-  );
-}
+```bash
+bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure check
 ```
 
-Do not add list/posture/token resources.
+Expected: PASS.
 
 - [ ] **Step 4: Add the Pulumi entrypoint**
 
-Create `packages/infrastructure/src/index.ts`:
+`index.ts` must:
 
-```ts
-import * as pulumi from '@pulumi/pulumi';
-import { createAccessApplication, getAccessStackDefinition } from './access.js';
+1. call `getAccessStackDefinition(pulumi.getStack())` before resource creation;
+2. read `cloudflareAccountId` with `config.require`;
+3. read `accessEmail` with `config.requireSecret`;
+4. read `devicePostureRuleId` with `config.require`;
+5. read optional `accessSessionDuration` with `config.get`;
+6. create exactly one Access application;
+7. export only non-secret application metadata needed for operator inspection.
 
-const config = new pulumi.Config();
-const stackDefinition = getAccessStackDefinition(pulumi.getStack());
-
-const accessApplication = createAccessApplication({
-  accountId: config.require('cloudflareAccountId'),
-  stackDefinition,
-  accessEmail: config.requireSecret('accessEmail'),
-  devicePostureRuleId: config.require('devicePostureRuleId'),
-  sessionDuration: config.get('accessSessionDuration')
-});
-
-export const accessApplicationId = accessApplication.id;
-```
-
-Stack validation must happen before resource creation.
-
-- [ ] **Step 5: Run focused/package verification**
+Run:
 
 ```bash
 bun run --filter=@dtx/infrastructure test:coverage
@@ -561,73 +267,47 @@ bun run --filter=@dtx/infrastructure check
 bun run --filter=@dtx/infrastructure build
 ```
 
-Expected: PASS.
+Expected: PASS and `dist/index.js` exists.
 
-If provider typings differ from the working Perseus shape, verify the current provider API before adapting names; do not redesign policy semantics.
+If selected `@pulumi/cloudflare` typings differ from the referenced resource shape, stop and reconcile against the installed provider API rather than widening scope.
 
-- [ ] **Step 6: Prove root coverage includes the new workspace**
+- [ ] **Step 5: Commit Task 2**
 
-```bash
-bun run test:coverage
-```
-
-Expected: the existing workspace coverage suite runs `@dtx/infrastructure`'s `test:coverage` task rather than silently skipping it.
-
-- [ ] **Step 7: Commit the Access resource slice**
-
-```bash
-git add packages/infrastructure
-git commit -m "feat: define DTXWeb Cloudflare Access apps"
-```
+Commit only the Access implementation/tests/entrypoint after the test, check, and build commands pass.
 
 ---
 
-### Task 3: Finalize Operator Documentation And Produce Non-mutating Preview Evidence
+### Task 3: Finish Operator Documentation And Preview Readiness
 
 **Files:**
 
 - Create: `packages/infrastructure/README.md`
-- Review/modify if implementation details require it: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- Modify only if implementation details changed: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- Modify only if implementation details changed: `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
 
 **Interfaces:**
 
-- Consumes the implemented infrastructure package and the already Pulumi-native operator runbook.
-- Produces repository-local setup documentation plus pre-prod/production preview evidence.
-- Produces **no live Cloudflare mutation**.
+- README documents local stack setup/config and points to the runbook for live rollout.
+- The runbook remains the sole source of live route matrices, posture comparison, apply, acceptance, and rollback.
 
-- [ ] **Step 1: Write the infrastructure README**
+- [ ] **Step 1: Write the infrastructure README without duplicating the live runbook**
 
 Document:
 
-- package owns only DTXWeb Access applications;
-- Workers/API/storage remain on Wrangler;
-- supported stacks are exactly `pre-prod` and `production`;
-- DTXWeb consumes the Perseus `adminAccessDevicePostureRuleId` as config;
-- `pulumi login --local` defaults to state under `~/.pulumi`;
-- stack config files are local/ignored;
-- Cloudflare token needs `Access: Apps and Policies Write` for application lifecycle;
-- package scripts are test/build/check only;
-- live commands live in the operator runbook and always specify `--stack`;
-- emergency provider-side deletion is documented only in the runbook.
+- `pulumi login --local`;
+- exact supported stacks (`pre-prod`, `production`);
+- required config keys and `accessEmail` secret handling;
+- obtaining the current Perseus posture-rule output;
+- `bun run --filter=@dtx/infrastructure build` before preview;
+- explicit `pulumi preview --stack pre-prod` and `pulumi preview --stack production` commands;
+- production apply hold until Better Auth/D1 reconciliation;
+- pointer to the operator runbook for all `up`/destroy/browser/device operations.
 
-Do not duplicate the route matrices.
+Do not add unscoped package scripts as shortcuts.
 
-- [ ] **Step 2: Validate the runbook against implemented config keys**
+- [ ] **Step 2: Verify the runbook preflight matches the implementation**
 
-Confirm the runbook uses exactly:
-
-```text
-cloudflareAccountId
-accessEmail
-devicePostureRuleId
-accessSessionDuration
-```
-
-Confirm it remains marked operator-executed and owns every `pulumi up`, `pulumi destroy`, browser/device check, and emergency dashboard fallback.
-
-If implementation changed no interface, make no gratuitous runbook edit.
-
-- [ ] **Step 3: Run complete non-live repository verification**
+The runbook must require, before preview:
 
 ```bash
 bun install --frozen-lockfile
@@ -635,88 +315,63 @@ bun run --filter=@dtx/infrastructure check
 bun run --filter=@dtx/infrastructure test:coverage
 bun run --filter=@dtx/infrastructure build
 .github/scripts/ci-affected-scope.test.sh
-bun run test:coverage
+bun run lint
+bunx prettier --check .
 ```
 
-Expected: PASS.
+It must also compare the current Perseus `adminAccessDevicePostureRuleId` against `pulumi config get devicePostureRuleId --stack pre-prod` and `--stack production`; mismatch is a hard stop.
 
-- [ ] **Step 4: Run Pulumi previews only when authenticated config already exists**
+- [ ] **Step 3: Produce non-mutating preview evidence when local credentials/config are available**
 
-If the environment already has the Cloudflare API token and DTXWeb stack config:
+After the build, from `packages/infrastructure`:
 
 ```bash
-cd packages/infrastructure
 pulumi preview --stack pre-prod
 pulumi preview --stack production
 ```
 
-Expected pre-prod preview:
+Expected:
 
-- one DTXWeb Access application;
-- hostname-wide `pre-prod.dtx.hapadona.com`;
-- existing posture-rule reference;
-- no API/list/posture/token/Worker/storage resource.
+- pre-prod preview registers one hostname-wide `DTXWeb Pre-prod` Access application only;
+- production preview registers one `DTXWeb Production App` with exactly `/app` and `/app/*` destinations;
+- neither preview creates posture/list/token/Worker/API resources.
 
-Expected production preview:
+If authenticated local config is unavailable, record previews as `NOT RUN — operator credentials/config unavailable`; do not fabricate stack config or secrets.
 
-- one `DTXWeb Production App`;
-- destinations exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`;
-- no hostname-wide production destination;
-- no API/list/posture/token/Worker/storage resource.
+Do **not** run `pulumi up`.
 
-If authenticated config is unavailable, record `NOT RUN — operator credentials/config required`; do not invent config or request secrets in PR comments.
+- [ ] **Step 4: Run final implementation verification and commit**
 
-**Do not run `pulumi up` or `pulumi destroy`.**
-
-- [ ] **Step 5: Commit documentation/preview-ready state**
+From the repository root:
 
 ```bash
-git add packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-git commit -m "docs: document DTXWeb Access operations"
+bun install --frozen-lockfile
+bun run --filter=dtx-web test -- 'src/routes/(app)/private-route-boundary.test.ts'
+bun run --filter=@dtx/infrastructure test:coverage
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure build
+.github/scripts/ci-affected-scope.test.sh
+bun run lint
+bunx prettier --check .
+git diff --check
 ```
 
-If the runbook did not change, commit only the README.
+Expected: all commands PASS and no secret/config/state file is tracked.
+
+Commit README/document corrections only after these gates pass.
 
 ---
 
-## Operator Handoff — Not Agent Plan Tasks
+## Operator Handoff After Implementation
 
-After Tasks 1–3, stop implementation and hand the operator to:
+The agent implementation ends after Task 3.
 
-`docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+A human operator then follows `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`:
 
-The operator performs, in order:
+1. apply and verify `pre-prod` first;
+2. keep pre-production Access enabled if accepted;
+3. **do not apply `production` yet**;
+4. wait for the queued Better Auth/D1 cutover to replace the current desktop auth flow and reconcile PR #221's production acceptance procedure;
+5. only after that reconciliation removes the production hold, preview/apply/verify the production stack.
 
-1. pre-prod preview review;
-2. `pulumi up --stack pre-prod`;
-3. pre-prod route/browser/posture acceptance;
-4. only after pre-prod is green, production preview review;
-5. `pulumi up --stack production`;
-6. production route/identity/posture/browser/session-expiry/desktop acceptance;
-7. stack-specific rollback if required;
-8. dashboard disable/delete only if Pulumi state/backend is unavailable during an emergency.
-
-These operations are deliberately outside the `For agentic workers` task list.
-
-## Final Implementation Verification
-
-Before claiming the implementation branch complete:
-
-```bash
-git diff --check
-bun run --filter=@dtx/infrastructure check
-bun run --filter=@dtx/infrastructure test:coverage
-.github/scripts/ci-affected-scope.test.sh
-```
-
-Confirm the diff contains no changes under:
-
-```text
-packages/dtx-web/
-packages/dtx-api/
-packages/dtx-desktop/
-```
-
-Confirm no committed file contains a real operator email, API token, device serial, Access cookie/JWT, Pulumi stack config, or state export.
-
-Confirm Access code contains no `ZeroTrustList`, `ZeroTrustDevicePostureRule`, `ZeroTrustAccessServiceToken`, Service Auth policy, or hostname-configurable production destination.
+This sequencing avoids validating and documenting a production desktop auth flow that the queued migration already plans to remove.

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -312,16 +312,23 @@ git commit -m "feat: scaffold DTXWeb Access infrastructure"
 
 - [ ] **Step 1: Add failing tests for the policy and application shape**
 
-Append focused tests to `src/access.test.ts`:
+Extend the existing import from `./access.js` with these names rather than adding a second import later in the file:
 
 ```ts
 import {
   ACCESS_APPLICATION_FLAGS,
   DEFAULT_ACCESS_SESSION_DURATION,
   buildAccessApplicationArgs,
-  buildAccessPolicy
+  buildAccessPolicy,
+  getAccessStackDefinition,
+  normalizeAccessEmail,
+  normalizeDevicePostureRuleId
 } from './access.js';
+```
 
+Add these focused tests:
+
+```ts
 it('builds one email + posture allow policy', () => {
   expect(buildAccessPolicy(' operator@example.com ', ' posture-rule-id ')).toEqual({
     name: 'Allow configured operator on trusted device',
@@ -363,6 +370,17 @@ it('never builds hostname-wide production Access', () => {
   });
 
   expect(args.destinations).not.toContainEqual({ type: 'public', uri: 'dtx.hapadona.com' });
+});
+
+it('rejects an empty Cloudflare account ID before deployment', () => {
+  expect(() =>
+    buildAccessApplicationArgs({
+      accountId: '   ',
+      stackDefinition: getAccessStackDefinition('pre-prod'),
+      accessEmail: 'operator@example.com',
+      devicePostureRuleId: 'posture-rule-id'
+    })
+  ).toThrow(/cloudflareAccountId must not be empty/);
 });
 ```
 
@@ -447,7 +465,7 @@ export function createAccessApplication(args: BuildAccessApplicationArgs) {
 }
 ```
 
-If the selected `@pulumi/cloudflare` version exposes a type spelling that differs from the currently working Perseus source, use the provider's current `ZeroTrustAccessApplicationArgs`/inline-policy types without changing the external behavior above. Do not switch to deprecated `AccessApplication` resources.
+The current Pulumi Cloudflare v6 resource is `ZeroTrustAccessApplication` and supports `destinations`, `policies`, `domain`, and `sessionDuration`. If dependency resolution installs a later compatible v6 release, keep this non-deprecated resource and the external behavior above; do not switch to deprecated `AccessApplication` resources.
 
 - [ ] **Step 4: Add the Pulumi program entrypoint**
 
@@ -488,7 +506,7 @@ Expected: all pass. The root `check` should discover the new workspace through t
 
 ```bash
 git add packages/infrastructure/src
- git commit -m "feat: manage DTXWeb Access with Pulumi"
+git commit -m "feat: manage DTXWeb Access with Pulumi"
 ```
 
 ---
@@ -540,7 +558,7 @@ pulumi stack output adminAccessDevicePostureRuleId
 
 Run that command from the Perseus infrastructure project/stack that owns the current trusted-device posture rule; do not copy serial numbers into DTXWeb.
 
-Document the Cloudflare token requirement as an account-scoped token with `Access: Apps and Policies Write`, which is the Cloudflare API permission accepted for Access application/policy writes. Do not add permissions for Workers, D1, R2, service tokens, or device-posture writes for this DTXWeb package.
+Document the Cloudflare token requirement as an account-scoped token with `Access: Apps and Policies Write`, which Cloudflare currently accepts for Access application and application-policy writes. Do not add permissions for Workers, D1, R2, service tokens, or device-posture writes for this DTXWeb package.
 
 - [ ] **Step 2: Replace dashboard configuration in the runbook with Pulumi preview/apply**
 

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -1,0 +1,496 @@
+# Cloudflare Zero Trust Web Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Protect production DTXWeb `/app` routes and the entire pre-production web hostname with Cloudflare Zero Trust Access while leaving public production routes and both API hostnames outside Access.
+
+**Architecture:** Configure two manually managed Cloudflare Access self-hosted public-hostname applications. Production is path-scoped to the exact `/app` parent and `/app/*` descendants; pre-production is hostname-wide. Both reuse the Perseus-style operator identity plus trusted-device serial-number posture requirement, while existing Supabase authentication stays unchanged behind the Access gate.
+
+**Tech Stack:** Cloudflare Zero Trust Access dashboard, Cloudflare One Client/WARP device posture, SvelteKit/Supabase existing authentication, Markdown operator documentation, curl/browser verification.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
+
+## Global Constraints
+
+- Do not add Pulumi, Terraform, or another infrastructure-as-code system.
+- Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop` for this slice.
+- Production Access destinations must be exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
+- Production `/`, `/blog`, `/preview`, `/editor`, `/login`, `/auth/*`, and every route outside `/app` remain outside Cloudflare Access.
+- Pre-production Access covers the entire `pre-prod.dtx.hapadona.com` hostname with no path bypass.
+- `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` remain outside Cloudflare Access.
+- Use an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check used for Perseus.
+- Use a `12h` Access session duration to match the existing Perseus configuration.
+- Prefer reusing the existing account-level Perseus serial-number list/posture rule when it is available in the same Cloudflare Zero Trust account. If the DTXWeb zone is in a different Zero Trust account, create an equivalent serial-number list/posture rule there; do not weaken the posture requirement.
+- Do not create Service Auth policies, service tokens, or Cloudflare Access credentials for API, desktop, CLI, or CI traffic.
+- Do not commit the allowed email address, device serial numbers, Access cookies, tokens, screenshots containing credentials, or other personal/security identifiers.
+- If implementation reveals that application code must change for the approved routing model to work, stop and create a separate follow-up rather than expanding this slice silently.
+
+---
+
+### Task 1: Add The Zero Trust Operator Runbook
+
+**Files:**
+
+- Create: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+
+**Interfaces:**
+
+- Consumes: the approved protection matrix from the design spec.
+- Produces: the durable repository source of truth for manual Cloudflare dashboard configuration, verification, and rollback.
+
+- [ ] **Step 1: Create the runbook with the exact intended configuration**
+
+Create `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` with:
+
+```markdown
+# Cloudflare Zero Trust Web Access Runbook
+
+## Scope
+
+DTXWeb uses manually managed Cloudflare Zero Trust Access for two browser-facing web surfaces:
+
+| Application | Protected destination |
+| --- | --- |
+| `DTXWeb Production App` | `dtx.hapadona.com/app` |
+| `DTXWeb Production App` | `dtx.hapadona.com/app/*` |
+| `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
+
+The production landing page and public tools/content remain outside Access. Both GraphQL API hostnames remain outside Access.
+
+## Required Policy
+
+Both Access applications use the same policy semantics:
+
+- Action: `Allow`
+- Include: the intended operator identity/email used for the existing Perseus Zero Trust access
+- Require: the trusted-device serial-number posture check used for Perseus
+- Session duration: `12h`
+
+Reuse the existing account-level Perseus serial-number list/posture rule when it is available in the same Cloudflare Zero Trust account. If DTXWeb is in a different Zero Trust account, create an equivalent serial-number list and posture rule there using the same intended trusted devices.
+
+Never commit the email address, device serial numbers, Access cookies, tokens, or other security identifiers to this repository.
+
+## Production Configuration
+
+In Cloudflare Dashboard:
+
+1. Go to **Zero Trust > Access controls > Applications**.
+2. Create a new **Self-hosted and private** application.
+3. Name it `DTXWeb Production App`.
+4. Add public-hostname destinations whose resulting URIs are exactly:
+   - `dtx.hapadona.com/app`
+   - `dtx.hapadona.com/app/*`
+5. Set the Access session duration to `12h`.
+6. Attach an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check.
+7. Do not add a Service Auth policy or service token.
+8. Save the application.
+
+Do not add a hostname-wide `dtx.hapadona.com` destination. Do not add `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, or other public paths.
+
+Cloudflare path wildcards do not cover their parent path, which is why both `/app` and `/app/*` are recorded explicitly.
+
+## Pre-production Configuration
+
+In Cloudflare Dashboard:
+
+1. Go to **Zero Trust > Access controls > Applications**.
+2. Create a new **Self-hosted and private** application.
+3. Name it `DTXWeb Pre-prod`.
+4. Add one public-hostname destination for the entire `pre-prod.dtx.hapadona.com` hostname with no path restriction.
+5. Set the Access session duration to `12h`.
+6. Attach an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check.
+7. Do not add a Service Auth policy or service token.
+8. Save the application.
+
+Do not add `api.pre-prod.dtx.hapadona.com` to this application.
+
+## Protection Matrix
+
+| URL family | Expected Access behavior |
+| --- | --- |
+| `https://dtx.hapadona.com/app` | Access required |
+| `https://dtx.hapadona.com/app/*` | Access required |
+| `https://dtx.hapadona.com/` | No Access challenge |
+| `https://dtx.hapadona.com/blog/*` | No Access challenge |
+| `https://dtx.hapadona.com/preview/*` | No Access challenge |
+| `https://dtx.hapadona.com/editor/*` | No Access challenge |
+| `https://dtx.hapadona.com/login` | No Access challenge |
+| `https://dtx.hapadona.com/auth/*` | No Access challenge |
+| `https://pre-prod.dtx.hapadona.com/*` | Access required |
+| `https://api.dtx.hapadona.com/*` | No Access challenge |
+| `https://api.pre-prod.dtx.hapadona.com/*` | No Access challenge |
+
+## Verification
+
+### Logged-out browser
+
+Use a private/incognito browser with no current Cloudflare Access session.
+
+Production:
+
+- Open `/app` and one descendant such as `/app/score`; both must enter Cloudflare Access before DTXWeb loads.
+- Open `/`, `/blog`, `/preview`, `/editor`, and `/login`; none may enter Cloudflare Access.
+
+Pre-production:
+
+- Open `/`, `/login`, `/blog`, `/preview`, `/editor`, and `/app`; every route must enter Cloudflare Access before DTXWeb loads.
+
+APIs:
+
+- Open or request both API hostnames and confirm neither is intercepted by Cloudflare Access. Their application/API-specific response status is not important for this check.
+
+### Allowed identity on trusted device
+
+Production:
+
+- Pass Access and open `/app`.
+- With no Supabase session, confirm SvelteKit redirects to public `/login`.
+- Complete the existing login flow and confirm the browser returns successfully to `/app` through the still-valid Access session.
+- Start the desktop browser-login flow and confirm public `/login` can return through protected `/app?redirect=desktop...` to the desktop callback.
+
+Pre-production:
+
+- Pass the hostname-wide Access gate.
+- Complete the normal pre-production login/OAuth flow and confirm callbacks on the same hostname work under the existing Access session.
+
+### Untrusted device
+
+From a device that does not satisfy the serial-number posture rule, confirm production `/app` and the pre-production hostname are denied before DTXWeb loads.
+
+## Rollback
+
+Production rollback:
+
+- Disable or delete `DTXWeb Production App` if `/app` must be restored immediately.
+- If public production routes are accidentally challenged, remove any broad destination and restore the application to only `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
+
+Pre-production rollback:
+
+- Disable or delete `DTXWeb Pre-prod` to restore the pre-production hostname.
+
+If either API hostname receives an Access challenge, remove that hostname from the relevant Access application. Do not introduce service tokens as an emergency workaround.
+
+No Worker rollback or code deployment is required for these Access-only changes.
+
+## References
+
+- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
+- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
+- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
+```
+
+- [ ] **Step 2: Format-check the runbook**
+
+Run:
+
+```bash
+bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+```
+
+Expected: exits `0` with the runbook formatted correctly.
+
+If it reports formatting differences, run:
+
+```bash
+bunx prettier --write docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+```
+
+Expected: the second command exits `0`.
+
+- [ ] **Step 3: Confirm the documentation does not contain secret values**
+
+Run:
+
+```bash
+git diff -- docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+```
+
+Expected: the document contains only application names, hostnames, route paths, policy semantics, and operator instructions. It must not contain an actual personal email address, device serial number, token, cookie, or credential.
+
+- [ ] **Step 4: Commit the runbook**
+
+```bash
+git add docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+git commit -m "docs: add Zero Trust web access runbook"
+```
+
+---
+
+### Task 2: Configure Production `/app` Access
+
+**Files:**
+
+- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- No source files modified.
+
+**Interfaces:**
+
+- Consumes: the existing Cloudflare zone for `dtx.hapadona.com`, the intended operator identity, and the trusted-device serial-number posture rule.
+- Produces: one Cloudflare Access application named `DTXWeb Production App` whose only protected production web destinations are `/app` and `/app/*`.
+
+- [ ] **Step 1: Confirm the existing Perseus posture components are reusable**
+
+In Cloudflare Zero Trust, inspect the device posture rules/lists already used for Perseus.
+
+Expected:
+
+- the intended trusted-device serial-number posture rule is visible in the same Zero Trust account as the DTXWeb zone and can be selected by an Access policy; or
+- if the DTXWeb zone is in a different Zero Trust account, create an equivalent serial-number list and serial-number posture rule there before continuing.
+
+Do not copy serial numbers into git, issue comments, PR descriptions, or terminal transcripts committed to the repo.
+
+- [ ] **Step 2: Create the production Access application**
+
+In **Zero Trust > Access controls > Applications**:
+
+1. Select **Create new application**.
+2. Select **Self-hosted and private**.
+3. Name the application `DTXWeb Production App`.
+4. Add public-hostname entries so the resulting protected destinations are exactly:
+
+```text
+dtx.hapadona.com/app
+dtx.hapadona.com/app/*
+```
+
+5. Set session duration to `12h`.
+6. Add an `Allow` policy whose Include rule matches the intended operator identity/email and whose Require rule matches the trusted-device serial-number posture check.
+7. Do not add a Service Auth policy.
+8. Save the application.
+
+Expected: there is no hostname-wide `dtx.hapadona.com` destination and no destination for any route outside `/app`.
+
+- [ ] **Step 3: Verify the unauthenticated production boundary**
+
+From a browser with no Access session, verify:
+
+```text
+https://dtx.hapadona.com/app        -> Cloudflare Access required
+https://dtx.hapadona.com/app/score  -> Cloudflare Access required
+https://dtx.hapadona.com/           -> no Cloudflare Access challenge
+https://dtx.hapadona.com/blog       -> no Cloudflare Access challenge
+https://dtx.hapadona.com/preview    -> no Cloudflare Access challenge
+https://dtx.hapadona.com/editor     -> no Cloudflare Access challenge
+https://dtx.hapadona.com/login      -> no Cloudflare Access challenge
+```
+
+Also request a representative `/auth/*` URL and confirm any response comes from DTXWeb rather than Cloudflare Access. A DTXWeb `404`, redirect, or application-specific response is acceptable; an Access login/challenge is not.
+
+- [ ] **Step 4: Verify the trusted production browser flow**
+
+Using the allowed identity on the trusted device:
+
+1. Open `https://dtx.hapadona.com/app` and pass Cloudflare Access.
+2. If the browser has no Supabase session, confirm DTXWeb redirects to `https://dtx.hapadona.com/login` without another Access challenge.
+3. Complete the existing Supabase login.
+4. Confirm the browser returns to `/app` and is accepted by the existing Access session.
+5. Sign out of Supabase and confirm this does not remove the Cloudflare Access boundary from `/app`.
+
+Expected: Cloudflare Access and Supabase remain two independent gates; public `/login` is not accidentally protected.
+
+- [ ] **Step 5: Verify production posture denial**
+
+From a device that does not satisfy the configured serial-number posture rule, request `https://dtx.hapadona.com/app`.
+
+Expected: Cloudflare denies access before the DTXWeb application loads.
+
+---
+
+### Task 3: Configure Hostname-Wide Pre-production Access
+
+**Files:**
+
+- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- No source files modified.
+
+**Interfaces:**
+
+- Consumes: the same intended operator identity and trusted-device posture semantics as production.
+- Produces: one Cloudflare Access application named `DTXWeb Pre-prod` protecting the entire `pre-prod.dtx.hapadona.com` web hostname.
+
+- [ ] **Step 1: Create the pre-production Access application**
+
+In **Zero Trust > Access controls > Applications**:
+
+1. Select **Create new application**.
+2. Select **Self-hosted and private**.
+3. Name the application `DTXWeb Pre-prod`.
+4. Add one public hostname for:
+
+```text
+pre-prod.dtx.hapadona.com
+```
+
+Do not enter a path restriction.
+
+5. Set session duration to `12h`.
+6. Add an `Allow` policy whose Include rule matches the intended operator identity/email and whose Require rule matches the trusted-device serial-number posture check.
+7. Do not add a Service Auth policy.
+8. Save the application.
+
+Expected: the entire pre-production web hostname is protected, including `/`, `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, `/app`, and future paths.
+
+- [ ] **Step 2: Verify the unauthenticated pre-production boundary**
+
+From a browser with no Access session, request each of:
+
+```text
+https://pre-prod.dtx.hapadona.com/
+https://pre-prod.dtx.hapadona.com/login
+https://pre-prod.dtx.hapadona.com/blog
+https://pre-prod.dtx.hapadona.com/preview
+https://pre-prod.dtx.hapadona.com/editor
+https://pre-prod.dtx.hapadona.com/app
+```
+
+Expected: every request is intercepted by Cloudflare Access before DTXWeb loads.
+
+- [ ] **Step 3: Verify the trusted pre-production auth flow**
+
+Using the allowed identity on the trusted device:
+
+1. Enter `https://pre-prod.dtx.hapadona.com/` through Cloudflare Access.
+2. Open `/login` under the same Access session.
+3. Complete the existing pre-production Supabase login/OAuth flow.
+4. Confirm the browser can return through the pre-production `/auth/*` callback and reach `/app` without being trapped in an Access/auth redirect loop.
+
+Expected: the hostname-wide Access session remains valid across the application login/OAuth flow.
+
+- [ ] **Step 4: Verify pre-production posture denial**
+
+From a device that does not satisfy the configured serial-number posture rule, request `https://pre-prod.dtx.hapadona.com/`.
+
+Expected: Cloudflare denies access before DTXWeb loads.
+
+---
+
+### Task 4: Verify API And Desktop Boundaries
+
+**Files:**
+
+- Reference: `packages/dtx-web/wrangler.jsonc`
+- Reference: `packages/dtx-desktop/src/renderer/src/services/authService.ts`
+- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- No source files modified.
+
+**Interfaces:**
+
+- Consumes: the two configured Access applications from Tasks 2 and 3.
+- Produces: evidence that browser-route protection did not introduce an Access dependency for GraphQL API clients or break the production desktop login entry flow.
+
+- [ ] **Step 1: Confirm both API hostnames remain outside Access**
+
+Run from a shell without Cloudflare Access credentials:
+
+```bash
+for url in \
+  https://api.dtx.hapadona.com \
+  https://api.pre-prod.dtx.hapadona.com; do
+  echo "=== $url ==="
+  curl -sS -o /dev/null -D - "$url" | sed -n '1,12p'
+done
+```
+
+Expected: neither response redirects to a `cloudflareaccess.com` Access login URL. A GraphQL/API-specific `200`, `4xx`, or redirect is acceptable; the purpose is only to confirm that Cloudflare Access is not intercepting the API hostname.
+
+If either API hostname is challenged by Access, stop and remove it from the Access application before proceeding. Do not add service tokens.
+
+- [ ] **Step 2: Verify the production desktop login browser boundary**
+
+Use the production desktop application and start its existing login flow.
+
+Expected sequence:
+
+```text
+desktop app
+  -> https://dtx.hapadona.com/login?redirect=desktop&desktop_callback=...
+     (public; no Access challenge)
+  -> existing Supabase login
+  -> https://dtx.hapadona.com/app?redirect=desktop&desktop_callback=...
+     (Cloudflare Access required if no valid Access session)
+  -> existing DTXWeb magic-link/deep-link callback
+  -> desktop app
+```
+
+Using the allowed identity on the trusted device, complete the flow and confirm the desktop receives its normal authenticated session.
+
+Expected: no API service token or desktop code change is required.
+
+- [ ] **Step 3: Re-run the complete route matrix from the runbook**
+
+Check every row in the runbook's Protection Matrix.
+
+Expected:
+
+- production `/app` only: protected;
+- production public routes: not protected;
+- pre-production web hostname: protected everywhere;
+- both APIs: not protected.
+
+Do not consider the implementation complete if any route falls into the wrong category.
+
+---
+
+### Task 5: Final Repository And Rollback Check
+
+**Files:**
+
+- Verify: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- Verify: repository working tree
+
+**Interfaces:**
+
+- Consumes: the completed dashboard configuration and verification results.
+- Produces: a clean implementation branch containing documentation only, with the external Cloudflare configuration matching that documentation.
+
+- [ ] **Step 1: Confirm no application or deployment code changed**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD~1..HEAD
+```
+
+Expected: the implementation commit contains only the Zero Trust runbook. There must be no changes under `packages/dtx-web`, `packages/dtx-api`, `packages/dtx-desktop`, `.github/workflows`, or a new infrastructure package.
+
+- [ ] **Step 2: Run repository diff checks**
+
+Run:
+
+```bash
+git diff --check HEAD~1..HEAD
+bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 3: Confirm rollback instructions match the live configuration**
+
+Read the runbook rollback section and verify the named Access applications are exactly:
+
+```text
+DTXWeb Production App
+DTXWeb Pre-prod
+```
+
+Expected: disabling/deleting those two applications is sufficient to remove the Access gates; no Worker or API deploy is required.
+
+- [ ] **Step 4: Final scope check**
+
+Confirm all of the following are true before marking the work complete:
+
+```text
+[production] dtx.hapadona.com/app      protected
+[production] dtx.hapadona.com/app/*    protected
+[production] other web routes          public to Access
+[pre-prod]   pre-prod.dtx.hapadona.com protected hostname-wide
+[API]        production API             public to Access
+[API]        pre-production API         public to Access
+[IaC]        none added
+[app code]   none changed
+[secrets]    none committed
+```
+
+Expected: every line matches the live Cloudflare configuration and repository diff.

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -87,19 +87,23 @@ Both Access applications use the same policy semantics:
 
 Reuse the existing Perseus identity provider and its current instant-authentication mode. Do not toggle instant authentication merely to make a header test easier.
 
-Before rollout, inspect a known protected Perseus route and set an uncommitted shell regex that matches the actual unauthenticated Access redirect for this tenant:
+Before rollout, inspect a known protected Perseus route and identify its actual unauthenticated Access signal. The response can differ by client and device posture:
 
-```bash
-export ACCESS_REDIRECT_RE='<regex matching this tenant\'s Access redirect Location>'
-```
+- If it returns an Access or direct-IdP redirect, set an uncommitted regex that matches the `Location` value:
 
-For a tenant using the normal Cloudflare Access login page, a suitable value is:
+  ```bash
+  export ACCESS_REDIRECT_RE='<regex matching the tenant Access redirect Location>'
+  ```
 
-```bash
-export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
-```
+  For the normal Cloudflare Access login page, a suitable value is:
 
-If Perseus uses instant authentication, set the regex to the known direct IdP redirect shape observed from that existing protected route. Keep one redirect mode for the whole DTXWeb rollout.
+  ```bash
+  export ACCESS_REDIRECT_RE='^location: https://[^/]+\\.cloudflareaccess\\.com/cdn-cgi/access/'
+  ```
+
+- If it returns HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers, leave `ACCESS_REDIRECT_RE` unset. The helpers below recognize that Access-denial signal directly.
+
+If Perseus uses instant authentication, use the observed direct IdP redirect shape when a redirect is present. Keep one identity-provider and instant-authentication mode for the whole DTXWeb rollout.
 
 Never commit the operator email, device serial numbers, tenant-specific cookies/tokens, or other credentials.
 
@@ -124,23 +128,38 @@ http_headers() {
   printf '%s\n' "$headers"
 }
 
-assert_access_redirect() {
+has_access_interception() {
+  headers="$1"
+
+  if [ -n "${ACCESS_REDIRECT_RE:-}" ] &&
+    printf '%s\\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+    return 0
+  fi
+
+  if printf '%s\\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
+    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
+    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
+    return 0
+  fi
+
+  return 1
+}
+
+assert_access_intercepted() {
   url="$1"
-  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
-  printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE" || {
+  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  has_access_interception "$headers" || {
     echo "FAIL: Access did not intercept $url" >&2
     return 1
   }
 }
 
-assert_no_access_redirect() {
+assert_no_access_interception() {
   url="$1"
-  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
-  if printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  if has_access_interception "$headers"; then
     echo "FAIL: Access unexpectedly intercepted $url" >&2
     return 1
   fi
@@ -149,8 +168,8 @@ assert_no_access_redirect() {
 
 Dry-run the harness before changing DTXWeb:
 
-- `assert_access_redirect` against a known protected Perseus URL must pass.
-- `assert_no_access_redirect https://dtx.hapadona.com/` must pass before production Access exists.
+- `assert_access_intercepted` against a known protected Perseus URL must pass.
+- `assert_no_access_interception https://dtx.hapadona.com/` must pass before production Access exists.
 - `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` must fail non-zero.
 
 Do not proceed until the invalid-host check fails loudly.
@@ -184,19 +203,19 @@ Set session duration to `12h`, attach the operator `Allow` policy with the seria
 Run the following with no Access session:
 
 ```bash
-assert_access_redirect https://pre-prod.dtx.hapadona.com/
-assert_access_redirect https://pre-prod.dtx.hapadona.com/login
-assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
-assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
-assert_access_redirect https://pre-prod.dtx.hapadona.com/preview/1
-assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
-assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
-assert_access_redirect https://pre-prod.dtx.hapadona.com/game
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/__data.json
-assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/login
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/auth/callback
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/blog
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/preview/1
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/editor
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/game
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/score
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/__data.json
+assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
 ```
 
 Every command must exit `0`. If one fails, disable/delete `DTXWeb Pre-prod` and stop before production.
@@ -221,21 +240,21 @@ Set session duration to `12h`, attach the same operator `Allow` policy and seria
 Run with no Access session:
 
 ```bash
-assert_access_redirect https://dtx.hapadona.com/app
-assert_access_redirect https://dtx.hapadona.com/app/
-assert_access_redirect https://dtx.hapadona.com/app/score
-assert_access_redirect https://dtx.hapadona.com/app/__data.json
+assert_access_intercepted https://dtx.hapadona.com/app
+assert_access_intercepted https://dtx.hapadona.com/app/
+assert_access_intercepted https://dtx.hapadona.com/app/score
+assert_access_intercepted https://dtx.hapadona.com/app/__data.json
 
-assert_no_access_redirect https://dtx.hapadona.com/
-assert_no_access_redirect https://dtx.hapadona.com/blog
-assert_no_access_redirect https://dtx.hapadona.com/preview/1
-assert_no_access_redirect https://dtx.hapadona.com/editor
-assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
-assert_no_access_redirect https://dtx.hapadona.com/game
-assert_no_access_redirect https://dtx.hapadona.com/login
-assert_no_access_redirect https://dtx.hapadona.com/auth/callback
-assert_no_access_redirect https://api.dtx.hapadona.com/
-assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+assert_no_access_interception https://dtx.hapadona.com/
+assert_no_access_interception https://dtx.hapadona.com/blog
+assert_no_access_interception https://dtx.hapadona.com/preview/1
+assert_no_access_interception https://dtx.hapadona.com/editor
+assert_no_access_interception https://dtx.hapadona.com/tool/dtx-to-midi
+assert_no_access_interception https://dtx.hapadona.com/game
+assert_no_access_interception https://dtx.hapadona.com/login
+assert_no_access_interception https://dtx.hapadona.com/auth/callback
+assert_no_access_interception https://api.dtx.hapadona.com/
+assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
 ```
 
 Every command must exit `0`. `/app/` is an explicit path-semantics probe; do not assume its behavior from the dashboard string alone. `/app/__data.json` proves SvelteKit data requests are inside the Access boundary. `/preview/1` exercises the real dynamic preview route instead of a 404 prefix.
@@ -385,7 +404,7 @@ Follow **Required Policy** and **Header Verification Helpers** from the runbook.
 Expected:
 
 - current Perseus IdP/instant-auth mode is recorded for the operator session;
-- `ACCESS_REDIRECT_RE` matches a known protected Perseus route;
+- a known protected Perseus route is recognized by either the configured `ACCESS_REDIRECT_RE` or the `403` Access-header signal;
 - production `/` is recognized as currently unprotected;
 - the intentionally invalid hostname causes `http_headers` to exit non-zero.
 

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -2,43 +2,49 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Protect production DTXWeb `/app` routes and the entire pre-production web hostname with Cloudflare Zero Trust Access while leaving public production routes and both API hostnames outside Access.
+**Goal:** Make production DTXWeb `/app` and production desktop login operator-only behind Cloudflare Zero Trust, while protecting the entire pre-production web hostname and leaving the public production site plus both API hostnames outside Access.
 
-**Architecture:** Configure two manually managed Cloudflare Access self-hosted public-hostname applications. Production is path-scoped to the exact `/app` parent and `/app/*` descendants; pre-production is hostname-wide. Both reuse the Perseus-style operator identity plus trusted-device serial-number posture requirement, while existing Supabase authentication stays unchanged behind the Access gate.
+**Architecture:** Configure two manually managed Cloudflare Access self-hosted public-hostname applications. Roll out hostname-wide pre-production first to prove identity, device posture, Supabase login/OAuth, and rollback; only then create the production application scoped to exactly `/app` and `/app/*`. Supabase stays as the inner application-authentication gate, and route boundaries are verified with HTTP headers plus trusted-device browser/desktop smoke tests.
 
-**Tech Stack:** Cloudflare Zero Trust Access dashboard, Cloudflare One Client/WARP device posture, SvelteKit/Supabase existing authentication, Markdown operator documentation, curl/browser verification.
+**Tech Stack:** Cloudflare Zero Trust Access dashboard, Cloudflare One Client/WARP device posture, SvelteKit/Supabase existing authentication, Markdown operator documentation, `curl` header verification.
 
 **Spec:** `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
 
 ## Global Constraints
 
 - Do not add Pulumi, Terraform, or another infrastructure-as-code system.
-- Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop` for this slice.
+- Do not add CI deployment for Zero Trust.
+- Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop` in this slice.
+- Production `/app` and production desktop login are intentionally operator-only behind Access; normal Supabase users are not expected to enter production `/app`.
 - Production Access destinations must be exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
-- Production `/`, `/blog`, `/preview`, `/editor`, `/login`, `/auth/*`, and every route outside `/app` remain outside Cloudflare Access.
+- Production `/`, `/blog`, `/preview`, `/editor`, `/tool/*`, `/game`, `/login`, `/auth/*`, and every route outside `/app` remain outside Access.
 - Pre-production Access covers the entire `pre-prod.dtx.hapadona.com` hostname with no path bypass.
-- `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` remain outside Cloudflare Access.
+- `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` remain outside Access.
 - Use an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check used for Perseus.
-- Use a `12h` Access session duration to match the existing Perseus configuration.
-- Prefer reusing the existing account-level Perseus serial-number list/posture rule when it is available in the same Cloudflare Zero Trust account. If the DTXWeb zone is in a different Zero Trust account, create an equivalent serial-number list/posture rule there; do not weaken the posture requirement.
-- Do not create Service Auth policies, service tokens, or Cloudflare Access credentials for API, desktop, CLI, or CI traffic.
-- Do not commit the allowed email address, device serial numbers, Access cookies, tokens, screenshots containing credentials, or other personal/security identifiers.
-- If implementation reveals that application code must change for the approved routing model to work, stop and create a separate follow-up rather than expanding this slice silently.
+- Use a `12h` Access session duration.
+- Prefer reusing the existing account-level Perseus serial-number list/posture rule when available in the same Zero Trust account. If DTXWeb is in another Zero Trust account, create an equivalent list/posture rule there without weakening the requirement.
+- Do not create Service Auth policies, service tokens, or Access credentials for API, desktop, CLI, or CI traffic.
+- Do not enable Managed OAuth or add machine-auth behavior in this slice.
+- Keep the normal Cloudflare Access login-page flow during rollout rather than enabling instant authentication; the header checks below use the Access `302`/`Location` signal.
+- Do not commit the operator email, device serial numbers, Access cookies, tokens, screenshots containing credentials, or other personal/security identifiers.
+- Configure and verify pre-production before creating the production Access application.
+- If implementation reveals that application code must change for the approved model to work, stop and create a separate follow-up rather than widening this slice.
 
 ---
 
-### Task 1: Add The Zero Trust Operator Runbook
+### Task 1: Add The Dedicated Zero Trust Operator Runbook
 
 **Files:**
 
 - Create: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- Reference: `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
 
 **Interfaces:**
 
-- Consumes: the approved protection matrix from the design spec.
-- Produces: the durable repository source of truth for manual Cloudflare dashboard configuration, verification, and rollback.
+- Consumes: the approved protection matrix and rollout order from the design spec.
+- Produces: the durable repository source of truth for manual Access configuration, verification, rollback, and the operator-only product intent.
 
-- [ ] **Step 1: Create the runbook with the exact intended configuration**
+- [ ] **Step 1: Create the runbook with the exact configuration and rollout contract**
 
 Create `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` with:
 
@@ -47,136 +53,211 @@ Create `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
 
 ## Scope
 
-DTXWeb uses manually managed Cloudflare Zero Trust Access for two browser-facing web surfaces:
+DTXWeb uses manually managed Cloudflare Zero Trust Access for two web surfaces:
 
 | Application | Protected destination |
 | --- | --- |
+| `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
 | `DTXWeb Production App` | `dtx.hapadona.com/app` |
 | `DTXWeb Production App` | `dtx.hapadona.com/app/*` |
-| `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
 
-The production landing page and public tools/content remain outside Access. Both GraphQL API hostnames remain outside Access.
+Production `/app` and production desktop login are intentionally operator-only. The configured Access identity and trusted-device posture are an outer gate; Supabase remains the inner application-authentication gate.
+
+A normal Supabase user may reach public `/login`, authenticate successfully, and then be denied when returning to `/app`. That is expected for this configuration: public `/login` is an entry point, not an Access bypass.
+
+The production landing page and public content/tools remain outside Access, including `/blog`, `/preview`, `/editor`, `/tool/*`, and `/game`. Both GraphQL API hostnames remain outside Access.
+
+This runbook is the durable Zero Trust source of truth. `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is useful precedent for human-executed Cloudflare operations but remains a historical API-migration runbook and is not modified for this feature.
 
 ## Required Policy
 
 Both Access applications use the same policy semantics:
 
 - Action: `Allow`
-- Include: the intended operator identity/email used for the existing Perseus Zero Trust access
+- Include: the intended operator identity/email used for existing Perseus access
 - Require: the trusted-device serial-number posture check used for Perseus
 - Session duration: `12h`
+- Service Auth: none
+- Managed OAuth: off
+- Instant authentication: off during this rollout so unauthenticated header verification has a stable Access-login redirect
 
-Reuse the existing account-level Perseus serial-number list/posture rule when it is available in the same Cloudflare Zero Trust account. If DTXWeb is in a different Zero Trust account, create an equivalent serial-number list and posture rule there using the same intended trusted devices.
+Reuse the existing account-level Perseus serial-number list/posture rule when it is available in the same Zero Trust account. If DTXWeb is in another Zero Trust account, create an equivalent serial-number list and posture rule there using the same intended trusted devices.
 
 Never commit the email address, device serial numbers, Access cookies, tokens, or other security identifiers to this repository.
 
-## Production Configuration
+## Rollout Order
 
-In Cloudflare Dashboard:
+1. Confirm the operator identity and trusted-device posture rule.
+2. Create and verify `DTXWeb Pre-prod`.
+3. Prove pre-production password login, Google OAuth, posture denial, and API non-interception.
+4. Stop and roll back pre-production if any check fails.
+5. Create `DTXWeb Production App` with only `/app` and `/app/*`.
+6. Run the complete production public/protected header matrix.
+7. Run the trusted production browser and desktop-login checks.
+8. Re-run both API non-interception checks.
 
-1. Go to **Zero Trust > Access controls > Applications**.
-2. Create a new **Self-hosted and private** application.
-3. Name it `DTXWeb Production App`.
-4. Add public-hostname destinations whose resulting URIs are exactly:
-   - `dtx.hapadona.com/app`
-   - `dtx.hapadona.com/app/*`
-5. Set the Access session duration to `12h`.
-6. Attach an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check.
-7. Do not add a Service Auth policy or service token.
-8. Save the application.
+Do not create the production Access application until the pre-production checks are green.
 
-Do not add a hostname-wide `dtx.hapadona.com` destination. Do not add `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, or other public paths.
+## Header Verification Helpers
 
-Cloudflare path wildcards do not cover their parent path, which is why both `/app` and `/app/*` are recorded explicitly.
+Use unauthenticated requests with no Access cookies:
+
+```bash
+access_headers() {
+  curl -sS -o /dev/null -D - "$1" | tr -d '\r'
+}
+
+assert_access_redirect() {
+  url="$1"
+  headers="$(access_headers "$url")"
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
+  printf '%s\n' "$headers" \
+    | grep -Eiq '^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/' \
+    || { echo "FAIL: Access did not intercept $url" >&2; return 1; }
+}
+
+assert_no_access_redirect() {
+  url="$1"
+  headers="$(access_headers "$url")"
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
+  if printf '%s\n' "$headers" \
+    | grep -Eiq '^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'; then
+    echo "FAIL: Access unexpectedly intercepted $url" >&2
+    return 1
+  fi
+}
+```
+
+An origin `200`, `3xx`, `4xx`, or `5xx` can all be valid for an unprotected URL. The boundary assertion is whether Cloudflare Access intercepted the request.
 
 ## Pre-production Configuration
 
-In Cloudflare Dashboard:
+In **Zero Trust > Access controls > Applications**:
 
-1. Go to **Zero Trust > Access controls > Applications**.
-2. Create a new **Self-hosted and private** application.
-3. Name it `DTXWeb Pre-prod`.
-4. Add one public-hostname destination for the entire `pre-prod.dtx.hapadona.com` hostname with no path restriction.
-5. Set the Access session duration to `12h`.
-6. Attach an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check.
-7. Do not add a Service Auth policy or service token.
-8. Save the application.
+1. Create a **Self-hosted and private** application.
+2. Name it `DTXWeb Pre-prod`.
+3. Add one public hostname for `pre-prod.dtx.hapadona.com` with no path restriction.
+4. Set session duration to `12h`.
+5. Attach the operator `Allow` policy with the serial-number posture requirement.
+6. Leave Service Auth, Managed OAuth, and instant authentication off.
+7. Save the application.
 
-Do not add `api.pre-prod.dtx.hapadona.com` to this application.
+Do not add `api.pre-prod.dtx.hapadona.com`.
 
-## Protection Matrix
+## Pre-production Verification
 
-| URL family | Expected Access behavior |
-| --- | --- |
-| `https://dtx.hapadona.com/app` | Access required |
-| `https://dtx.hapadona.com/app/*` | Access required |
-| `https://dtx.hapadona.com/` | No Access challenge |
-| `https://dtx.hapadona.com/blog/*` | No Access challenge |
-| `https://dtx.hapadona.com/preview/*` | No Access challenge |
-| `https://dtx.hapadona.com/editor/*` | No Access challenge |
-| `https://dtx.hapadona.com/login` | No Access challenge |
-| `https://dtx.hapadona.com/auth/*` | No Access challenge |
-| `https://pre-prod.dtx.hapadona.com/*` | Access required |
-| `https://api.dtx.hapadona.com/*` | No Access challenge |
-| `https://api.pre-prod.dtx.hapadona.com/*` | No Access challenge |
+Run:
 
-## Verification
+```bash
+assert_access_redirect https://pre-prod.dtx.hapadona.com/
+assert_access_redirect https://pre-prod.dtx.hapadona.com/login
+assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
+assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
+assert_access_redirect https://pre-prod.dtx.hapadona.com/preview
+assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
+assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
+assert_access_redirect https://pre-prod.dtx.hapadona.com/game
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
+assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+```
 
-### Logged-out browser
+Then, on the trusted WARP/Cloudflare One device with the allowed identity:
 
-Use a private/incognito browser with no current Cloudflare Access session.
+- enter the pre-production hostname through Access;
+- complete a password login and return to the application;
+- complete Google OAuth and confirm the callback returns behind the same hostname-wide Access gate;
+- confirm normal pre-production API-backed application behavior still works;
+- from a device that fails the serial posture rule, confirm the hostname is denied before DTXWeb loads.
 
-Production:
+If any pre-production check fails, disable/delete `DTXWeb Pre-prod` and stop. Do not create production Access yet.
 
-- Open `/app` and one descendant such as `/app/score`; both must enter Cloudflare Access before DTXWeb loads.
-- Open `/`, `/blog`, `/preview`, `/editor`, and `/login`; none may enter Cloudflare Access.
+## Production Configuration
 
-Pre-production:
+Only after pre-production verification succeeds:
 
-- Open `/`, `/login`, `/blog`, `/preview`, `/editor`, and `/app`; every route must enter Cloudflare Access before DTXWeb loads.
+1. Create a **Self-hosted and private** application.
+2. Name it `DTXWeb Production App`.
+3. Add exactly these public-hostname destinations:
+   - `dtx.hapadona.com/app`
+   - `dtx.hapadona.com/app/*`
+4. Set session duration to `12h`.
+5. Attach the operator `Allow` policy with the serial-number posture requirement.
+6. Leave Service Auth, Managed OAuth, and instant authentication off.
+7. Save the application.
 
-APIs:
+Do not add a hostname-wide `dtx.hapadona.com` destination or any other production path.
 
-- Open or request both API hostnames and confirm neither is intercepted by Cloudflare Access. Their application/API-specific response status is not important for this check.
+## Production Header Matrix
 
-### Allowed identity on trusted device
+Run:
 
-Production:
+```bash
+assert_access_redirect https://dtx.hapadona.com/app
+assert_access_redirect https://dtx.hapadona.com/app/score
 
-- Pass Access and open `/app`.
-- With no Supabase session, confirm SvelteKit redirects to public `/login`.
-- Complete the existing login flow and confirm the browser returns successfully to `/app` through the still-valid Access session.
-- Start the desktop browser-login flow and confirm public `/login` can return through protected `/app?redirect=desktop...` to the desktop callback.
+assert_no_access_redirect https://dtx.hapadona.com/
+assert_no_access_redirect https://dtx.hapadona.com/blog
+assert_no_access_redirect https://dtx.hapadona.com/preview
+assert_no_access_redirect https://dtx.hapadona.com/editor
+assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
+assert_no_access_redirect https://dtx.hapadona.com/game
+assert_no_access_redirect https://dtx.hapadona.com/login
+assert_no_access_redirect https://dtx.hapadona.com/auth/callback
+assert_no_access_redirect https://api.dtx.hapadona.com/
+assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+```
 
-Pre-production:
+The public matrix is intentionally broad enough to catch an accidentally hostname-wide or over-broad production destination; `/tool/dtx-to-midi` also catches accidental `/t*`-style scoping.
 
-- Pass the hostname-wide Access gate.
-- Complete the normal pre-production login/OAuth flow and confirm callbacks on the same hostname work under the existing Access session.
+## Trusted Production Browser Verification
 
-### Untrusted device
+On the trusted WARP/Cloudflare One device with the allowed identity:
 
-From a device that does not satisfy the serial-number posture rule, confirm production `/app` and the pre-production hostname are denied before DTXWeb loads.
+1. Open production `/app` and pass Access.
+2. With no Supabase session, confirm SvelteKit redirects to public `/login`.
+3. Complete normal Supabase login.
+4. Confirm the browser returns to protected `/app` using the existing Access session.
+5. Confirm a Supabase logout does not remove the Access gate.
+
+From a Supabase account that does not match the configured Access identity, confirm `/login` can still be public while `/app` remains inaccessible. Do not add a bypass to make that account reach `/app`; operator-only access is intentional.
+
+## Production Desktop Login Verification
+
+This is a required production check, not an optional smoke test.
+
+On the trusted device:
+
+1. Start desktop login so the browser opens `/login?redirect=desktop&desktop_callback=...`.
+2. Confirm `/login` remains public.
+3. Complete password login and confirm the return to `/app?redirect=desktop...` passes Access and opens the desktop callback.
+4. Repeat with Google login.
+5. Verify the bundled `dtx://auth-callback` flow.
+6. When a `tauri dev` instance is available, verify its loopback `http://127.0.0.1:<port>/auth-callback` flow in the same browser tab so the `sessionStorage` callback handoff is exercised.
+
+If the browser reaches public `/login` but cannot complete the protected `/app` handoff on the trusted operator device, disable the production Access app and investigate separately. Do not widen the policy or add path bypasses in this slice.
 
 ## Rollback
 
-Production rollback:
+Pre-production:
 
-- Disable or delete `DTXWeb Production App` if `/app` must be restored immediately.
-- If public production routes are accidentally challenged, remove any broad destination and restore the application to only `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
+- Disable or delete `DTXWeb Pre-prod` if the hostname-wide gate breaks identity, posture, login, OAuth, or route behavior.
 
-Pre-production rollback:
+Production:
 
-- Disable or delete `DTXWeb Pre-prod` to restore the pre-production hostname.
+- Disable or delete `DTXWeb Production App` if `/app` or desktop login fails for the trusted operator device.
+- If any public production route is intercepted, disable the application, correct it back to exactly `/app` and `/app/*`, and rerun the full header matrix before re-enabling.
 
-If either API hostname receives an Access challenge, remove that hostname from the relevant Access application. Do not introduce service tokens as an emergency workaround.
+If either API hostname is intercepted, remove it from Access. Do not introduce service tokens as an emergency workaround.
 
-No Worker rollback or code deployment is required for these Access-only changes.
+No Worker rollback or code deployment is required for these dashboard-only changes.
 
 ## References
 
 - https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
 - https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
 - https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
+- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
 ```
 
 - [ ] **Step 2: Format-check the runbook**
@@ -187,9 +268,9 @@ Run:
 bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
 ```
 
-Expected: exits `0` with the runbook formatted correctly.
+Expected: exit `0`.
 
-If it reports formatting differences, run:
+If formatting differs:
 
 ```bash
 bunx prettier --write docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -198,7 +279,7 @@ bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust
 
 Expected: the second command exits `0`.
 
-- [ ] **Step 3: Confirm the documentation does not contain secret values**
+- [ ] **Step 3: Review the staged runbook for secrets and scope drift**
 
 Run:
 
@@ -206,7 +287,15 @@ Run:
 git diff -- docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
 ```
 
-Expected: the document contains only application names, hostnames, route paths, policy semantics, and operator instructions. It must not contain an actual personal email address, device serial number, token, cookie, or credential.
+Expected:
+
+- no actual operator email;
+- no device serial number;
+- no Access cookie/token;
+- rollout order is pre-production before production;
+- production destinations are only `/app` and `/app/*`;
+- `/tool/*` and `/game` are explicitly public in production;
+- API hostnames remain outside Access.
 
 - [ ] **Step 4: Commit the runbook**
 
@@ -217,7 +306,7 @@ git commit -m "docs: add Zero Trust web access runbook"
 
 ---
 
-### Task 2: Configure Production `/app` Access
+### Task 2: Configure And Prove Hostname-Wide Pre-production Access
 
 **Files:**
 
@@ -226,271 +315,242 @@ git commit -m "docs: add Zero Trust web access runbook"
 
 **Interfaces:**
 
-- Consumes: the existing Cloudflare zone for `dtx.hapadona.com`, the intended operator identity, and the trusted-device serial-number posture rule.
-- Produces: one Cloudflare Access application named `DTXWeb Production App` whose only protected production web destinations are `/app` and `/app/*`.
+- Consumes: the existing Zero Trust tenant, intended operator identity, trusted-device posture rule, and `pre-prod.dtx.hapadona.com` web hostname.
+- Produces: a verified `DTXWeb Pre-prod` Access application and a go/no-go decision for production.
 
-- [ ] **Step 1: Confirm the existing Perseus posture components are reusable**
+- [ ] **Step 1: Confirm the Perseus posture components are reusable**
 
-In Cloudflare Zero Trust, inspect the device posture rules/lists already used for Perseus.
+In Cloudflare Zero Trust, inspect the identity/policy and device posture resources used for Perseus.
 
 Expected:
 
-- the intended trusted-device serial-number posture rule is visible in the same Zero Trust account as the DTXWeb zone and can be selected by an Access policy; or
-- if the DTXWeb zone is in a different Zero Trust account, create an equivalent serial-number list and serial-number posture rule there before continuing.
+- the intended operator identity is known to the operator but not copied into git;
+- the serial-number posture rule is selectable in the DTXWeb Zero Trust account; or
+- if the zone is under another Zero Trust account, an equivalent serial list/posture rule is created there before continuing.
 
-Do not copy serial numbers into git, issue comments, PR descriptions, or terminal transcripts committed to the repo.
-
-- [ ] **Step 2: Create the production Access application**
+- [ ] **Step 2: Create `DTXWeb Pre-prod`**
 
 In **Zero Trust > Access controls > Applications**:
 
-1. Select **Create new application**.
-2. Select **Self-hosted and private**.
-3. Name the application `DTXWeb Production App`.
-4. Add public-hostname entries so the resulting protected destinations are exactly:
+1. Create a **Self-hosted and private** application.
+2. Name it `DTXWeb Pre-prod`.
+3. Add `pre-prod.dtx.hapadona.com` as the public hostname with no path.
+4. Set session duration to `12h`.
+5. Add the operator `Allow` policy and require the serial-number posture rule.
+6. Leave Service Auth, Managed OAuth, and instant authentication off.
+7. Save.
+
+Expected: every path on the pre-production web hostname is under this application; the pre-production API hostname is not.
+
+- [ ] **Step 3: Run the unauthenticated pre-production header matrix**
+
+Source the two shell helpers from the runbook, then run:
+
+```bash
+assert_access_redirect https://pre-prod.dtx.hapadona.com/
+assert_access_redirect https://pre-prod.dtx.hapadona.com/login
+assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
+assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
+assert_access_redirect https://pre-prod.dtx.hapadona.com/preview
+assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
+assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
+assert_access_redirect https://pre-prod.dtx.hapadona.com/game
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
+assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+```
+
+Expected: all commands exit `0`.
+
+If any command fails, disable/delete `DTXWeb Pre-prod` and stop before production.
+
+- [ ] **Step 4: Prove trusted-device pre-production login and OAuth**
+
+On the trusted WARP/Cloudflare One device with the configured operator identity:
+
+1. Enter `https://pre-prod.dtx.hapadona.com/` through Access.
+2. Open `/login` under the established Access session.
+3. Complete password login and confirm the existing app flow succeeds.
+4. Log out of Supabase while keeping the Access session.
+5. Complete Google login and confirm `/auth/callback` returns successfully under Access.
+6. Open `/app` and one API-backed page to confirm normal application behavior.
+
+Expected: Access remains the outer hostname gate and both existing Supabase login paths work behind it.
+
+- [ ] **Step 5: Prove posture denial on pre-production**
+
+From a device that does not satisfy the serial posture rule, request the pre-production hostname.
+
+Expected: Cloudflare denies access before DTXWeb loads.
+
+- [ ] **Step 6: Record the pre-production go/no-go**
+
+Proceed only if Steps 3-5 all pass. Otherwise roll back pre-production and stop this implementation before Task 3.
+
+---
+
+### Task 3: Configure Production `/app` And Prove The Route Boundary
+
+**Files:**
+
+- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- No source files modified.
+
+**Interfaces:**
+
+- Consumes: successful Task 2 verification and the same operator identity/posture semantics.
+- Produces: `DTXWeb Production App` with only `/app` and `/app/*`, plus deterministic evidence that public production routes were not captured.
+
+- [ ] **Step 1: Create the production Access application**
+
+In **Zero Trust > Access controls > Applications**:
+
+1. Create a **Self-hosted and private** application.
+2. Name it `DTXWeb Production App`.
+3. Add exactly:
 
 ```text
 dtx.hapadona.com/app
 dtx.hapadona.com/app/*
 ```
 
-5. Set session duration to `12h`.
-6. Add an `Allow` policy whose Include rule matches the intended operator identity/email and whose Require rule matches the trusted-device serial-number posture check.
-7. Do not add a Service Auth policy.
-8. Save the application.
+4. Set session duration to `12h`.
+5. Add the operator `Allow` policy and require the serial-number posture rule.
+6. Leave Service Auth, Managed OAuth, and instant authentication off.
+7. Save.
 
-Expected: there is no hostname-wide `dtx.hapadona.com` destination and no destination for any route outside `/app`.
+Expected: no hostname-wide production destination and no third destination.
 
-- [ ] **Step 3: Verify the unauthenticated production boundary**
-
-From a browser with no Access session, verify:
-
-```text
-https://dtx.hapadona.com/app        -> Cloudflare Access required
-https://dtx.hapadona.com/app/score  -> Cloudflare Access required
-https://dtx.hapadona.com/           -> no Cloudflare Access challenge
-https://dtx.hapadona.com/blog       -> no Cloudflare Access challenge
-https://dtx.hapadona.com/preview    -> no Cloudflare Access challenge
-https://dtx.hapadona.com/editor     -> no Cloudflare Access challenge
-https://dtx.hapadona.com/login      -> no Cloudflare Access challenge
-```
-
-Also request a representative `/auth/*` URL and confirm any response comes from DTXWeb rather than Cloudflare Access. A DTXWeb `404`, redirect, or application-specific response is acceptable; an Access login/challenge is not.
-
-- [ ] **Step 4: Verify the trusted production browser flow**
-
-Using the allowed identity on the trusted device:
-
-1. Open `https://dtx.hapadona.com/app` and pass Cloudflare Access.
-2. If the browser has no Supabase session, confirm DTXWeb redirects to `https://dtx.hapadona.com/login` without another Access challenge.
-3. Complete the existing Supabase login.
-4. Confirm the browser returns to `/app` and is accepted by the existing Access session.
-5. Sign out of Supabase and confirm this does not remove the Cloudflare Access boundary from `/app`.
-
-Expected: Cloudflare Access and Supabase remain two independent gates; public `/login` is not accidentally protected.
-
-- [ ] **Step 5: Verify production posture denial**
-
-From a device that does not satisfy the configured serial-number posture rule, request `https://dtx.hapadona.com/app`.
-
-Expected: Cloudflare denies access before the DTXWeb application loads.
-
----
-
-### Task 3: Configure Hostname-Wide Pre-production Access
-
-**Files:**
-
-- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No source files modified.
-
-**Interfaces:**
-
-- Consumes: the same intended operator identity and trusted-device posture semantics as production.
-- Produces: one Cloudflare Access application named `DTXWeb Pre-prod` protecting the entire `pre-prod.dtx.hapadona.com` web hostname.
-
-- [ ] **Step 1: Create the pre-production Access application**
-
-In **Zero Trust > Access controls > Applications**:
-
-1. Select **Create new application**.
-2. Select **Self-hosted and private**.
-3. Name the application `DTXWeb Pre-prod`.
-4. Add one public hostname for:
-
-```text
-pre-prod.dtx.hapadona.com
-```
-
-Do not enter a path restriction.
-
-5. Set session duration to `12h`.
-6. Add an `Allow` policy whose Include rule matches the intended operator identity/email and whose Require rule matches the trusted-device serial-number posture check.
-7. Do not add a Service Auth policy.
-8. Save the application.
-
-Expected: the entire pre-production web hostname is protected, including `/`, `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, `/app`, and future paths.
-
-- [ ] **Step 2: Verify the unauthenticated pre-production boundary**
-
-From a browser with no Access session, request each of:
-
-```text
-https://pre-prod.dtx.hapadona.com/
-https://pre-prod.dtx.hapadona.com/login
-https://pre-prod.dtx.hapadona.com/blog
-https://pre-prod.dtx.hapadona.com/preview
-https://pre-prod.dtx.hapadona.com/editor
-https://pre-prod.dtx.hapadona.com/app
-```
-
-Expected: every request is intercepted by Cloudflare Access before DTXWeb loads.
-
-- [ ] **Step 3: Verify the trusted pre-production auth flow**
-
-Using the allowed identity on the trusted device:
-
-1. Enter `https://pre-prod.dtx.hapadona.com/` through Cloudflare Access.
-2. Open `/login` under the same Access session.
-3. Complete the existing pre-production Supabase login/OAuth flow.
-4. Confirm the browser can return through the pre-production `/auth/*` callback and reach `/app` without being trapped in an Access/auth redirect loop.
-
-Expected: the hostname-wide Access session remains valid across the application login/OAuth flow.
-
-- [ ] **Step 4: Verify pre-production posture denial**
-
-From a device that does not satisfy the configured serial-number posture rule, request `https://pre-prod.dtx.hapadona.com/`.
-
-Expected: Cloudflare denies access before DTXWeb loads.
-
----
-
-### Task 4: Verify API And Desktop Boundaries
-
-**Files:**
-
-- Reference: `packages/dtx-web/wrangler.jsonc`
-- Reference: `packages/dtx-desktop/src/renderer/src/services/authService.ts`
-- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No source files modified.
-
-**Interfaces:**
-
-- Consumes: the two configured Access applications from Tasks 2 and 3.
-- Produces: evidence that browser-route protection did not introduce an Access dependency for GraphQL API clients or break the production desktop login entry flow.
-
-- [ ] **Step 1: Confirm both API hostnames remain outside Access**
-
-Run from a shell without Cloudflare Access credentials:
+- [ ] **Step 2: Run the protected production assertions**
 
 ```bash
-for url in \
-  https://api.dtx.hapadona.com \
-  https://api.pre-prod.dtx.hapadona.com; do
-  echo "=== $url ==="
-  curl -sS -o /dev/null -D - "$url" | sed -n '1,12p'
-done
-```
-
-Expected: neither response redirects to a `cloudflareaccess.com` Access login URL. A GraphQL/API-specific `200`, `4xx`, or redirect is acceptable; the purpose is only to confirm that Cloudflare Access is not intercepting the API hostname.
-
-If either API hostname is challenged by Access, stop and remove it from the Access application before proceeding. Do not add service tokens.
-
-- [ ] **Step 2: Verify the production desktop login browser boundary**
-
-Use the production desktop application and start its existing login flow.
-
-Expected sequence:
-
-```text
-desktop app
-  -> https://dtx.hapadona.com/login?redirect=desktop&desktop_callback=...
-     (public; no Access challenge)
-  -> existing Supabase login
-  -> https://dtx.hapadona.com/app?redirect=desktop&desktop_callback=...
-     (Cloudflare Access required if no valid Access session)
-  -> existing DTXWeb magic-link/deep-link callback
-  -> desktop app
-```
-
-Using the allowed identity on the trusted device, complete the flow and confirm the desktop receives its normal authenticated session.
-
-Expected: no API service token or desktop code change is required.
-
-- [ ] **Step 3: Re-run the complete route matrix from the runbook**
-
-Check every row in the runbook's Protection Matrix.
-
-Expected:
-
-- production `/app` only: protected;
-- production public routes: not protected;
-- pre-production web hostname: protected everywhere;
-- both APIs: not protected.
-
-Do not consider the implementation complete if any route falls into the wrong category.
-
----
-
-### Task 5: Final Repository And Rollback Check
-
-**Files:**
-
-- Verify: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- Verify: repository working tree
-
-**Interfaces:**
-
-- Consumes: the completed dashboard configuration and verification results.
-- Produces: a clean implementation branch containing documentation only, with the external Cloudflare configuration matching that documentation.
-
-- [ ] **Step 1: Confirm no application or deployment code changed**
-
-Run:
-
-```bash
-git status --short
-git diff --stat HEAD~1..HEAD
-```
-
-Expected: the implementation commit contains only the Zero Trust runbook. There must be no changes under `packages/dtx-web`, `packages/dtx-api`, `packages/dtx-desktop`, `.github/workflows`, or a new infrastructure package.
-
-- [ ] **Step 2: Run repository diff checks**
-
-Run:
-
-```bash
-git diff --check HEAD~1..HEAD
-bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+assert_access_redirect https://dtx.hapadona.com/app
+assert_access_redirect https://dtx.hapadona.com/app/score
 ```
 
 Expected: both commands exit `0`.
 
-- [ ] **Step 3: Confirm rollback instructions match the live configuration**
+- [ ] **Step 3: Run the full public production matrix**
 
-Read the runbook rollback section and verify the named Access applications are exactly:
-
-```text
-DTXWeb Production App
-DTXWeb Pre-prod
+```bash
+assert_no_access_redirect https://dtx.hapadona.com/
+assert_no_access_redirect https://dtx.hapadona.com/blog
+assert_no_access_redirect https://dtx.hapadona.com/preview
+assert_no_access_redirect https://dtx.hapadona.com/editor
+assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
+assert_no_access_redirect https://dtx.hapadona.com/game
+assert_no_access_redirect https://dtx.hapadona.com/login
+assert_no_access_redirect https://dtx.hapadona.com/auth/callback
 ```
 
-Expected: disabling/deleting those two applications is sufficient to remove the Access gates; no Worker or API deploy is required.
+Expected: every command exits `0`.
 
-- [ ] **Step 4: Final scope check**
+If any route shows an Access redirect, disable `DTXWeb Production App` immediately, correct the destination set, and rerun Steps 2-3 before continuing.
 
-Confirm all of the following are true before marking the work complete:
+- [ ] **Step 4: Prove the operator-only browser behavior**
 
-```text
-[production] dtx.hapadona.com/app      protected
-[production] dtx.hapadona.com/app/*    protected
-[production] other web routes          public to Access
-[pre-prod]   pre-prod.dtx.hapadona.com protected hostname-wide
-[API]        production API             public to Access
-[API]        pre-production API         public to Access
-[IaC]        none added
-[app code]   none changed
-[secrets]    none committed
+On the trusted operator device:
+
+1. Open `/app` and pass Access.
+2. With no Supabase session, confirm DTXWeb sends the browser to public `/login`.
+3. Complete Supabase login and confirm return to protected `/app` succeeds under the existing Access session.
+4. Sign out of Supabase and confirm `/app` remains Access-protected.
+
+Expected: Access and Supabase remain independent gates.
+
+Using a Supabase identity that is not the configured Access identity, confirm public `/login` does not grant entry to `/app`.
+
+Expected: the user is denied by Access on the `/app` return. This is intentional; do not widen the Access policy.
+
+- [ ] **Step 5: Prove production posture denial**
+
+From a device that fails the serial posture rule, request `https://dtx.hapadona.com/app`.
+
+Expected: denied before DTXWeb loads.
+
+---
+
+### Task 4: Verify Production Desktop Login, APIs, And Final Acceptance
+
+**Files:**
+
+- Reference: `packages/dtx-desktop/src/renderer/src/services/authService.ts`
+- Reference: `packages/dtx-web/src/routes/(login)/login/+page.svelte`
+- Reference: `packages/dtx-web/src/routes/(login)/login/+page.server.ts`
+- Reference: `packages/dtx-web/src/routes/auth/callback/+server.ts`
+- Reference: `packages/dtx-web/src/routes/(app)/app/+page.svelte`
+- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- No source files modified.
+
+**Interfaces:**
+
+- Consumes: verified pre-production and production Access applications.
+- Produces: final acceptance evidence for the desktop `/login -> /app -> callback` handoff and API exclusion.
+
+- [ ] **Step 1: Verify the bundled production desktop login flow**
+
+On the trusted operator device with the bundled desktop app:
+
+1. Start desktop login.
+2. Confirm the browser opens the public production `/login?redirect=desktop&desktop_callback=...` flow without an Access challenge on `/login`.
+3. Complete password login.
+4. Confirm the browser return to `/app?redirect=desktop...` passes Access.
+5. Confirm the generated magic link reaches `dtx://auth-callback` and the desktop session becomes authenticated.
+6. Repeat the flow with Google login.
+
+Expected: both password and Google desktop logins complete through protected `/app` for the trusted operator.
+
+- [ ] **Step 2: Verify the Tauri-development loopback handoff when available**
+
+With a `tauri dev` instance running on its configured loopback callback port:
+
+1. Start desktop login from that development instance.
+2. Keep the login and callback flow in the same browser tab.
+3. Complete password login and confirm `/app?redirect=desktop...` passes Access.
+4. Confirm the magic link returns to `http://127.0.0.1:<configured-port>/auth-callback`.
+5. Repeat with Google login if practical in the development environment.
+
+Expected: the loopback callback succeeds, proving the `/login` `sessionStorage` callback handoff survived the Access-gated return to `/app`.
+
+If this fails while bundled `dtx://` succeeds, disable the production Access application and investigate the handoff separately. Do not add an Access bypass in this slice.
+
+- [ ] **Step 3: Re-run both API exclusion assertions**
+
+```bash
+assert_no_access_redirect https://api.dtx.hapadona.com/
+assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
 ```
 
-Expected: every line matches the live Cloudflare configuration and repository diff.
+Expected: both commands exit `0`. The APIs may return their own redirect/error/status; they must not redirect into Cloudflare Access.
+
+- [ ] **Step 4: Re-run the production boundary spot check**
+
+```bash
+assert_access_redirect https://dtx.hapadona.com/app
+assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
+assert_no_access_redirect https://dtx.hapadona.com/game
+assert_no_access_redirect https://dtx.hapadona.com/login
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 5: Record final operator verification**
+
+In the implementation notes/PR checklist, record only non-sensitive outcomes:
+
+```text
+Pre-prod hostname-wide Access: PASS
+Pre-prod password + Google auth: PASS
+Prod /app + /app/* Access: PASS
+Prod public route matrix: PASS
+Prod bundled desktop login: PASS
+Prod tauri-dev loopback login: PASS or NOT RUN (environment unavailable)
+Prod + pre-prod API exclusion: PASS
+Untrusted-device posture denial: PASS
+```
+
+Do not paste cookies, JWTs, operator email addresses, device serial numbers, or screenshots containing those values.
+
+- [ ] **Step 6: Stop if any required acceptance check is red**
+
+Required checks are all lines above except the Tauri-development loopback line when no development instance is available. A required failure means disable the affected Access application and investigate separately; do not broaden routes or policies in this slice to force a green result.

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -2,539 +2,888 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make production DTXWeb `/app` and desktop login against deployed web environments operator-only behind Cloudflare Zero Trust, while protecting the entire pre-production web hostname and leaving the public production site plus both API hostnames outside Access.
+**Goal:** Manage DTXWeb Cloudflare Zero Trust Access declaratively with a small Pulumi package that protects all pre-production web traffic and only production `/app`, while reusing the existing Perseus device-posture rule.
 
-**Architecture:** Configure two manually managed Cloudflare Access self-hosted public-hostname applications. Roll out hostname-wide pre-production first; only after identity, posture, Supabase auth, and the verification harness are proven should production be scoped to exactly `/app` and `/app/*`. The checked-in runbook is the single executable source of truth for all matrices and manual checks; this plan references those sections instead of duplicating their command blocks.
+**Architecture:** Add an Access-only `packages/infrastructure` workspace modeled on the proven Perseus Pulumi implementation. One program serves exactly two stacks (`pre-prod` and `production`); stack name owns the immutable hostname/path scope, while Pulumi config supplies only the Cloudflare account ID, secret operator email, existing Perseus posture-rule ID, and optional session duration. Apply and verify pre-production first; production is a separate stack and is not applied until pre-production acceptance is green.
 
-**Tech Stack:** Cloudflare Zero Trust Access dashboard, Cloudflare One Client/WARP device posture, SvelteKit/Supabase existing authentication, Markdown operator documentation, `curl` header verification.
+**Tech Stack:** Bun workspaces/Turborepo, TypeScript, Pulumi `@pulumi/pulumi` `^3.144.0`, Pulumi Cloudflare provider `@pulumi/cloudflare` `^6.13.0`, Vitest `^4.0.18`, Cloudflare Zero Trust Access, Wrangler for existing Worker/API deployment.
 
 **Spec:** `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
 
 ## Global Constraints
 
-- Do not add Pulumi, Terraform, or another infrastructure-as-code system.
-- Do not add CI deployment for Zero Trust.
-- Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop` in this slice.
-- Production `/app` and desktop login against production are intentionally operator-only behind Access.
-- Production Access destinations must be exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
-- Production `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, `/auth/*`, and every intended public route outside `/app` remain outside Access.
-- Pre-production Access covers the entire `pre-prod.dtx.hapadona.com` hostname with no path bypass.
-- `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` remain outside Access.
-- Use an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check used for Perseus.
-- Use a `12h` Access session duration.
-- Reuse the existing Perseus identity-provider and instant-authentication mode; do not change instant authentication merely to simplify `curl` verification.
-- Verify the Access `Include` identity selector independently from the device-posture `Require` selector.
-- Do not create Service Auth, Managed OAuth, service tokens, or other Access credentials for API, desktop, E2E, CLI, or CI traffic.
-- Unattended E2E against the Access-protected pre-production hostname is unsupported by this slice.
-- Standalone desktop development that targets a deployed web hostname is subject to the same Access gate; the full local-stack `dev:local-web` path remains the non-operator development option.
-- Do not commit the operator email, device serial numbers, Access cookies, tokens, screenshots containing credentials, or other personal/security identifiers.
-- Configure and prove pre-production before creating the production Access application.
-- If verification reveals that application code must change for the approved model to work, stop and create a separate follow-up rather than widening this slice.
+- Pulumi owns only DTXWeb Cloudflare Access applications in this slice; Wrangler keeps ownership of Workers, API deployment, D1, R2, service bindings, runtime variables, and application secrets.
+- Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
+- Reuse the existing Perseus device-posture rule by Cloudflare resource ID; do not create a DTXWeb serial list or device-posture rule.
+- Do not add a Pulumi `StackReference` to Perseus.
+- Supported stack names are exactly `pre-prod` and `production`; any other stack must fail before registering resources.
+- Pre-production scope is code-owned and hostname-wide: `pre-prod.dtx.hapadona.com`.
+- Production scope is code-owned and exactly `dtx.hapadona.com/app` plus `dtx.hapadona.com/app/*`; production hostname/path destinations are not Pulumi config.
+- Keep `api.dtx.hapadona.com`, `api.pre-prod.dtx.hapadona.com`, and all intended public production routes outside Access.
+- The Access policy has one `allow` decision with the configured email in `includes` and the existing posture-rule ID in `requires`; default session duration is `12h`.
+- Reuse the hardened browser-application flags already proven in Perseus: `appLauncherVisible: false`, `allowAuthenticateViaWarp: false`, `enableBindingCookie: true`, `httpOnlyCookieAttribute: true`, `pathCookieAttribute: false`.
+- Do not add service tokens, Service Auth, CLI Access applications, Managed OAuth, Worker-side `CF_Authorization` validation, or unattended pre-production E2E credentials.
+- `accessEmail` is Pulumi secret config. `devicePostureRuleId` is plain config and must point to the Perseus-managed rule.
+- `Pulumi.<stack>.yaml`, `.pulumi/`, API tokens, operator email, device serials, Access cookies/JWTs, and screenshots containing security identifiers must not be committed.
+- Keep deployment operator-executed and local-backend-based for this slice; do not add GitHub Actions deployment.
+- Every operational `preview`, `up`, and `destroy` command must name its stack explicitly.
+- Run and prove `pre-prod` before applying `production`.
+- The checked-in runbook owns live route matrices, browser/desktop acceptance, and rollback commands; do not duplicate those matrices in future operational docs.
+- If runtime verification requires application/API/desktop code changes, stop and create a separate follow-up instead of expanding this slice.
 
 ---
 
-### Task 1: Add The Dedicated Zero Trust Operator Runbook
+### Task 1: Add The Infrastructure Workspace And Immutable Stack Definitions
 
 **Files:**
 
-- Create: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- Reference: `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
+- Modify: `package.json`
+- Modify: `bun.lock`
+- Create: `packages/infrastructure/.gitignore`
+- Create: `packages/infrastructure/Pulumi.yaml`
+- Create: `packages/infrastructure/package.json`
+- Create: `packages/infrastructure/tsconfig.json`
+- Create: `packages/infrastructure/vitest.config.ts`
+- Create: `packages/infrastructure/src/access.ts`
+- Create: `packages/infrastructure/src/access.test.ts`
 
 **Interfaces:**
 
-- Consumes: the approved protection matrix, rollout order, and product consequences from the design spec.
-- Produces: the single executable source of truth for dashboard configuration, HTTP helpers, route matrices, browser/desktop checks, known limitations, and rollback.
+- Produces: `AccessStackDefinition`, `getAccessStackDefinition(stackName)`, `normalizeAccessEmail(rawValue)`, and `normalizeDevicePostureRuleId(rawValue)` in `src/access.ts`.
+- Later tasks consume those exact helpers to build Pulumi application args and select the current stack.
 
-- [ ] **Step 1: Create the runbook**
+- [ ] **Step 1: Add the workspace/package scaffolding**
 
-Create `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` with:
+Add `packages/infrastructure` to the root `workspaces` array; do not add root deploy scripts yet.
 
-```markdown
-# Cloudflare Zero Trust Web Access Runbook
+Create `packages/infrastructure/package.json` with the same dependency floors currently working in Perseus:
 
-## Scope And Invariants
-
-DTXWeb uses manually managed Cloudflare Zero Trust Access for two web surfaces:
-
-| Application | Protected destination |
-| --- | --- |
-| `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
-| `DTXWeb Production App` | `dtx.hapadona.com/app` |
-| `DTXWeb Production App` | `dtx.hapadona.com/app/*` |
-
-Production `/app` and production desktop login are intentionally operator-only. The Access identity and trusted-device posture are an outer gate; Supabase remains the inner application-authentication gate.
-
-Production Access covers the intended private route family: exact `/app` and descendants under `/app/`. New private production pages MUST live under `/app`; a new private sibling such as `/studio` or `/admin` would be publicly reachable until this Access design is updated. `hooks.server.ts` currently uses the slightly broader `pathname.startsWith('/app')`; do not rely on that string-prefix quirk for new routes.
-
-A normal Supabase user may reach public `/login`, authenticate successfully, and then be denied when returning to `/app`. If they now hold a Supabase session, the server redirects `/login` back to `/app` and the only current sign-out UI is inside the protected `(app)` layout. The current recovery is to clear the Drumery/Supabase cookies for `dtx.hapadona.com`. A public `/logout` route or changing the authenticated `/login` redirect is a deferred product decision, not part of this dashboard-only slice.
-
-Standalone desktop development (`bun run dev:desktop`) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup that points to production, so the ordinary standalone `tauri dev` login is operator-only after this rollout. Pointing it at pre-production does not help a non-operator because pre-production is hostname-wide Access-protected. Non-operator contributors must use the full local stack (`bun run dev`, which uses `dtx-desktop#dev:local-web`) or a separately designed ungated development environment.
-
-The web E2E harness can override `PLAYWRIGHT_BASE_URL`, but this slice provides no non-interactive Access credential. Unattended E2E/CI against `pre-prod.dtx.hapadona.com` is therefore unsupported until a separate Access-authentication design is approved.
-
-This runbook is the durable Zero Trust source of truth. `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is precedent for human-executed Cloudflare operations but remains a historical API-migration checklist.
-
-## Required Policy
-
-Both Access applications use the same policy semantics:
-
-- Action: `Allow`
-- Include: the intended operator identity/email used for Perseus access
-- Require: the trusted-device serial-number posture check used for Perseus
-- Session duration: `12h`
-- Service Auth: none
-- Managed OAuth: off
-
-Reuse the existing Perseus identity provider and its current instant-authentication mode. Do not toggle instant authentication merely to make a header test easier.
-
-Before rollout, inspect a known protected Perseus route and identify its actual unauthenticated Access signal. The response can differ by client and device posture:
-
-- If it returns an Access or direct-IdP redirect, set an uncommitted regex that matches the `Location` value:
-
-  ```bash
-  export ACCESS_REDIRECT_RE='<regex matching the tenant Access redirect Location>'
-  ```
-
-  For the normal Cloudflare Access login page, a suitable value is:
-
-  ```bash
-  export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
-  ```
-
-- If it returns HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers, leave `ACCESS_REDIRECT_RE` unset. The helpers below recognize that Access-denial signal directly.
-
-If Perseus uses instant authentication, use the observed direct IdP redirect shape when a redirect is present. Keep one identity-provider and instant-authentication mode for the whole DTXWeb rollout.
-
-Never commit the operator email, device serial numbers, tenant-specific cookies/tokens, or other credentials.
-
-## Header Verification Helpers
-
-Use unauthenticated requests with no Access cookies. A request that fails DNS, connection, TLS, or timeout checks MUST fail the assertion instead of being interpreted as an unprotected route.
-
-```bash
-http_headers() {
-  url="$1"
-  raw="$(curl -sS --max-time 15 -o /dev/null -D - "$url")" || {
-    echo "FAIL: no HTTP response from $url" >&2
-    return 1
+```json
+{
+  "name": "@dtx/infrastructure",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "postinstall": "echo 'Skipping automatic pulumi install during dependency install'",
+    "pulumi:install": "command -v pulumi > /dev/null 2>&1 && pulumi install || echo 'Skipping pulumi install: Pulumi CLI not found'",
+    "pulumi:preview": "pulumi preview",
+    "pulumi:up": "pulumi up",
+    "pulumi:destroy": "pulumi destroy",
+    "pulumi:refresh": "pulumi refresh",
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.144.0",
+    "@pulumi/cloudflare": "^6.13.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.9.0",
+    "vitest": "^4.0.18"
   }
-
-  headers="$(printf '%s\n' "$raw" | tr -d '\r')"
-  printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ [0-9]{3}' || {
-    echo "FAIL: no HTTP status line from $url" >&2
-    return 1
-  }
-
-  printf '%s\n' "$headers"
-}
-
-has_access_interception() {
-  headers="$1"
-
-  if [ -n "${ACCESS_REDIRECT_RE:-}" ] &&
-    printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
-    return 0
-  fi
-
-  if printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
-    printf '%s\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
-    printf '%s\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
-    return 0
-  fi
-
-  return 1
-}
-
-assert_access_intercepted() {
-  url="$1"
-  headers="$(http_headers "$url")" || return 1
-  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\(aud\|domain\):/Ip'
-  has_access_interception "$headers" || {
-    echo "FAIL: Access did not intercept $url" >&2
-    return 1
-  }
-}
-
-assert_no_access_interception() {
-  url="$1"
-  headers="$(http_headers "$url")" || return 1
-  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\(aud\|domain\):/Ip'
-  if has_access_interception "$headers"; then
-    echo "FAIL: Access unexpectedly intercepted $url" >&2
-    return 1
-  fi
 }
 ```
 
-Dry-run the harness before changing DTXWeb:
+Create `Pulumi.yaml`:
 
-- `assert_access_intercepted` against a known protected Perseus URL must pass.
-- `assert_no_access_interception https://dtx.hapadona.com/` must pass before production Access exists.
-- `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` must fail non-zero.
+```yaml
+name: dtxweb-infrastructure
+runtime: nodejs
+description: DTXWeb Cloudflare Access infrastructure managed by Pulumi
+main: dist/index.js
+```
 
-Do not proceed until the invalid-host check fails loudly.
-
-## Rollout Order
-
-1. Confirm the Perseus IdP, instant-auth mode, operator identity, and serial posture rule.
-2. Dry-run the header helpers.
-3. Create and verify `DTXWeb Pre-prod`.
-4. Prove pre-production password login, Google OAuth, posture denial, and API non-interception.
-5. Stop and roll back if any required pre-production check fails.
-6. Create `DTXWeb Production App` with only `/app` and `/app/*`.
-7. Run the complete production matrix.
-8. Prove the Access identity selector and posture selector independently.
-9. Run production browser and desktop-login checks.
-10. Characterize expired Access behavior during SvelteKit client-side navigation.
-11. Record final non-sensitive results and deferred limitations.
-
-## Pre-production Configuration
-
-Create `DTXWeb Pre-prod` as **Self-hosted and private** for the entire public hostname:
+Create `.gitignore`:
 
 ```text
-pre-prod.dtx.hapadona.com
+Pulumi.*.yaml
+.pulumi/
+node_modules/
+dist/
+.env
+.env.local
 ```
 
-Set session duration to `12h`, attach the operator `Allow` policy with the serial-number posture requirement, and use the same IdP/instant-auth mode as Perseus. Do not add `api.pre-prod.dtx.hapadona.com`, Service Auth, Managed OAuth, or service tokens.
+Create `tsconfig.json` following Perseus:
 
-## Pre-production Verification Matrix
-
-Run the following with no Access session:
-
-```bash
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/login
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/auth/callback
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/blog
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/preview/1
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/editor
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/game
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/app
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/score
-assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/__data.json
-assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}
 ```
 
-Every command must exit `0`. If one fails, disable/delete `DTXWeb Pre-prod` and stop before production.
+Create `vitest.config.ts`:
 
-On the trusted operator device, complete both password login and Google OAuth behind the hostname-wide Access session and confirm an API-backed `/app` page works normally.
+```ts
+import { defineConfig } from 'vitest/config';
 
-From a device that fails the serial posture rule, confirm pre-production is denied before DTXWeb loads.
-
-## Production Configuration
-
-Only after all required pre-production checks pass, create `DTXWeb Production App` as **Self-hosted and private** with exactly:
-
-```text
-dtx.hapadona.com/app
-dtx.hapadona.com/app/*
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    requireAssertions: true
+  }
+});
 ```
-
-Set session duration to `12h`, attach the same operator `Allow` policy and serial posture requirement, and preserve the Perseus IdP/instant-auth mode. Do not add a hostname-wide production destination, public routes, Service Auth, Managed OAuth, or service tokens.
-
-## Production Header Matrix
-
-Run with no Access session:
-
-```bash
-assert_access_intercepted https://dtx.hapadona.com/app
-assert_access_intercepted https://dtx.hapadona.com/app/
-assert_access_intercepted https://dtx.hapadona.com/app/score
-assert_access_intercepted https://dtx.hapadona.com/app/__data.json
-
-assert_no_access_interception https://dtx.hapadona.com/
-assert_no_access_interception https://dtx.hapadona.com/blog
-assert_no_access_interception https://dtx.hapadona.com/preview/1
-assert_no_access_interception https://dtx.hapadona.com/editor
-assert_no_access_interception https://dtx.hapadona.com/tool/dtx-to-midi
-assert_no_access_interception https://dtx.hapadona.com/game
-assert_no_access_interception https://dtx.hapadona.com/login
-assert_no_access_interception https://dtx.hapadona.com/auth/callback
-assert_no_access_interception https://api.dtx.hapadona.com/
-assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
-```
-
-Every command must exit `0`. `/app/` is an explicit path-semantics probe; do not assume its behavior from the dashboard string alone. `/app/__data.json` proves SvelteKit data requests are inside the Access boundary. `/preview/1` exercises the real dynamic preview route instead of a 404 prefix.
-
-If any public route or API is intercepted, disable the production application, correct the destinations, and rerun this entire matrix before continuing.
-
-## Production Identity And Posture Verification
-
-Verify the two Access policy clauses independently:
-
-1. Configured operator identity on the trusted device: allowed.
-2. On that same trusted device, use a fresh browser profile/session and authenticate to Access with a second IdP identity that is NOT in the `Include` list: denied by Access.
-3. Configured operator identity from a device that fails the serial posture rule: denied by Access.
-
-A second Supabase account is not a substitute for check 2; the Access identity selector and Supabase session are separate gates.
-
-Do not claim the identity selector verified if no non-allowed IdP identity was actually exercised.
-
-## Trusted Production Browser Verification
-
-On the trusted operator device:
-
-1. Open `/app` and pass Access.
-2. With no Supabase session, confirm DTXWeb redirects to public `/login`.
-3. Complete Supabase login and confirm return to protected `/app` succeeds under the existing Access session.
-4. Sign out of Supabase and confirm `/app` remains Access-protected.
-
-Characterize the non-operator dead end separately:
-
-1. Use a Supabase account that does not correspond to the allowed Access identity.
-2. Authenticate on public `/login` and confirm the return to `/app` is denied by Access.
-3. Confirm revisiting `/login` with that Supabase session redirects back to `/app` and no public sign-out UI is reachable.
-4. Recover by clearing the production Drumery/Supabase cookies.
-
-Record this as a known limitation. Do not widen Access to make the non-operator account work.
-
-## Access Session Expiry / Client-side Navigation Check
-
-The root server layout has a server `load`, so client-side navigation uses SvelteKit data requests under paths such as `/app/__data.json`.
-
-On the trusted operator device with a valid Supabase session:
-
-1. Keep a browser tab on a public production page.
-2. End the Access session using the tenant's normal Access logout/session-clearing procedure so a new protected request requires Access again.
-3. Trigger a SvelteKit client-side navigation into `/app` without first doing a full-page protected navigation.
-4. Record what the UI shows when the framework data request encounters Access reauthentication.
-5. Navigate directly/reload `/app` and confirm the browser can complete Access reauthentication and recover.
-
-If client-side navigation shows an opaque fetch error but a direct `/app` reload recovers, document that UX as a deferred follow-up. Do not add a bypass. If the operator cannot recover with a direct browser navigation, disable the production Access application and investigate before acceptance.
-
-## Production Desktop Login Verification
-
-This is required because standalone desktop development against a deployed web environment also traverses the protected production `/app` handoff in the current operator setup.
-
-### Bundled desktop
-
-On the trusted operator device:
-
-1. Start desktop login and confirm public `/login?redirect=desktop&desktop_callback=...` loads without Access interception.
-2. Complete password login and confirm the return through protected `/app?redirect=desktop...` succeeds.
-3. Confirm the generated magic link reaches `dtx://auth-callback` and the desktop session authenticates.
-4. Repeat with Google login.
-
-### Standalone `tauri dev`
-
-Using the current standalone desktop-development setup:
-
-1. Start `bun run dev:desktop` and confirm the browser login target is the expected deployed production web hostname.
-2. Keep the login flow in the same browser tab so `/login` can preserve `desktop_callback` in `sessionStorage`.
-3. Complete password login and confirm protected `/app?redirect=desktop...` passes Access.
-4. Confirm the magic link reaches `http://127.0.0.1:<configured-port>/auth-callback`.
-5. Repeat with Google login.
-
-This check is required when the current `.env` points standalone desktop development at production. If the local operator configuration has deliberately changed, record the actual target and still verify the deployed-environment loopback flow before accepting production Access.
-
-The full local-stack `bun run dev` path is not an Access test: it uses `dev:local-web` and localhost intentionally.
-
-## Rollback
-
-Pre-production:
-
-- Disable/delete `DTXWeb Pre-prod` if the hostname-wide gate fails a required check.
-
-Production:
-
-- Disable/delete `DTXWeb Production App` if the trusted operator cannot use `/app`, cannot recover after Access reauthentication, or cannot complete required desktop login.
-- If a public route or API is intercepted, disable the production application, restore exactly `/app` and `/app/*`, and rerun the entire Production Header Matrix.
-
-Do not introduce service tokens, API Access, route bypasses, or policy widening as an emergency workaround.
-
-No Worker rollback or code deployment is required for these dashboard-only changes.
-
-## References
-
-- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
-- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
-- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
-- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
-- https://developers.cloudflare.com/learning-paths/clientless-access/customize-ux/login-page/
-```
-
-- [ ] **Step 2: Review scope/secrets and commit the runbook**
 
 Run:
 
 ```bash
-git diff -- docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+bun install
 ```
 
-Confirm:
+Expected: `bun.lock` updates and `@dtx/infrastructure` is recognized as a workspace.
 
-- no actual operator email, device serial, Access cookie, JWT, or token is present;
-- the invalid-host harness check fails loudly;
-- the runbook has exactly one pre-production matrix and one production matrix;
-- production destinations remain only `/app` and `/app/*`;
-- `/tool/*`, `/game`, `/preview/1`, `/login`, and `/auth/*` remain public in production;
-- both API hostnames remain outside Access;
-- standalone deployed-environment desktop development and non-operator recovery limitations are documented.
+- [ ] **Step 2: Write failing tests for stack scope and input validation**
 
-Commit:
+Create the first `src/access.test.ts` tests:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  getAccessStackDefinition,
+  normalizeAccessEmail,
+  normalizeDevicePostureRuleId
+} from './access.js';
+
+describe('getAccessStackDefinition', () => {
+  it('makes pre-prod hostname-wide', () => {
+    expect(getAccessStackDefinition('pre-prod')).toEqual({
+      applicationName: 'DTXWeb Pre-prod',
+      domain: 'pre-prod.dtx.hapadona.com',
+      destinations: [{ type: 'public', uri: 'pre-prod.dtx.hapadona.com' }]
+    });
+  });
+
+  it('makes production exactly /app plus /app/*', () => {
+    expect(getAccessStackDefinition('production')).toEqual({
+      applicationName: 'DTXWeb Production App',
+      domain: 'dtx.hapadona.com/app',
+      destinations: [
+        { type: 'public', uri: 'dtx.hapadona.com/app' },
+        { type: 'public', uri: 'dtx.hapadona.com/app/*' }
+      ]
+    });
+  });
+
+  it('rejects unsupported stacks before resource creation', () => {
+    expect(() => getAccessStackDefinition('dev')).toThrow(/Unsupported DTXWeb infrastructure stack/);
+  });
+});
+
+describe('Access config validation', () => {
+  it('normalizes one email address', () => {
+    expect(normalizeAccessEmail(' operator@example.com ')).toBe('operator@example.com');
+  });
+
+  it('rejects malformed or multiple emails', () => {
+    expect(() => normalizeAccessEmail('not-an-email')).toThrow(/single email address/);
+    expect(() => normalizeAccessEmail('a@example.com,b@example.com')).toThrow(/single email address/);
+  });
+
+  it('requires an existing posture-rule ID', () => {
+    expect(normalizeDevicePostureRuleId(' posture-rule-id ')).toBe('posture-rule-id');
+    expect(() => normalizeDevicePostureRuleId('   ')).toThrow(/devicePostureRuleId must not be empty/);
+  });
+});
+```
+
+- [ ] **Step 3: Run the focused tests and verify they fail**
+
+Run:
 
 ```bash
-git add docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-git commit -m "docs: add Zero Trust web access runbook"
+bun run --filter=@dtx/infrastructure test
 ```
 
-The repository's staged Markdown hook runs Prettier during the commit; do not add a separate format-only task unless the hook itself fails.
+Expected: FAIL because `src/access.ts` or the named exports do not exist yet.
+
+- [ ] **Step 4: Implement only the immutable stack model and validators**
+
+Create `src/access.ts` with these public interfaces and behavior:
+
+```ts
+const ACCESS_EMAIL_PATTERN = /^[^\s@,]+@[^\s@,]+\.[^\s@,]+$/;
+
+export interface AccessDestination {
+  type: 'public';
+  uri: string;
+}
+
+export interface AccessStackDefinition {
+  applicationName: string;
+  domain: string;
+  destinations: AccessDestination[];
+}
+
+const ACCESS_STACKS: Record<'pre-prod' | 'production', AccessStackDefinition> = {
+  'pre-prod': {
+    applicationName: 'DTXWeb Pre-prod',
+    domain: 'pre-prod.dtx.hapadona.com',
+    destinations: [{ type: 'public', uri: 'pre-prod.dtx.hapadona.com' }]
+  },
+  production: {
+    applicationName: 'DTXWeb Production App',
+    domain: 'dtx.hapadona.com/app',
+    destinations: [
+      { type: 'public', uri: 'dtx.hapadona.com/app' },
+      { type: 'public', uri: 'dtx.hapadona.com/app/*' }
+    ]
+  }
+};
+
+export function getAccessStackDefinition(stackName: string): AccessStackDefinition {
+  if (stackName !== 'pre-prod' && stackName !== 'production') {
+    throw new Error(`Unsupported DTXWeb infrastructure stack: ${stackName}`);
+  }
+  return ACCESS_STACKS[stackName];
+}
+
+export function normalizeAccessEmail(rawValue: string): string {
+  const value = rawValue.trim();
+  if (!ACCESS_EMAIL_PATTERN.test(value)) {
+    throw new Error('accessEmail must be a single email address');
+  }
+  return value;
+}
+
+export function normalizeDevicePostureRuleId(rawValue: string): string {
+  const value = rawValue.trim();
+  if (!value) throw new Error('devicePostureRuleId must not be empty');
+  return value;
+}
+```
+
+Do not make hostnames or destinations parameters.
+
+- [ ] **Step 5: Run the focused test/check cycle**
+
+Run:
+
+```bash
+bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the independently testable stack-model slice**
+
+```bash
+git add package.json bun.lock packages/infrastructure
+git commit -m "feat: scaffold DTXWeb Access infrastructure"
+```
 
 ---
 
-### Task 2: Configure And Prove Hostname-Wide Pre-production Access
+### Task 2: Build The Access Application Args And Pulumi Entrypoint
 
 **Files:**
 
-- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No source files modified.
+- Modify: `packages/infrastructure/src/access.ts`
+- Modify: `packages/infrastructure/src/access.test.ts`
+- Create: `packages/infrastructure/src/index.ts`
 
 **Interfaces:**
 
-- Consumes: the runbook's **Required Policy**, **Header Verification Helpers**, **Pre-production Configuration**, and **Pre-production Verification Matrix** sections.
-- Produces: a verified `DTXWeb Pre-prod` application and a hard go/no-go decision for production.
+- Consumes: `AccessStackDefinition`, `getAccessStackDefinition`, `normalizeAccessEmail`, and `normalizeDevicePostureRuleId` from Task 1.
+- Produces: `DEFAULT_ACCESS_SESSION_DURATION`, `ACCESS_APPLICATION_FLAGS`, `buildAccessPolicy(...)`, `buildAccessApplicationArgs(...)`, and `createAccessApplication(...)`.
+- `src/index.ts` is the only Pulumi program entrypoint and calls `getAccessStackDefinition(pulumi.getStack())` before creating resources.
 
-- [ ] **Step 1: Establish and validate the tenant-specific Access signal**
+- [ ] **Step 1: Add failing tests for the policy and application shape**
 
-Follow **Required Policy** and **Header Verification Helpers** from the runbook.
+Append focused tests to `src/access.test.ts`:
+
+```ts
+import {
+  ACCESS_APPLICATION_FLAGS,
+  DEFAULT_ACCESS_SESSION_DURATION,
+  buildAccessApplicationArgs,
+  buildAccessPolicy
+} from './access.js';
+
+it('builds one email + posture allow policy', () => {
+  expect(buildAccessPolicy(' operator@example.com ', ' posture-rule-id ')).toEqual({
+    name: 'Allow configured operator on trusted device',
+    decision: 'allow',
+    precedence: 1,
+    includes: [{ email: { email: 'operator@example.com' } }],
+    requires: [{ devicePosture: { integrationUid: 'posture-rule-id' } }]
+  });
+});
+
+it('builds the production application with the hardened defaults', () => {
+  const args = buildAccessApplicationArgs({
+    accountId: 'account-id',
+    stackDefinition: getAccessStackDefinition('production'),
+    accessEmail: 'operator@example.com',
+    devicePostureRuleId: 'posture-rule-id'
+  });
+
+  expect(args).toMatchObject({
+    accountId: 'account-id',
+    name: 'DTXWeb Production App',
+    type: 'self_hosted',
+    domain: 'dtx.hapadona.com/app',
+    destinations: [
+      { type: 'public', uri: 'dtx.hapadona.com/app' },
+      { type: 'public', uri: 'dtx.hapadona.com/app/*' }
+    ],
+    sessionDuration: DEFAULT_ACCESS_SESSION_DURATION,
+    ...ACCESS_APPLICATION_FLAGS
+  });
+});
+
+it('never builds hostname-wide production Access', () => {
+  const args = buildAccessApplicationArgs({
+    accountId: 'account-id',
+    stackDefinition: getAccessStackDefinition('production'),
+    accessEmail: 'operator@example.com',
+    devicePostureRuleId: 'posture-rule-id'
+  });
+
+  expect(args.destinations).not.toContainEqual({ type: 'public', uri: 'dtx.hapadona.com' });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify the new expectations fail**
+
+```bash
+bun run --filter=@dtx/infrastructure test
+```
+
+Expected: FAIL because the application/policy builders do not exist.
+
+- [ ] **Step 3: Implement the Pulumi-compatible builders and resource factory**
+
+Extend `src/access.ts` using the same provider shapes as Perseus:
+
+```ts
+import * as cloudflare from '@pulumi/cloudflare';
+import * as pulumi from '@pulumi/pulumi';
+
+export const DEFAULT_ACCESS_SESSION_DURATION = '12h';
+
+export const ACCESS_APPLICATION_FLAGS = {
+  appLauncherVisible: false,
+  allowAuthenticateViaWarp: false,
+  enableBindingCookie: true,
+  httpOnlyCookieAttribute: true,
+  pathCookieAttribute: false
+} as const;
+
+type AccessPolicy = cloudflare.types.input.ZeroTrustAccessApplicationPolicy;
+type AccessApplicationArgs = cloudflare.ZeroTrustAccessApplicationArgs;
+
+function normalizeAccessEmailInput(value: pulumi.Input<string>): pulumi.Input<string> {
+  return typeof value === 'string'
+    ? normalizeAccessEmail(value)
+    : pulumi.output(value).apply(normalizeAccessEmail);
+}
+
+export function buildAccessPolicy(
+  accessEmail: pulumi.Input<string>,
+  devicePostureRuleId: string
+): AccessPolicy {
+  return {
+    name: 'Allow configured operator on trusted device',
+    decision: 'allow',
+    precedence: 1,
+    includes: [{ email: { email: normalizeAccessEmailInput(accessEmail) } }],
+    requires: [
+      { devicePosture: { integrationUid: normalizeDevicePostureRuleId(devicePostureRuleId) } }
+    ]
+  };
+}
+
+export interface BuildAccessApplicationArgs {
+  accountId: string;
+  stackDefinition: AccessStackDefinition;
+  accessEmail: pulumi.Input<string>;
+  devicePostureRuleId: string;
+  sessionDuration?: string;
+}
+
+export function buildAccessApplicationArgs(args: BuildAccessApplicationArgs): AccessApplicationArgs {
+  if (!args.accountId.trim()) throw new Error('cloudflareAccountId must not be empty');
+
+  return {
+    accountId: args.accountId.trim(),
+    name: args.stackDefinition.applicationName,
+    type: 'self_hosted',
+    domain: args.stackDefinition.domain,
+    destinations: args.stackDefinition.destinations,
+    sessionDuration: args.sessionDuration ?? DEFAULT_ACCESS_SESSION_DURATION,
+    ...ACCESS_APPLICATION_FLAGS,
+    policies: [buildAccessPolicy(args.accessEmail, args.devicePostureRuleId)]
+  };
+}
+
+export function createAccessApplication(args: BuildAccessApplicationArgs) {
+  return new cloudflare.ZeroTrustAccessApplication(
+    'dtxweb-access-application',
+    buildAccessApplicationArgs(args)
+  );
+}
+```
+
+If the selected `@pulumi/cloudflare` version exposes a type spelling that differs from the currently working Perseus source, use the provider's current `ZeroTrustAccessApplicationArgs`/inline-policy types without changing the external behavior above. Do not switch to deprecated `AccessApplication` resources.
+
+- [ ] **Step 4: Add the Pulumi program entrypoint**
+
+Create `src/index.ts`:
+
+```ts
+import * as pulumi from '@pulumi/pulumi';
+import { createAccessApplication, getAccessStackDefinition } from './access.js';
+
+const config = new pulumi.Config();
+const stackDefinition = getAccessStackDefinition(pulumi.getStack());
+
+const application = createAccessApplication({
+  accountId: config.require('cloudflareAccountId'),
+  stackDefinition,
+  accessEmail: config.requireSecret('accessEmail'),
+  devicePostureRuleId: config.require('devicePostureRuleId'),
+  sessionDuration: config.get('accessSessionDuration') ?? undefined
+});
+
+export const accessApplicationId = application.id;
+```
+
+Do not create or look up the posture resource in this program.
+
+- [ ] **Step 5: Run the package and root static checks**
+
+```bash
+bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure build
+bun run check
+```
+
+Expected: all pass. The root `check` should discover the new workspace through the existing Turborepo `check` task without a `turbo.json` change.
+
+- [ ] **Step 6: Commit the Access resource implementation**
+
+```bash
+git add packages/infrastructure/src
+ git commit -m "feat: manage DTXWeb Access with Pulumi"
+```
+
+---
+
+### Task 3: Rewrite The Infrastructure README And Zero Trust Runbook For Pulumi
+
+**Files:**
+
+- Create: `packages/infrastructure/README.md`
+- Modify: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+
+**Interfaces:**
+
+- Consumes: the exact stack/config names from Tasks 1-2.
+- Produces: the single operator procedure for obtaining the Perseus posture-rule ID, configuring local stacks, previewing/applying Access, running acceptance, and rolling back one environment.
+
+- [ ] **Step 1: Write the infrastructure README with exact local setup commands**
+
+Document these prerequisites and commands without real identifiers:
+
+```bash
+cd packages/infrastructure
+pulumi login --local
+
+pulumi stack select pre-prod || pulumi stack init pre-prod
+pulumi stack select production || pulumi stack init production
+
+pulumi config set cloudflareAccountId "$CLOUDFLARE_ACCOUNT_ID" --stack pre-prod
+pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack pre-prod
+pulumi config set devicePostureRuleId "$PERSEUS_POSTURE_RULE_ID" --stack pre-prod
+
+pulumi config set cloudflareAccountId "$CLOUDFLARE_ACCOUNT_ID" --stack production
+pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack production
+pulumi config set devicePostureRuleId "$PERSEUS_POSTURE_RULE_ID" --stack production
+```
+
+Document that the optional duration override is:
+
+```bash
+pulumi config set accessSessionDuration 12h --stack pre-prod
+pulumi config set accessSessionDuration 12h --stack production
+```
+
+Document how to obtain the shared posture ID from the existing Perseus infrastructure stack:
+
+```bash
+pulumi stack output adminAccessDevicePostureRuleId
+```
+
+Run that command from the Perseus infrastructure project/stack that owns the current trusted-device posture rule; do not copy serial numbers into DTXWeb.
+
+Document the Cloudflare token requirement as an account-scoped token with `Access: Apps and Policies Write`, which is the Cloudflare API permission accepted for Access application/policy writes. Do not add permissions for Workers, D1, R2, service tokens, or device-posture writes for this DTXWeb package.
+
+- [ ] **Step 2: Replace dashboard configuration in the runbook with Pulumi preview/apply**
+
+Keep the existing hardened HTTP helper, pre-production route matrix, production route matrix, independent identity/posture checks, browser checks, desktop checks, session-expiry check, and known non-operator lockout.
+
+Replace the configuration sections with these named operations:
+
+```bash
+bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure build
+
+cd packages/infrastructure
+pulumi preview --stack pre-prod
+pulumi up --stack pre-prod
+```
+
+Then, only after pre-production acceptance is green:
+
+```bash
+pulumi preview --stack production
+pulumi up --stack production
+```
+
+State the preview acceptance criteria explicitly:
+
+- pre-prod preview: one `cloudflare:index/zeroTrustAccessApplication:ZeroTrustAccessApplication`, hostname-wide `pre-prod.dtx.hapadona.com`, no API hostname;
+- production preview: one Access application with exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` destinations;
+- hard stop if preview creates a device list, posture rule, service token, Worker/storage resource, API Access application, or hostname-wide production destination.
+
+- [ ] **Step 3: Rewrite rollback around stack-specific destroy previews**
+
+Use exactly:
+
+```bash
+pulumi preview --destroy --stack pre-prod
+pulumi destroy --stack pre-prod --yes
+```
+
+or:
+
+```bash
+pulumi preview --destroy --stack production
+pulumi destroy --stack production --yes
+```
+
+Before `destroy`, require the operator to confirm the preview deletes only the corresponding DTXWeb Access application. Do not use `pulumi stack rm` as rollback; retain stack/config state for a later re-apply.
+
+- [ ] **Step 4: Add secret/state hygiene checks**
+
+Run:
+
+```bash
+bunx prettier --check packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+git status --short
+git check-ignore packages/infrastructure/Pulumi.pre-prod.yaml packages/infrastructure/Pulumi.production.yaml packages/infrastructure/.pulumi
+```
 
 Expected:
 
-- current Perseus IdP/instant-auth mode is recorded for the operator session;
-- a known protected Perseus route is recognized by either the configured `ACCESS_REDIRECT_RE` or the `403` Access-header signal;
-- production `/` is recognized as currently unprotected;
-- the intentionally invalid hostname causes `http_headers` to exit non-zero.
+- formatting check passes;
+- stack config/state paths are ignored;
+- no operator email, device serial, API token, Access cookie/JWT, or Pulumi local state is staged.
 
-Do not create either DTXWeb Access application until the harness passes these checks.
+- [ ] **Step 5: Commit the Pulumi operator documentation**
 
-- [ ] **Step 2: Create `DTXWeb Pre-prod`**
-
-Follow **Pre-production Configuration** from the runbook exactly.
-
-Expected: the entire pre-production web hostname is protected and `api.pre-prod.dtx.hapadona.com` is not part of the application.
-
-- [ ] **Step 3: Execute the runbook's pre-production verification**
-
-Run the complete **Pre-production Verification Matrix** from the runbook, then perform its trusted-operator password/Google checks and failed-posture check.
-
-Expected: every required matrix command exits `0`; both Supabase login paths work behind Access; failed posture is denied.
-
-- [ ] **Step 4: Make the production go/no-go decision**
-
-Proceed only if Step 3 is fully green. Otherwise disable/delete `DTXWeb Pre-prod`, record the non-sensitive failure, and stop before production.
+```bash
+git add packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+git commit -m "docs: document Pulumi Access rollout"
+```
 
 ---
 
-### Task 3: Configure Production And Prove Both Access Policy Clauses
+### Task 4: Configure, Preview, Apply, And Prove Pre-production
 
 **Files:**
 
+- Reference: `packages/infrastructure/README.md`
 - Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No source files modified.
+- No tracked source files should change during stack configuration or apply.
 
 **Interfaces:**
 
-- Consumes: successful Task 2 verification plus the runbook's **Production Configuration**, **Production Header Matrix**, **Production Identity And Posture Verification**, **Trusted Production Browser Verification**, and **Access Session Expiry / Client-side Navigation Check** sections.
-- Produces: a path-scoped production Access application with route-boundary, identity, posture, and browser-session evidence.
+- Consumes: built infrastructure package plus local `pre-prod` Pulumi config containing `cloudflareAccountId`, secret `accessEmail`, and the existing Perseus `devicePostureRuleId`.
+- Produces: a verified hostname-wide `DTXWeb Pre-prod` Access application and a hard go/no-go for production.
 
-- [ ] **Step 1: Create `DTXWeb Production App`**
+- [ ] **Step 1: Establish local backend/config without committing it**
 
-Follow **Production Configuration** from the runbook exactly.
+Follow the README to log into the local backend and select/init `pre-prod`. Set the three required values using shell/environment values; never paste them into tracked Markdown or source.
 
-Expected: exactly two destinations exist: `/app` and `/app/*`.
+Verify:
 
-- [ ] **Step 2: Run the single production route matrix**
+```bash
+pulumi config --stack pre-prod
+```
 
-Execute the complete **Production Header Matrix** from the runbook.
+Expected: the three keys exist; `accessEmail` is displayed as a secret value.
 
-Expected: `/app`, `/app/`, `/app/score`, and `/app/__data.json` are intercepted; every public route and both API hostnames are not intercepted; every assertion has a real HTTP response.
+- [ ] **Step 2: Re-run the code gate immediately before preview**
 
-If any assertion fails, use the runbook's production rollback and do not continue.
+```bash
+bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure build
+```
 
-- [ ] **Step 3: Prove Access identity and device posture independently**
+Expected: PASS.
 
-Execute **Production Identity And Posture Verification** from the runbook.
+- [ ] **Step 3: Preview pre-production and inspect resource scope**
+
+```bash
+cd packages/infrastructure
+pulumi preview --stack pre-prod
+```
 
 Expected:
 
-- operator identity + trusted device: allowed;
-- non-allowed IdP identity on the same trusted device: denied;
-- operator identity on failed-posture device: denied.
+- exactly one DTXWeb-managed resource is created;
+- it is a `ZeroTrustAccessApplication` named `DTXWeb Pre-prod`;
+- its destination is hostname-wide `pre-prod.dtx.hapadona.com`;
+- no API hostname, posture/list, service token, Worker, or storage resource appears.
 
-A second Supabase account does not satisfy the non-allowed Access-identity check.
+If the preview differs, stop before `up` and fix the code/config.
 
-- [ ] **Step 4: Prove browser behavior and document the known non-operator dead end**
+- [ ] **Step 4: Apply pre-production**
 
-Execute **Trusted Production Browser Verification** from the runbook.
+```bash
+pulumi up --stack pre-prod
+```
 
-Expected: operator `/app -> /login -> /app` works; non-operator Supabase login reaches the intended Access denial; revisiting `/login` while still signed in reproduces the documented dead end; clearing production site cookies recovers the browser.
+Expected: one Access application created successfully.
 
-Do not treat the non-operator dead end as a reason to widen Access. The public logout/auth-guard change is deferred.
+- [ ] **Step 5: Execute the runbook's complete pre-production acceptance**
 
-- [ ] **Step 5: Characterize Access-session expiry during client navigation**
+Run the runbook's pre-production HTTP matrix with no Access session, then perform:
 
-Execute **Access Session Expiry / Client-side Navigation Check** from the runbook.
+- allowed operator identity on trusted posture;
+- password login behind Access;
+- Google OAuth behind Access;
+- API-backed app behavior;
+- failed-posture denial;
+- pre-production API non-interception.
 
-Expected: the observed client-side behavior is recorded, and a direct protected navigation/reload provides a usable reauthentication path for the operator. If direct recovery fails, roll back production and stop.
+Expected: every required check passes.
+
+- [ ] **Step 6: Enforce the go/no-go**
+
+If any required check fails:
+
+```bash
+pulumi preview --destroy --stack pre-prod
+pulumi destroy --stack pre-prod --yes
+```
+
+Confirm only `DTXWeb Pre-prod` is deleted, record the non-sensitive failure, and stop. Do not start Task 5.
+
+If all checks pass, record only `Pre-prod Access: PASS`-style outcomes in the PR/implementation notes; do not commit credentials or screenshots containing identifiers.
 
 ---
 
-### Task 4: Verify Production Desktop Development And Final Acceptance
+### Task 5: Preview, Apply, And Prove Production `/app`
 
 **Files:**
 
-- Reference: `packages/dtx-desktop/package.json`
-- Reference: `packages/dtx-desktop/src/renderer/src/services/authService.ts`
-- Reference: `packages/dtx-web/src/routes/(login)/login/+page.svelte`
-- Reference: `packages/dtx-web/src/routes/(login)/login/+page.server.ts`
-- Reference: `packages/dtx-web/src/routes/auth/callback/+server.ts`
-- Reference: `packages/dtx-web/src/routes/(app)/app/+page.svelte`
+- Reference: `packages/infrastructure/README.md`
 - Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No source files modified.
+- No tracked source files should change during production stack configuration or apply.
 
 **Interfaces:**
 
-- Consumes: verified pre-production and production Access applications.
-- Produces: final acceptance evidence for deployed-environment desktop auth plus the documented non-operator/local-development consequences.
+- Consumes: a fully green Task 4 and local `production` Pulumi config using the same operator identity semantics and Perseus posture-rule ID.
+- Produces: path-scoped production Access plus route, identity, posture, browser, session-expiry, and desktop evidence.
 
-- [ ] **Step 1: Run all production desktop checks from the runbook**
+- [ ] **Step 1: Configure/select production only after pre-production is green**
 
-Execute **Production Desktop Login Verification**, including both bundled `dtx://` and standalone `tauri dev` loopback flows against the deployed production web target used by the current operator setup.
+Follow the README to select/init `production` and set the required config. Verify:
 
-Expected: password and Google login succeed for the trusted operator in both required flows; the loopback callback survives the `/login` `sessionStorage` handoff through protected `/app`.
+```bash
+pulumi config --stack production
+```
 
-If the current ignored `.env` has deliberately changed away from production, record the actual target and still exercise a deployed-environment loopback flow before accepting production Access. The full local-stack `dev:local-web` path is not a substitute for this check.
+Expected: `cloudflareAccountId`, secret `accessEmail`, and `devicePostureRuleId` exist.
 
-- [ ] **Step 2: Re-run durable acceptance sections, not copied commands**
+- [ ] **Step 2: Preview production and reject any broadening**
 
-Re-run the runbook's **Production Header Matrix** and confirm Task 2's pre-production application remains enabled and usable.
+```bash
+pulumi preview --stack production
+```
 
-Expected: the single checked-in matrices still pass after the desktop verification; no public/API boundary drift occurred during troubleshooting.
+Expected:
 
-- [ ] **Step 3: Record final non-sensitive outcomes**
+- exactly one DTXWeb-managed Access application;
+- name `DTXWeb Production App`;
+- destinations exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`;
+- no hostname-wide `dtx.hapadona.com` destination;
+- no API hostname or additional Cloudflare resource type.
 
-Record only outcomes, for example:
+Any mismatch is a hard stop.
+
+- [ ] **Step 3: Apply production**
+
+```bash
+pulumi up --stack production
+```
+
+Expected: one production Access application created successfully.
+
+- [ ] **Step 4: Run the complete production route matrix**
+
+Execute the runbook's single production matrix.
+
+Expected protected/intercepted:
+
+- `/app`
+- `/app/`
+- `/app/score`
+- `/app/__data.json`
+
+Expected outside Access:
+
+- `/`
+- `/blog`
+- `/preview/1`
+- `/editor`
+- `/tool/dtx-to-midi`
+- `/game`
+- `/login`
+- `/auth/callback`
+- both API hostnames.
+
+Every assertion must prove a real HTTP response; DNS/connection/TLS/timeout failure is not a pass.
+
+- [ ] **Step 5: Prove the Access policy clauses independently**
+
+Follow the runbook exactly:
+
+1. configured operator identity + trusted device => allowed;
+2. non-allowed IdP identity on that same trusted device => denied by Access;
+3. configured operator identity on a device that fails the posture rule => denied by Access.
+
+Do not substitute a second Supabase identity for step 2.
+
+- [ ] **Step 6: Complete browser/session/non-operator acceptance**
+
+Verify:
+
+- operator `/app -> /login -> /app` works with Access as the outer gate and Supabase as the inner gate;
+- ending the Access session during SvelteKit client navigation into `/app` is characterized and direct `/app` navigation/reload provides a usable reauthentication path;
+- a signed-in non-operator reproduces the documented `/login -> /app` denial dead end and cookie clearing recovers the browser.
+
+If direct protected navigation cannot recover after Access reauthentication, rollback production and stop.
+
+- [ ] **Step 7: Complete bundled and standalone desktop authentication**
+
+On the trusted operator device verify both password and Google login for:
+
+- bundled desktop callback `dtx://auth-callback`;
+- standalone `bun run dev:desktop` loopback callback `http://127.0.0.1:<configured-port>/auth-callback` against the deployed production target used by the current local `.env`.
+
+The full-local-stack `bun run dev` / `dev:local-web` flow is not a substitute for this production Access test.
+
+- [ ] **Step 8: Roll back production on any required failure**
+
+```bash
+pulumi preview --destroy --stack production
+pulumi destroy --stack production --yes
+```
+
+Confirm the only deletion is `DTXWeb Production App`. Keep the verified pre-production stack intact for diagnosis.
+
+---
+
+### Task 6: Run Final Repository Verification And Record Non-sensitive Acceptance
+
+**Files:**
+
+- Modify only if needed for factual documentation corrections found during execution: `packages/infrastructure/README.md`, `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- Do not modify application/API/desktop source.
+
+**Interfaces:**
+
+- Consumes: successful Tasks 1-5.
+- Produces: final evidence that the codebase contains only the approved Access IaC/docs and that live environment acceptance matches the spec.
+
+- [ ] **Step 1: Run fresh infrastructure and repository checks**
+
+```bash
+bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure build
+bun run check
+bun run test
+```
+
+Expected: PASS. If an unrelated pre-existing repository failure appears, record it precisely rather than claiming a green repository.
+
+- [ ] **Step 2: Prove scope stayed out of application code**
+
+Run:
+
+```bash
+git diff --exit-code main...HEAD -- packages/dtx-web packages/dtx-api packages/dtx-desktop
+git status --short
+```
+
+Expected: no changes under the three application packages; no local Pulumi config/state or secrets appear as tracked/staged files.
+
+- [ ] **Step 3: Re-run both durable route-boundary checks after all troubleshooting**
+
+Re-run the runbook's pre-production and production HTTP matrices.
+
+Expected: both still pass; production public/API boundaries did not drift during browser/desktop troubleshooting.
+
+- [ ] **Step 4: Record only non-sensitive outcomes**
+
+Use a checklist like:
 
 ```text
-Header harness invalid-host failure: PASS
-Pre-prod hostname-wide Access: PASS
-Pre-prod password + Google auth: PASS
-Prod /app + /app/* Access: PASS
-Prod public/API matrix: PASS
-Prod Access identity selector: PASS
-Prod posture selector: PASS
-Prod operator browser auth: PASS
-Prod non-operator lockout characterized: PASS
-Prod expired-session client navigation characterized: PASS
-Prod bundled desktop login: PASS
-Prod standalone tauri-dev loopback login: PASS
+Infrastructure unit tests/typecheck/build: PASS
+Pre-prod preview scope: PASS
+Pre-prod Access acceptance: PASS
+Production preview exact /app scope: PASS
+Production public/API matrix: PASS
+Production Access identity selector: PASS
+Production posture selector: PASS
+Production operator browser auth: PASS
+Production expired-session recovery characterized: PASS
+Production non-operator lockout characterized: PASS
+Production bundled desktop auth: PASS
+Production tauri-dev loopback auth: PASS
 ```
 
-Do not paste cookies, JWTs, IdP identities, operator email addresses, device serial numbers, or screenshots containing those values.
+Do not record operator email, posture-rule ID, account ID, cookies/JWTs, API tokens, or device serials.
 
-- [ ] **Step 4: Stop if a required acceptance check is red**
+- [ ] **Step 5: Commit only factual doc corrections, if execution required them**
 
-A required failure means follow the environment-specific rollback in the runbook and investigate separately. Do not broaden routes/policies, add a service token, or change application code inside this slice merely to force a green result.
+If no documentation changed, do not create an empty commit.
+
+If the runbook/README needed factual corrections discovered during live execution:
+
+```bash
+git add packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+git commit -m "docs: refine Zero Trust rollout guidance"
+```
+
+The implementation is complete only when fresh verification evidence exists for the final tracked code and the final live Access state.

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -2,43 +2,48 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Manage DTXWeb Cloudflare Zero Trust Access declaratively with a small Pulumi package that protects all pre-production web traffic and only production `/app`, while reusing the existing Perseus device-posture rule.
+**Goal:** Add a CI-covered, Access-only Pulumi package that declaratively defines DTXWeb pre-production and production Cloudflare Access applications while reusing the existing Perseus device-posture rule.
 
-**Architecture:** Add an Access-only `packages/infrastructure` workspace modeled on the proven Perseus Pulumi implementation. One program serves exactly two stacks (`pre-prod` and `production`); stack name owns the immutable hostname/path scope, while Pulumi config supplies only the Cloudflare account ID, secret operator email, existing Perseus posture-rule ID, and optional session duration. Apply and verify pre-production first; production is a separate stack and is not applied until pre-production acceptance is green.
+**Architecture:** Add `@dtx/infrastructure` as a normal Drumery workspace, wire it into the existing fail-closed affected-scope and coverage CI, and model the security-sensitive Access shape with pure TypeScript builders plus one Pulumi resource factory. Stack name owns immutable scope: `pre-prod` is hostname-wide and `production` is exactly `/app` plus `/app/*`. This implementation plan stops at tested code, rewritten operator docs, and Pulumi preview evidence; live `pulumi up`, browser/device acceptance, and `pulumi destroy` are operator-only runbook actions.
 
-**Tech Stack:** Bun workspaces/Turborepo, TypeScript, Pulumi `@pulumi/pulumi` `^3.144.0`, Pulumi Cloudflare provider `@pulumi/cloudflare` `^6.13.0`, Vitest `^4.0.18`, Cloudflare Zero Trust Access, Wrangler for existing Worker/API deployment.
+**Tech Stack:** Bun workspaces/Turborepo, TypeScript `^5.8.3`, Vitest `^3.1.4`, `@vitest/coverage-v8` `^3.0.0`, `@types/node` `^20.11.25`, Pulumi `@pulumi/pulumi` `^3.144.0`, Pulumi Cloudflare provider `@pulumi/cloudflare` `^6.13.0`, Cloudflare Zero Trust Access, Wrangler for existing Worker/API deployment.
 
 **Spec:** `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
 
 ## Global Constraints
 
-- Pulumi owns only DTXWeb Cloudflare Access applications in this slice; Wrangler keeps ownership of Workers, API deployment, D1, R2, service bindings, runtime variables, and application secrets.
+- Pulumi owns only DTXWeb Cloudflare Access applications in this slice; Wrangler keeps ownership of Workers, API deployment, D1, R2, service bindings, routes, runtime variables, and application secrets.
 - Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
-- Reuse the existing Perseus device-posture rule by Cloudflare resource ID; do not create a DTXWeb serial list or device-posture rule.
+- Reuse the existing Perseus device-posture rule by Cloudflare resource ID; do not create a DTXWeb serial list or posture rule.
 - Do not add a Pulumi `StackReference` to Perseus.
-- Supported stack names are exactly `pre-prod` and `production`; any other stack must fail before registering resources.
+- Supported stack names are exactly `pre-prod` and `production`; any other stack must fail before resource registration.
 - Pre-production scope is code-owned and hostname-wide: `pre-prod.dtx.hapadona.com`.
-- Production scope is code-owned and exactly `dtx.hapadona.com/app` plus `dtx.hapadona.com/app/*`; production hostname/path destinations are not Pulumi config.
-- Keep `api.dtx.hapadona.com`, `api.pre-prod.dtx.hapadona.com`, and all intended public production routes outside Access.
-- The Access policy has one `allow` decision with the configured email in `includes` and the existing posture-rule ID in `requires`; default session duration is `12h`.
-- Reuse the hardened browser-application flags already proven in Perseus: `appLauncherVisible: false`, `allowAuthenticateViaWarp: false`, `enableBindingCookie: true`, `httpOnlyCookieAttribute: true`, `pathCookieAttribute: false`.
-- Do not add service tokens, Service Auth, CLI Access applications, Managed OAuth, Worker-side `CF_Authorization` validation, or unattended pre-production E2E credentials.
-- `accessEmail` is Pulumi secret config. `devicePostureRuleId` is plain config and must point to the Perseus-managed rule.
-- `Pulumi.<stack>.yaml`, `.pulumi/`, API tokens, operator email, device serials, Access cookies/JWTs, and screenshots containing security identifiers must not be committed.
-- Keep deployment operator-executed and local-backend-based for this slice; do not add GitHub Actions deployment.
-- Every operational `preview`, `up`, and `destroy` command must name its stack explicitly.
-- Run and prove `pre-prod` before applying `production`.
-- The checked-in runbook owns live route matrices, browser/desktop acceptance, and rollback commands; do not duplicate those matrices in future operational docs.
-- If runtime verification requires application/API/desktop code changes, stop and create a separate follow-up instead of expanding this slice.
+- Production scope is code-owned and exactly `dtx.hapadona.com/app` plus `dtx.hapadona.com/app/*`; hostname/path destinations are not Pulumi config.
+- Keep both API hostnames and all intended public production routes outside Access.
+- The Access policy has one `allow` decision with configured email in `includes` and the existing posture-rule ID in `requires`; default session duration is `12h`.
+- Reuse the hardened browser-application flags proven in Perseus: `appLauncherVisible: false`, `allowAuthenticateViaWarp: false`, `enableBindingCookie: true`, `httpOnlyCookieAttribute: true`, `pathCookieAttribute: false`.
+- Do not add service tokens, Service Auth, CLI Access applications, Managed OAuth, Worker-side Access JWT validation, or unattended pre-production E2E credentials.
+- `accessEmail` is Pulumi secret config. `devicePostureRuleId` is plain config pointing to the Perseus-managed rule.
+- Do not commit Pulumi stack config, Pulumi state exports, API tokens, operator email, device serials, Access cookies/JWTs, or sensitive screenshots.
+- Keep deployment operator-executed and local-backend-based; do not add GitHub Actions deployment.
+- Do not add unscoped `pulumi:up`, `pulumi:destroy`, or `pulumi:preview` package scripts.
+- Every operational Pulumi command in docs names its stack explicitly.
+- Run/prove pre-production before production.
+- The checked-in runbook is the single live operator source of truth; do not duplicate its route matrices in this plan.
+- **Do not execute `pulumi up` or `pulumi destroy` from this implementation plan.**
+- If runtime verification requires application/API/desktop code changes, stop and create a separate follow-up.
 
 ---
 
-### Task 1: Add The Infrastructure Workspace And Immutable Stack Definitions
+### Task 1: Add The Infrastructure Workspace And Wire It Into Fail-Closed CI
 
 **Files:**
 
 - Modify: `package.json`
 - Modify: `bun.lock`
+- Modify: `.github/scripts/ci-affected-scope.sh`
+- Modify: `.github/scripts/ci-affected-scope.test.sh`
+- Create: `.github/scripts/fixtures/turbo-infrastructure.json`
 - Create: `packages/infrastructure/.gitignore`
 - Create: `packages/infrastructure/Pulumi.yaml`
 - Create: `packages/infrastructure/package.json`
@@ -49,14 +54,68 @@
 
 **Interfaces:**
 
-- Produces: `AccessStackDefinition`, `getAccessStackDefinition(stackName)`, `normalizeAccessEmail(rawValue)`, and `normalizeDevicePostureRuleId(rawValue)` in `src/access.ts`.
-- Later tasks consume those exact helpers to build Pulumi application args and select the current stack.
+- Produces workspace `@dtx/infrastructure` with `build`, `check`, `test`, `test:coverage`, and `test:watch` scripts.
+- Produces CI identity `@dtx/infrastructure:packages/infrastructure` and marks that package as unit-test-affecting.
+- Produces `AccessStackDefinition`, `getAccessStackDefinition(stackName)`, `normalizeAccessEmail(rawValue)`, and `normalizeDevicePostureRuleId(rawValue)` in `src/access.ts`.
 
-- [ ] **Step 1: Add the workspace/package scaffolding**
+- [ ] **Step 1: Add a failing affected-scope fixture/test for infrastructure-only changes**
 
-Add `packages/infrastructure` to the root `workspaces` array; do not add root deploy scripts yet.
+Create `.github/scripts/fixtures/turbo-infrastructure.json`:
 
-Create `packages/infrastructure/package.json` with the same dependency floors currently working in Perseus:
+```json
+{"packageManager":"bun","packages":{"count":1,"items":[{"name":"@dtx/infrastructure","path":"packages/infrastructure"}]}}
+```
+
+Add these cases beside the existing web/e2e cases in `.github/scripts/ci-affected-scope.test.sh`:
+
+```bash
+run_expected infrastructure-only-unit unit turbo-infrastructure.json true packages/infrastructure/src/change.ts infrastructure
+run_expected infrastructure-only-lint lint turbo-infrastructure.json true packages/infrastructure/src/change.ts infrastructure
+```
+
+- [ ] **Step 2: Run the affected-scope contract and verify it fails closed**
+
+Run:
+
+```bash
+.github/scripts/ci-affected-scope.test.sh
+```
+
+Expected: FAIL at the new infrastructure case with the detector reporting an unknown package.
+
+- [ ] **Step 3: Extend the detector allowlist and unit gate**
+
+In `.github/scripts/ci-affected-scope.sh`, extend the package allowlist with:
+
+```bash
+'@dtx/infrastructure:packages/infrastructure' | \
+```
+
+Add `@dtx/infrastructure` to the `unit_affected=true` package-name case:
+
+```bash
+case "$package_name" in
+  '@dtx/common' | '@dtx/ui-components' | '@dtx/infrastructure' | dtx-api | dtx-desktop | dtx-web)
+    unit_affected=true
+    ;;
+esac
+```
+
+Do not weaken the unknown-package fail-closed branch.
+
+- [ ] **Step 4: Re-run the detector tests**
+
+```bash
+.github/scripts/ci-affected-scope.test.sh
+```
+
+Expected: all affected-scope tests pass, including infrastructure `unit => true` and `lint => true`.
+
+- [ ] **Step 5: Add workspace/package scaffolding using Drumery's JS test toolchain**
+
+Add `packages/infrastructure` to root `workspaces`.
+
+Create `packages/infrastructure/package.json`:
 
 ```json
 {
@@ -66,29 +125,27 @@ Create `packages/infrastructure/package.json` with the same dependency floors cu
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "postinstall": "echo 'Skipping automatic pulumi install during dependency install'",
-    "pulumi:install": "command -v pulumi > /dev/null 2>&1 && pulumi install || echo 'Skipping pulumi install: Pulumi CLI not found'",
-    "pulumi:preview": "pulumi preview",
-    "pulumi:up": "pulumi up",
-    "pulumi:destroy": "pulumi destroy",
-    "pulumi:refresh": "pulumi refresh",
     "check": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest --run",
+    "test:coverage": "vitest --run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@pulumi/pulumi": "^3.144.0",
-    "@pulumi/cloudflare": "^6.13.0"
+    "@pulumi/cloudflare": "^6.13.0",
+    "@pulumi/pulumi": "^3.144.0"
   },
   "devDependencies": {
-    "@types/node": "^22.10.0",
-    "typescript": "^5.9.0",
-    "vitest": "^4.0.18"
+    "@types/node": "^20.11.25",
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
   }
 }
 ```
 
-Create `Pulumi.yaml`:
+Do not copy Perseus's Vitest 4, TypeScript 5.9, Node types 22, or unscoped Pulumi scripts.
+
+Create `packages/infrastructure/Pulumi.yaml`:
 
 ```yaml
 name: dtxweb-infrastructure
@@ -97,7 +154,7 @@ description: DTXWeb Cloudflare Access infrastructure managed by Pulumi
 main: dist/index.js
 ```
 
-Create `.gitignore`:
+Create `packages/infrastructure/.gitignore`:
 
 ```text
 Pulumi.*.yaml
@@ -108,7 +165,7 @@ dist/
 .env.local
 ```
 
-Create `tsconfig.json` following Perseus:
+Create `packages/infrastructure/tsconfig.json`:
 
 ```json
 {
@@ -132,7 +189,7 @@ Create `tsconfig.json` following Perseus:
 }
 ```
 
-Create `vitest.config.ts`:
+Create `packages/infrastructure/vitest.config.ts`:
 
 ```ts
 import { defineConfig } from 'vitest/config';
@@ -152,11 +209,11 @@ Run:
 bun install
 ```
 
-Expected: `bun.lock` updates and `@dtx/infrastructure` is recognized as a workspace.
+Expected: `bun.lock` updates and Bun recognizes `@dtx/infrastructure` as a workspace.
 
-- [ ] **Step 2: Write failing tests for stack scope and input validation**
+- [ ] **Step 6: Write failing tests for immutable stack scope and config validation**
 
-Create the first `src/access.test.ts` tests:
+Create `packages/infrastructure/src/access.test.ts`:
 
 ```ts
 import { describe, expect, it } from 'vitest';
@@ -169,6 +226,7 @@ import {
 describe('getAccessStackDefinition', () => {
   it('makes pre-prod hostname-wide', () => {
     expect(getAccessStackDefinition('pre-prod')).toEqual({
+      stackName: 'pre-prod',
       applicationName: 'DTXWeb Pre-prod',
       domain: 'pre-prod.dtx.hapadona.com',
       destinations: [{ type: 'public', uri: 'pre-prod.dtx.hapadona.com' }]
@@ -177,6 +235,7 @@ describe('getAccessStackDefinition', () => {
 
   it('makes production exactly /app plus /app/*', () => {
     expect(getAccessStackDefinition('production')).toEqual({
+      stackName: 'production',
       applicationName: 'DTXWeb Production App',
       domain: 'dtx.hapadona.com/app',
       destinations: [
@@ -196,7 +255,7 @@ describe('Access config validation', () => {
     expect(normalizeAccessEmail(' operator@example.com ')).toBe('operator@example.com');
   });
 
-  it('rejects malformed or multiple emails', () => {
+  it('rejects malformed and multiple emails', () => {
     expect(() => normalizeAccessEmail('not-an-email')).toThrow(/single email address/);
     expect(() => normalizeAccessEmail('a@example.com,b@example.com')).toThrow(/single email address/);
   });
@@ -208,19 +267,17 @@ describe('Access config validation', () => {
 });
 ```
 
-- [ ] **Step 3: Run the focused tests and verify they fail**
-
-Run:
+- [ ] **Step 7: Run the focused unit tests and verify they fail**
 
 ```bash
 bun run --filter=@dtx/infrastructure test
 ```
 
-Expected: FAIL because `src/access.ts` or the named exports do not exist yet.
+Expected: FAIL because `src/access.ts` or its exports do not exist.
 
-- [ ] **Step 4: Implement only the immutable stack model and validators**
+- [ ] **Step 8: Implement the immutable stack model and validators**
 
-Create `src/access.ts` with these public interfaces and behavior:
+Create `packages/infrastructure/src/access.ts`:
 
 ```ts
 const ACCESS_EMAIL_PATTERN = /^[^\s@,]+@[^\s@,]+\.[^\s@,]+$/;
@@ -231,18 +288,21 @@ export interface AccessDestination {
 }
 
 export interface AccessStackDefinition {
+  stackName: 'pre-prod' | 'production';
   applicationName: string;
   domain: string;
   destinations: AccessDestination[];
 }
 
-const ACCESS_STACKS: Record<'pre-prod' | 'production', AccessStackDefinition> = {
+const ACCESS_STACKS: Record<AccessStackDefinition['stackName'], AccessStackDefinition> = {
   'pre-prod': {
+    stackName: 'pre-prod',
     applicationName: 'DTXWeb Pre-prod',
     domain: 'pre-prod.dtx.hapadona.com',
     destinations: [{ type: 'public', uri: 'pre-prod.dtx.hapadona.com' }]
   },
   production: {
+    stackName: 'production',
     applicationName: 'DTXWeb Production App',
     domain: 'dtx.hapadona.com/app',
     destinations: [
@@ -274,29 +334,28 @@ export function normalizeDevicePostureRuleId(rawValue: string): string {
 }
 ```
 
-Do not make hostnames or destinations parameters.
+Hostnames/destinations must remain internal constants, not function parameters.
 
-- [ ] **Step 5: Run the focused test/check cycle**
-
-Run:
+- [ ] **Step 9: Run the package and CI contract checks**
 
 ```bash
-bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure test:coverage
 bun run --filter=@dtx/infrastructure check
+.github/scripts/ci-affected-scope.test.sh
 ```
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit the independently testable stack-model slice**
+- [ ] **Step 10: Commit the independently testable workspace/CI slice**
 
 ```bash
-git add package.json bun.lock packages/infrastructure
+git add package.json bun.lock .github/scripts packages/infrastructure
 git commit -m "feat: scaffold DTXWeb Access infrastructure"
 ```
 
 ---
 
-### Task 2: Build The Access Application Args And Pulumi Entrypoint
+### Task 2: Build The Perseus-shaped Access Application And Pulumi Entrypoint
 
 **Files:**
 
@@ -306,13 +365,13 @@ git commit -m "feat: scaffold DTXWeb Access infrastructure"
 
 **Interfaces:**
 
-- Consumes: `AccessStackDefinition`, `getAccessStackDefinition`, `normalizeAccessEmail`, and `normalizeDevicePostureRuleId` from Task 1.
-- Produces: `DEFAULT_ACCESS_SESSION_DURATION`, `ACCESS_APPLICATION_FLAGS`, `buildAccessPolicy(...)`, `buildAccessApplicationArgs(...)`, and `createAccessApplication(...)`.
-- `src/index.ts` is the only Pulumi program entrypoint and calls `getAccessStackDefinition(pulumi.getStack())` before creating resources.
+- Consumes: `AccessStackDefinition`, `getAccessStackDefinition`, `normalizeAccessEmail`, `normalizeDevicePostureRuleId`.
+- Produces: `DEFAULT_ACCESS_SESSION_DURATION`, `ACCESS_APPLICATION_FLAGS`, `buildAccessPolicy(...)`, `buildAccessApplicationArgs(...)`, `createAccessApplication(...)`.
+- `src/index.ts` is the only Pulumi entrypoint.
 
-- [ ] **Step 1: Add failing tests for the policy and application shape**
+- [ ] **Step 1: Write failing tests for the policy and application shape**
 
-Extend the existing import from `./access.js` with these names rather than adding a second import later in the file:
+Extend the import in `access.test.ts`:
 
 ```ts
 import {
@@ -326,7 +385,7 @@ import {
 } from './access.js';
 ```
 
-Add these focused tests:
+Add:
 
 ```ts
 it('builds one email + posture allow policy', () => {
@@ -339,7 +398,7 @@ it('builds one email + posture allow policy', () => {
   });
 });
 
-it('builds the production application with the hardened defaults', () => {
+it('builds production with exact destinations and hardened defaults', () => {
   const args = buildAccessApplicationArgs({
     accountId: 'account-id',
     stackDefinition: getAccessStackDefinition('production'),
@@ -359,20 +418,11 @@ it('builds the production application with the hardened defaults', () => {
     sessionDuration: DEFAULT_ACCESS_SESSION_DURATION,
     ...ACCESS_APPLICATION_FLAGS
   });
-});
-
-it('never builds hostname-wide production Access', () => {
-  const args = buildAccessApplicationArgs({
-    accountId: 'account-id',
-    stackDefinition: getAccessStackDefinition('production'),
-    accessEmail: 'operator@example.com',
-    devicePostureRuleId: 'posture-rule-id'
-  });
 
   expect(args.destinations).not.toContainEqual({ type: 'public', uri: 'dtx.hapadona.com' });
 });
 
-it('rejects an empty Cloudflare account ID before deployment', () => {
+it('rejects a blank Cloudflare account ID', () => {
   expect(() =>
     buildAccessApplicationArgs({
       accountId: '   ',
@@ -384,17 +434,17 @@ it('rejects an empty Cloudflare account ID before deployment', () => {
 });
 ```
 
-- [ ] **Step 2: Run the tests and verify the new expectations fail**
+- [ ] **Step 2: Run tests and verify the new expectations fail**
 
 ```bash
 bun run --filter=@dtx/infrastructure test
 ```
 
-Expected: FAIL because the application/policy builders do not exist.
+Expected: FAIL because the Access builders/constants do not exist.
 
-- [ ] **Step 3: Implement the Pulumi-compatible builders and resource factory**
+- [ ] **Step 3: Implement the policy/application builders**
 
-Extend `src/access.ts` using the same provider shapes as Perseus:
+Extend `access.ts`:
 
 ```ts
 import * as cloudflare from '@pulumi/cloudflare';
@@ -413,6 +463,12 @@ export const ACCESS_APPLICATION_FLAGS = {
 type AccessPolicy = cloudflare.types.input.ZeroTrustAccessApplicationPolicy;
 type AccessApplicationArgs = cloudflare.ZeroTrustAccessApplicationArgs;
 
+function normalizeAccountId(rawValue: string): string {
+  const value = rawValue.trim();
+  if (!value) throw new Error('cloudflareAccountId must not be empty');
+  return value;
+}
+
 function normalizeAccessEmailInput(value: pulumi.Input<string>): pulumi.Input<string> {
   return typeof value === 'string'
     ? normalizeAccessEmail(value)
@@ -429,7 +485,11 @@ export function buildAccessPolicy(
     precedence: 1,
     includes: [{ email: { email: normalizeAccessEmailInput(accessEmail) } }],
     requires: [
-      { devicePosture: { integrationUid: normalizeDevicePostureRuleId(devicePostureRuleId) } }
+      {
+        devicePosture: {
+          integrationUid: normalizeDevicePostureRuleId(devicePostureRuleId)
+        }
+      }
     ]
   };
 }
@@ -442,34 +502,36 @@ export interface BuildAccessApplicationArgs {
   sessionDuration?: string;
 }
 
-export function buildAccessApplicationArgs(args: BuildAccessApplicationArgs): AccessApplicationArgs {
-  if (!args.accountId.trim()) throw new Error('cloudflareAccountId must not be empty');
-
+export function buildAccessApplicationArgs(
+  args: BuildAccessApplicationArgs
+): AccessApplicationArgs {
   return {
-    accountId: args.accountId.trim(),
+    accountId: normalizeAccountId(args.accountId),
     name: args.stackDefinition.applicationName,
     type: 'self_hosted',
     domain: args.stackDefinition.domain,
     destinations: args.stackDefinition.destinations,
-    sessionDuration: args.sessionDuration ?? DEFAULT_ACCESS_SESSION_DURATION,
+    sessionDuration: args.sessionDuration?.trim() || DEFAULT_ACCESS_SESSION_DURATION,
     ...ACCESS_APPLICATION_FLAGS,
     policies: [buildAccessPolicy(args.accessEmail, args.devicePostureRuleId)]
   };
 }
 
-export function createAccessApplication(args: BuildAccessApplicationArgs) {
+export function createAccessApplication(
+  args: BuildAccessApplicationArgs
+): cloudflare.ZeroTrustAccessApplication {
   return new cloudflare.ZeroTrustAccessApplication(
-    'dtxweb-access-application',
+    `dtxweb-${args.stackDefinition.stackName}-access`,
     buildAccessApplicationArgs(args)
   );
 }
 ```
 
-The current Pulumi Cloudflare v6 resource is `ZeroTrustAccessApplication` and supports `destinations`, `policies`, `domain`, and `sessionDuration`. If dependency resolution installs a later compatible v6 release, keep this non-deprecated resource and the external behavior above; do not switch to deprecated `AccessApplication` resources.
+Do not add list/posture/token resources.
 
-- [ ] **Step 4: Add the Pulumi program entrypoint**
+- [ ] **Step 4: Add the Pulumi entrypoint**
 
-Create `src/index.ts`:
+Create `packages/infrastructure/src/index.ts`:
 
 ```ts
 import * as pulumi from '@pulumi/pulumi';
@@ -478,430 +540,184 @@ import { createAccessApplication, getAccessStackDefinition } from './access.js';
 const config = new pulumi.Config();
 const stackDefinition = getAccessStackDefinition(pulumi.getStack());
 
-const application = createAccessApplication({
+const accessApplication = createAccessApplication({
   accountId: config.require('cloudflareAccountId'),
   stackDefinition,
   accessEmail: config.requireSecret('accessEmail'),
   devicePostureRuleId: config.require('devicePostureRuleId'),
-  sessionDuration: config.get('accessSessionDuration') ?? undefined
+  sessionDuration: config.get('accessSessionDuration')
 });
 
-export const accessApplicationId = application.id;
+export const accessApplicationId = accessApplication.id;
 ```
 
-Do not create or look up the posture resource in this program.
+Stack validation must happen before `createAccessApplication`.
 
-- [ ] **Step 5: Run the package and root static checks**
-
-```bash
-bun run --filter=@dtx/infrastructure test
-bun run --filter=@dtx/infrastructure check
-bun run --filter=@dtx/infrastructure build
-bun run check
-```
-
-Expected: all pass. The root `check` should discover the new workspace through the existing Turborepo `check` task without a `turbo.json` change.
-
-- [ ] **Step 6: Commit the Access resource implementation**
+- [ ] **Step 5: Run focused and package-wide verification**
 
 ```bash
-git add packages/infrastructure/src
-git commit -m "feat: manage DTXWeb Access with Pulumi"
-```
-
----
-
-### Task 3: Rewrite The Infrastructure README And Zero Trust Runbook For Pulumi
-
-**Files:**
-
-- Create: `packages/infrastructure/README.md`
-- Modify: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-
-**Interfaces:**
-
-- Consumes: the exact stack/config names from Tasks 1-2.
-- Produces: the single operator procedure for obtaining the Perseus posture-rule ID, configuring local stacks, previewing/applying Access, running acceptance, and rolling back one environment.
-
-- [ ] **Step 1: Write the infrastructure README with exact local setup commands**
-
-Document these prerequisites and commands without real identifiers:
-
-```bash
-cd packages/infrastructure
-pulumi login --local
-
-pulumi stack select pre-prod || pulumi stack init pre-prod
-pulumi stack select production || pulumi stack init production
-
-pulumi config set cloudflareAccountId "$CLOUDFLARE_ACCOUNT_ID" --stack pre-prod
-pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack pre-prod
-pulumi config set devicePostureRuleId "$PERSEUS_POSTURE_RULE_ID" --stack pre-prod
-
-pulumi config set cloudflareAccountId "$CLOUDFLARE_ACCOUNT_ID" --stack production
-pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack production
-pulumi config set devicePostureRuleId "$PERSEUS_POSTURE_RULE_ID" --stack production
-```
-
-Document that the optional duration override is:
-
-```bash
-pulumi config set accessSessionDuration 12h --stack pre-prod
-pulumi config set accessSessionDuration 12h --stack production
-```
-
-Document how to obtain the shared posture ID from the existing Perseus infrastructure stack:
-
-```bash
-pulumi stack output adminAccessDevicePostureRuleId
-```
-
-Run that command from the Perseus infrastructure project/stack that owns the current trusted-device posture rule; do not copy serial numbers into DTXWeb.
-
-Document the Cloudflare token requirement as an account-scoped token with `Access: Apps and Policies Write`, which Cloudflare currently accepts for Access application and application-policy writes. Do not add permissions for Workers, D1, R2, service tokens, or device-posture writes for this DTXWeb package.
-
-- [ ] **Step 2: Replace dashboard configuration in the runbook with Pulumi preview/apply**
-
-Keep the existing hardened HTTP helper, pre-production route matrix, production route matrix, independent identity/posture checks, browser checks, desktop checks, session-expiry check, and known non-operator lockout.
-
-Replace the configuration sections with these named operations:
-
-```bash
-bun run --filter=@dtx/infrastructure test
-bun run --filter=@dtx/infrastructure check
-bun run --filter=@dtx/infrastructure build
-
-cd packages/infrastructure
-pulumi preview --stack pre-prod
-pulumi up --stack pre-prod
-```
-
-Then, only after pre-production acceptance is green:
-
-```bash
-pulumi preview --stack production
-pulumi up --stack production
-```
-
-State the preview acceptance criteria explicitly:
-
-- pre-prod preview: one `cloudflare:index/zeroTrustAccessApplication:ZeroTrustAccessApplication`, hostname-wide `pre-prod.dtx.hapadona.com`, no API hostname;
-- production preview: one Access application with exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` destinations;
-- hard stop if preview creates a device list, posture rule, service token, Worker/storage resource, API Access application, or hostname-wide production destination.
-
-- [ ] **Step 3: Rewrite rollback around stack-specific destroy previews**
-
-Use exactly:
-
-```bash
-pulumi preview --destroy --stack pre-prod
-pulumi destroy --stack pre-prod --yes
-```
-
-or:
-
-```bash
-pulumi preview --destroy --stack production
-pulumi destroy --stack production --yes
-```
-
-Before `destroy`, require the operator to confirm the preview deletes only the corresponding DTXWeb Access application. Do not use `pulumi stack rm` as rollback; retain stack/config state for a later re-apply.
-
-- [ ] **Step 4: Add secret/state hygiene checks**
-
-Run:
-
-```bash
-bunx prettier --check packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-git status --short
-git check-ignore packages/infrastructure/Pulumi.pre-prod.yaml packages/infrastructure/Pulumi.production.yaml packages/infrastructure/.pulumi
-```
-
-Expected:
-
-- formatting check passes;
-- stack config/state paths are ignored;
-- no operator email, device serial, API token, Access cookie/JWT, or Pulumi local state is staged.
-
-- [ ] **Step 5: Commit the Pulumi operator documentation**
-
-```bash
-git add packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-git commit -m "docs: document Pulumi Access rollout"
-```
-
----
-
-### Task 4: Configure, Preview, Apply, And Prove Pre-production
-
-**Files:**
-
-- Reference: `packages/infrastructure/README.md`
-- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No tracked source files should change during stack configuration or apply.
-
-**Interfaces:**
-
-- Consumes: built infrastructure package plus local `pre-prod` Pulumi config containing `cloudflareAccountId`, secret `accessEmail`, and the existing Perseus `devicePostureRuleId`.
-- Produces: a verified hostname-wide `DTXWeb Pre-prod` Access application and a hard go/no-go for production.
-
-- [ ] **Step 1: Establish local backend/config without committing it**
-
-Follow the README to log into the local backend and select/init `pre-prod`. Set the three required values using shell/environment values; never paste them into tracked Markdown or source.
-
-Verify:
-
-```bash
-pulumi config --stack pre-prod
-```
-
-Expected: the three keys exist; `accessEmail` is displayed as a secret value.
-
-- [ ] **Step 2: Re-run the code gate immediately before preview**
-
-```bash
-bun run --filter=@dtx/infrastructure test
+bun run --filter=@dtx/infrastructure test:coverage
 bun run --filter=@dtx/infrastructure check
 bun run --filter=@dtx/infrastructure build
 ```
 
 Expected: PASS.
 
-- [ ] **Step 3: Preview pre-production and inspect resource scope**
+If the selected Cloudflare provider typings differ from the working Perseus shape, verify the current provider API before adapting names; do not redesign the policy semantics.
+
+- [ ] **Step 6: Run the existing root unit-coverage command**
+
+```bash
+bun run test:coverage
+```
+
+Expected: the existing workspace coverage suite runs and includes `@dtx/infrastructure` rather than silently skipping it.
+
+- [ ] **Step 7: Commit the Access resource slice**
+
+```bash
+git add packages/infrastructure
+
+git commit -m "feat: define DTXWeb Cloudflare Access apps"
+```
+
+---
+
+### Task 3: Finalize Operator Documentation And Produce Non-mutating Preview Evidence
+
+**Files:**
+
+- Create: `packages/infrastructure/README.md`
+- Review/modify if implementation details require it: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+
+**Interfaces:**
+
+- Consumes the implemented `@dtx/infrastructure` package and the already rewritten operator runbook.
+- Produces repository-local setup documentation plus pre-prod/production preview evidence.
+- Produces **no live Cloudflare mutation**.
+
+- [ ] **Step 1: Write the infrastructure README**
+
+Document:
+
+- this package owns only DTXWeb Access applications;
+- Workers/API/storage remain on Wrangler;
+- supported stacks are exactly `pre-prod` and `production`;
+- DTXWeb consumes the Perseus `adminAccessDevicePostureRuleId` as config;
+- `pulumi login --local` defaults to state under `~/.pulumi`;
+- stack config files are local/ignored;
+- Cloudflare token requires `Access: Apps and Policies Write` for application lifecycle;
+- package scripts are test/build/check only;
+- live commands are taken from the operator runbook and always specify `--stack`;
+- emergency provider-side deletion is documented only in the runbook.
+
+Do not duplicate the full route matrices from the runbook.
+
+- [ ] **Step 2: Validate the runbook against the implemented package**
+
+Review `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` and confirm its config keys exactly match code:
+
+```text
+cloudflareAccountId
+accessEmail
+devicePostureRuleId
+accessSessionDuration
+```
+
+Confirm it remains marked operator-executed and owns every `pulumi up`, `pulumi destroy`, browser/device check, and dashboard emergency fallback.
+
+If the implementation changed no interface, make no gratuitous runbook edit.
+
+- [ ] **Step 3: Run the complete non-live repository verification**
+
+```bash
+bun install --frozen-lockfile
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure test:coverage
+bun run --filter=@dtx/infrastructure build
+.github/scripts/ci-affected-scope.test.sh
+bun run test:coverage
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run Pulumi previews only when authenticated local config is available**
+
+If the operator/development environment already has the Cloudflare API token plus DTXWeb stack config, run:
 
 ```bash
 cd packages/infrastructure
 pulumi preview --stack pre-prod
-```
-
-Expected:
-
-- exactly one DTXWeb-managed resource is created;
-- it is a `ZeroTrustAccessApplication` named `DTXWeb Pre-prod`;
-- its destination is hostname-wide `pre-prod.dtx.hapadona.com`;
-- no API hostname, posture/list, service token, Worker, or storage resource appears.
-
-If the preview differs, stop before `up` and fix the code/config.
-
-- [ ] **Step 4: Apply pre-production**
-
-```bash
-pulumi up --stack pre-prod
-```
-
-Expected: one Access application created successfully.
-
-- [ ] **Step 5: Execute the runbook's complete pre-production acceptance**
-
-Run the runbook's pre-production HTTP matrix with no Access session, then perform:
-
-- allowed operator identity on trusted posture;
-- password login behind Access;
-- Google OAuth behind Access;
-- API-backed app behavior;
-- failed-posture denial;
-- pre-production API non-interception.
-
-Expected: every required check passes.
-
-- [ ] **Step 6: Enforce the go/no-go**
-
-If any required check fails:
-
-```bash
-pulumi preview --destroy --stack pre-prod
-pulumi destroy --stack pre-prod --yes
-```
-
-Confirm only `DTXWeb Pre-prod` is deleted, record the non-sensitive failure, and stop. Do not start Task 5.
-
-If all checks pass, record only `Pre-prod Access: PASS`-style outcomes in the PR/implementation notes; do not commit credentials or screenshots containing identifiers.
-
----
-
-### Task 5: Preview, Apply, And Prove Production `/app`
-
-**Files:**
-
-- Reference: `packages/infrastructure/README.md`
-- Reference: `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- No tracked source files should change during production stack configuration or apply.
-
-**Interfaces:**
-
-- Consumes: a fully green Task 4 and local `production` Pulumi config using the same operator identity semantics and Perseus posture-rule ID.
-- Produces: path-scoped production Access plus route, identity, posture, browser, session-expiry, and desktop evidence.
-
-- [ ] **Step 1: Configure/select production only after pre-production is green**
-
-Follow the README to select/init `production` and set the required config. Verify:
-
-```bash
-pulumi config --stack production
-```
-
-Expected: `cloudflareAccountId`, secret `accessEmail`, and `devicePostureRuleId` exist.
-
-- [ ] **Step 2: Preview production and reject any broadening**
-
-```bash
 pulumi preview --stack production
 ```
 
-Expected:
+Expected pre-prod preview:
 
-- exactly one DTXWeb-managed Access application;
-- name `DTXWeb Production App`;
+- one DTXWeb Access application;
+- hostname-wide `pre-prod.dtx.hapadona.com`;
+- existing posture-rule reference;
+- no API/list/posture/token/Worker/storage resource.
+
+Expected production preview:
+
+- one `DTXWeb Production App`;
 - destinations exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`;
-- no hostname-wide `dtx.hapadona.com` destination;
-- no API hostname or additional Cloudflare resource type.
+- no hostname-wide production destination;
+- no API/list/posture/token/Worker/storage resource.
 
-Any mismatch is a hard stop.
+If authenticated config is unavailable, record the previews as `NOT RUN — operator credentials/config required`; do not manufacture config values or ask for secrets in PR comments.
 
-- [ ] **Step 3: Apply production**
+**Do not run `pulumi up` or `pulumi destroy`.**
 
-```bash
-pulumi up --stack production
-```
-
-Expected: one production Access application created successfully.
-
-- [ ] **Step 4: Run the complete production route matrix**
-
-Execute the runbook's single production matrix.
-
-Expected protected/intercepted:
-
-- `/app`
-- `/app/`
-- `/app/score`
-- `/app/__data.json`
-
-Expected outside Access:
-
-- `/`
-- `/blog`
-- `/preview/1`
-- `/editor`
-- `/tool/dtx-to-midi`
-- `/game`
-- `/login`
-- `/auth/callback`
-- both API hostnames.
-
-Every assertion must prove a real HTTP response; DNS/connection/TLS/timeout failure is not a pass.
-
-- [ ] **Step 5: Prove the Access policy clauses independently**
-
-Follow the runbook exactly:
-
-1. configured operator identity + trusted device => allowed;
-2. non-allowed IdP identity on that same trusted device => denied by Access;
-3. configured operator identity on a device that fails the posture rule => denied by Access.
-
-Do not substitute a second Supabase identity for step 2.
-
-- [ ] **Step 6: Complete browser/session/non-operator acceptance**
-
-Verify:
-
-- operator `/app -> /login -> /app` works with Access as the outer gate and Supabase as the inner gate;
-- ending the Access session during SvelteKit client navigation into `/app` is characterized and direct `/app` navigation/reload provides a usable reauthentication path;
-- a signed-in non-operator reproduces the documented `/login -> /app` denial dead end and cookie clearing recovers the browser.
-
-If direct protected navigation cannot recover after Access reauthentication, rollback production and stop.
-
-- [ ] **Step 7: Complete bundled and standalone desktop authentication**
-
-On the trusted operator device verify both password and Google login for:
-
-- bundled desktop callback `dtx://auth-callback`;
-- standalone `bun run dev:desktop` loopback callback `http://127.0.0.1:<configured-port>/auth-callback` against the deployed production target used by the current local `.env`.
-
-The full-local-stack `bun run dev` / `dev:local-web` flow is not a substitute for this production Access test.
-
-- [ ] **Step 8: Roll back production on any required failure**
-
-```bash
-pulumi preview --destroy --stack production
-pulumi destroy --stack production --yes
-```
-
-Confirm the only deletion is `DTXWeb Production App`. Keep the verified pre-production stack intact for diagnosis.
-
----
-
-### Task 6: Run Final Repository Verification And Record Non-sensitive Acceptance
-
-**Files:**
-
-- Modify only if needed for factual documentation corrections found during execution: `packages/infrastructure/README.md`, `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- Do not modify application/API/desktop source.
-
-**Interfaces:**
-
-- Consumes: successful Tasks 1-5.
-- Produces: final evidence that the codebase contains only the approved Access IaC/docs and that live environment acceptance matches the spec.
-
-- [ ] **Step 1: Run fresh infrastructure and repository checks**
-
-```bash
-bun run --filter=@dtx/infrastructure test
-bun run --filter=@dtx/infrastructure check
-bun run --filter=@dtx/infrastructure build
-bun run check
-bun run test
-```
-
-Expected: PASS. If an unrelated pre-existing repository failure appears, record it precisely rather than claiming a green repository.
-
-- [ ] **Step 2: Prove scope stayed out of application code**
-
-Run:
-
-```bash
-git diff --exit-code main...HEAD -- packages/dtx-web packages/dtx-api packages/dtx-desktop
-git status --short
-```
-
-Expected: no changes under the three application packages; no local Pulumi config/state or secrets appear as tracked/staged files.
-
-- [ ] **Step 3: Re-run both durable route-boundary checks after all troubleshooting**
-
-Re-run the runbook's pre-production and production HTTP matrices.
-
-Expected: both still pass; production public/API boundaries did not drift during browser/desktop troubleshooting.
-
-- [ ] **Step 4: Record only non-sensitive outcomes**
-
-Use a checklist like:
-
-```text
-Infrastructure unit tests/typecheck/build: PASS
-Pre-prod preview scope: PASS
-Pre-prod Access acceptance: PASS
-Production preview exact /app scope: PASS
-Production public/API matrix: PASS
-Production Access identity selector: PASS
-Production posture selector: PASS
-Production operator browser auth: PASS
-Production expired-session recovery characterized: PASS
-Production non-operator lockout characterized: PASS
-Production bundled desktop auth: PASS
-Production tauri-dev loopback auth: PASS
-```
-
-Do not record operator email, posture-rule ID, account ID, cookies/JWTs, API tokens, or device serials.
-
-- [ ] **Step 5: Commit only factual doc corrections, if execution required them**
-
-If no documentation changed, do not create an empty commit.
-
-If the runbook/README needed factual corrections discovered during live execution:
+- [ ] **Step 5: Commit documentation/preview-ready state**
 
 ```bash
 git add packages/infrastructure/README.md docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-git commit -m "docs: refine Zero Trust rollout guidance"
+git commit -m "docs: document DTXWeb Access operations"
 ```
 
-The implementation is complete only when fresh verification evidence exists for the final tracked code and the final live Access state.
+If the runbook did not change, commit only the README.
+
+---
+
+## Operator Handoff — Not Agent Plan Tasks
+
+After Tasks 1–3 are complete, stop implementation and hand the operator to:
+
+`docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+
+The operator performs, in order:
+
+1. pre-prod preview review;
+2. `pulumi up --stack pre-prod`;
+3. pre-prod route/browser/posture acceptance;
+4. only after pre-prod is green, production preview review;
+5. `pulumi up --stack production`;
+6. production route/identity/posture/browser/session-expiry/desktop acceptance;
+7. stack-specific rollback if required;
+8. dashboard disable/delete only if Pulumi state/backend is unavailable during an emergency.
+
+These are deliberately outside the `For agentic workers` task list.
+
+## Final Implementation Verification
+
+Before claiming the implementation branch complete, verify:
+
+```bash
+git diff --check
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure test:coverage
+.github/scripts/ci-affected-scope.test.sh
+```
+
+Confirm the diff contains no changes under:
+
+```text
+packages/dtx-web/
+packages/dtx-api/
+packages/dtx-desktop/
+```
+
+Confirm no committed file contains real operator email, API token, device serial, Access cookie/JWT, Pulumi stack config, or Pulumi state export.
+
+Confirm the Access code contains no `ZeroTrustList`, `ZeroTrustDevicePostureRule`, `ZeroTrustAccessServiceToken`, Service Auth policy, or hostname-configurable production destination.

--- a/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make production DTXWeb `/app` and production desktop login operator-only behind Cloudflare Zero Trust, while protecting the entire pre-production web hostname and leaving the public production site plus both API hostnames outside Access.
+**Goal:** Make production DTXWeb `/app` and desktop login against deployed web environments operator-only behind Cloudflare Zero Trust, while protecting the entire pre-production web hostname and leaving the public production site plus both API hostnames outside Access.
 
-**Architecture:** Configure two manually managed Cloudflare Access self-hosted public-hostname applications. Roll out hostname-wide pre-production first to prove identity, device posture, Supabase login/OAuth, and rollback; only then create the production application scoped to exactly `/app` and `/app/*`. Supabase stays as the inner application-authentication gate, and route boundaries are verified with HTTP headers plus trusted-device browser/desktop smoke tests.
+**Architecture:** Configure two manually managed Cloudflare Access self-hosted public-hostname applications. Roll out hostname-wide pre-production first; only after identity, posture, Supabase auth, and the verification harness are proven should production be scoped to exactly `/app` and `/app/*`. The checked-in runbook is the single executable source of truth for all matrices and manual checks; this plan references those sections instead of duplicating their command blocks.
 
 **Tech Stack:** Cloudflare Zero Trust Access dashboard, Cloudflare One Client/WARP device posture, SvelteKit/Supabase existing authentication, Markdown operator documentation, `curl` header verification.
 
@@ -15,20 +15,21 @@
 - Do not add Pulumi, Terraform, or another infrastructure-as-code system.
 - Do not add CI deployment for Zero Trust.
 - Do not modify `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop` in this slice.
-- Production `/app` and production desktop login are intentionally operator-only behind Access; normal Supabase users are not expected to enter production `/app`.
+- Production `/app` and desktop login against production are intentionally operator-only behind Access.
 - Production Access destinations must be exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
-- Production `/`, `/blog`, `/preview`, `/editor`, `/tool/*`, `/game`, `/login`, `/auth/*`, and every route outside `/app` remain outside Access.
+- Production `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, `/auth/*`, and every intended public route outside `/app` remain outside Access.
 - Pre-production Access covers the entire `pre-prod.dtx.hapadona.com` hostname with no path bypass.
 - `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` remain outside Access.
 - Use an `Allow` policy that includes the intended operator identity/email and requires the trusted-device serial-number posture check used for Perseus.
 - Use a `12h` Access session duration.
-- Prefer reusing the existing account-level Perseus serial-number list/posture rule when available in the same Zero Trust account. If DTXWeb is in another Zero Trust account, create an equivalent list/posture rule there without weakening the requirement.
-- Do not create Service Auth policies, service tokens, or Access credentials for API, desktop, CLI, or CI traffic.
-- Do not enable Managed OAuth or add machine-auth behavior in this slice.
-- Keep the normal Cloudflare Access login-page flow during rollout rather than enabling instant authentication; the header checks below use the Access `302`/`Location` signal.
+- Reuse the existing Perseus identity-provider and instant-authentication mode; do not change instant authentication merely to simplify `curl` verification.
+- Verify the Access `Include` identity selector independently from the device-posture `Require` selector.
+- Do not create Service Auth, Managed OAuth, service tokens, or other Access credentials for API, desktop, E2E, CLI, or CI traffic.
+- Unattended E2E against the Access-protected pre-production hostname is unsupported by this slice.
+- Standalone desktop development that targets a deployed web hostname is subject to the same Access gate; the full local-stack `dev:local-web` path remains the non-operator development option.
 - Do not commit the operator email, device serial numbers, Access cookies, tokens, screenshots containing credentials, or other personal/security identifiers.
-- Configure and verify pre-production before creating the production Access application.
-- If implementation reveals that application code must change for the approved model to work, stop and create a separate follow-up rather than widening this slice.
+- Configure and prove pre-production before creating the production Access application.
+- If verification reveals that application code must change for the approved model to work, stop and create a separate follow-up rather than widening this slice.
 
 ---
 
@@ -41,17 +42,17 @@
 
 **Interfaces:**
 
-- Consumes: the approved protection matrix and rollout order from the design spec.
-- Produces: the durable repository source of truth for manual Access configuration, verification, rollback, and the operator-only product intent.
+- Consumes: the approved protection matrix, rollout order, and product consequences from the design spec.
+- Produces: the single executable source of truth for dashboard configuration, HTTP helpers, route matrices, browser/desktop checks, known limitations, and rollback.
 
-- [ ] **Step 1: Create the runbook with the exact configuration and rollout contract**
+- [ ] **Step 1: Create the runbook**
 
 Create `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` with:
 
 ```markdown
 # Cloudflare Zero Trust Web Access Runbook
 
-## Scope
+## Scope And Invariants
 
 DTXWeb uses manually managed Cloudflare Zero Trust Access for two web surfaces:
 
@@ -61,144 +62,173 @@ DTXWeb uses manually managed Cloudflare Zero Trust Access for two web surfaces:
 | `DTXWeb Production App` | `dtx.hapadona.com/app` |
 | `DTXWeb Production App` | `dtx.hapadona.com/app/*` |
 
-Production `/app` and production desktop login are intentionally operator-only. The configured Access identity and trusted-device posture are an outer gate; Supabase remains the inner application-authentication gate.
+Production `/app` and production desktop login are intentionally operator-only. The Access identity and trusted-device posture are an outer gate; Supabase remains the inner application-authentication gate.
 
-A normal Supabase user may reach public `/login`, authenticate successfully, and then be denied when returning to `/app`. That is expected for this configuration: public `/login` is an entry point, not an Access bypass.
+Production Access covers the intended private route family: exact `/app` and descendants under `/app/`. New private production pages MUST live under `/app`; a new private sibling such as `/studio` or `/admin` would be publicly reachable until this Access design is updated. `hooks.server.ts` currently uses the slightly broader `pathname.startsWith('/app')`; do not rely on that string-prefix quirk for new routes.
 
-The production landing page and public content/tools remain outside Access, including `/blog`, `/preview`, `/editor`, `/tool/*`, and `/game`. Both GraphQL API hostnames remain outside Access.
+A normal Supabase user may reach public `/login`, authenticate successfully, and then be denied when returning to `/app`. If they now hold a Supabase session, the server redirects `/login` back to `/app` and the only current sign-out UI is inside the protected `(app)` layout. The current recovery is to clear the Drumery/Supabase cookies for `dtx.hapadona.com`. A public `/logout` route or changing the authenticated `/login` redirect is a deferred product decision, not part of this dashboard-only slice.
 
-This runbook is the durable Zero Trust source of truth. `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is useful precedent for human-executed Cloudflare operations but remains a historical API-migration runbook and is not modified for this feature.
+Standalone desktop development (`bun run dev:desktop`) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup that points to production, so the ordinary standalone `tauri dev` login is operator-only after this rollout. Pointing it at pre-production does not help a non-operator because pre-production is hostname-wide Access-protected. Non-operator contributors must use the full local stack (`bun run dev`, which uses `dtx-desktop#dev:local-web`) or a separately designed ungated development environment.
+
+The web E2E harness can override `PLAYWRIGHT_BASE_URL`, but this slice provides no non-interactive Access credential. Unattended E2E/CI against `pre-prod.dtx.hapadona.com` is therefore unsupported until a separate Access-authentication design is approved.
+
+This runbook is the durable Zero Trust source of truth. `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is precedent for human-executed Cloudflare operations but remains a historical API-migration checklist.
 
 ## Required Policy
 
 Both Access applications use the same policy semantics:
 
 - Action: `Allow`
-- Include: the intended operator identity/email used for existing Perseus access
+- Include: the intended operator identity/email used for Perseus access
 - Require: the trusted-device serial-number posture check used for Perseus
 - Session duration: `12h`
 - Service Auth: none
 - Managed OAuth: off
-- Instant authentication: off during this rollout so unauthenticated header verification has a stable Access-login redirect
 
-Reuse the existing account-level Perseus serial-number list/posture rule when it is available in the same Zero Trust account. If DTXWeb is in another Zero Trust account, create an equivalent serial-number list and posture rule there using the same intended trusted devices.
+Reuse the existing Perseus identity provider and its current instant-authentication mode. Do not toggle instant authentication merely to make a header test easier.
 
-Never commit the email address, device serial numbers, Access cookies, tokens, or other security identifiers to this repository.
+Before rollout, inspect a known protected Perseus route and set an uncommitted shell regex that matches the actual unauthenticated Access redirect for this tenant:
 
-## Rollout Order
+```bash
+export ACCESS_REDIRECT_RE='<regex matching this tenant\'s Access redirect Location>'
+```
 
-1. Confirm the operator identity and trusted-device posture rule.
-2. Create and verify `DTXWeb Pre-prod`.
-3. Prove pre-production password login, Google OAuth, posture denial, and API non-interception.
-4. Stop and roll back pre-production if any check fails.
-5. Create `DTXWeb Production App` with only `/app` and `/app/*`.
-6. Run the complete production public/protected header matrix.
-7. Run the trusted production browser and desktop-login checks.
-8. Re-run both API non-interception checks.
+For a tenant using the normal Cloudflare Access login page, a suitable value is:
 
-Do not create the production Access application until the pre-production checks are green.
+```bash
+export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
+```
+
+If Perseus uses instant authentication, set the regex to the known direct IdP redirect shape observed from that existing protected route. Keep one redirect mode for the whole DTXWeb rollout.
+
+Never commit the operator email, device serial numbers, tenant-specific cookies/tokens, or other credentials.
 
 ## Header Verification Helpers
 
-Use unauthenticated requests with no Access cookies:
+Use unauthenticated requests with no Access cookies. A request that fails DNS, connection, TLS, or timeout checks MUST fail the assertion instead of being interpreted as an unprotected route.
 
 ```bash
-access_headers() {
-  curl -sS -o /dev/null -D - "$1" | tr -d '\r'
+http_headers() {
+  url="$1"
+  raw="$(curl -sS --max-time 15 -o /dev/null -D - "$url")" || {
+    echo "FAIL: no HTTP response from $url" >&2
+    return 1
+  }
+
+  headers="$(printf '%s\n' "$raw" | tr -d '\r')"
+  printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ [0-9]{3}' || {
+    echo "FAIL: no HTTP status line from $url" >&2
+    return 1
+  }
+
+  printf '%s\n' "$headers"
 }
 
 assert_access_redirect() {
   url="$1"
-  headers="$(access_headers "$url")"
+  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
+  headers="$(http_headers "$url")" || return 1
   printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
-  printf '%s\n' "$headers" \
-    | grep -Eiq '^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/' \
-    || { echo "FAIL: Access did not intercept $url" >&2; return 1; }
+  printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE" || {
+    echo "FAIL: Access did not intercept $url" >&2
+    return 1
+  }
 }
 
 assert_no_access_redirect() {
   url="$1"
-  headers="$(access_headers "$url")"
+  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
+  headers="$(http_headers "$url")" || return 1
   printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
-  if printf '%s\n' "$headers" \
-    | grep -Eiq '^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'; then
+  if printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
     echo "FAIL: Access unexpectedly intercepted $url" >&2
     return 1
   fi
 }
 ```
 
-An origin `200`, `3xx`, `4xx`, or `5xx` can all be valid for an unprotected URL. The boundary assertion is whether Cloudflare Access intercepted the request.
+Dry-run the harness before changing DTXWeb:
+
+- `assert_access_redirect` against a known protected Perseus URL must pass.
+- `assert_no_access_redirect https://dtx.hapadona.com/` must pass before production Access exists.
+- `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` must fail non-zero.
+
+Do not proceed until the invalid-host check fails loudly.
+
+## Rollout Order
+
+1. Confirm the Perseus IdP, instant-auth mode, operator identity, and serial posture rule.
+2. Dry-run the header helpers.
+3. Create and verify `DTXWeb Pre-prod`.
+4. Prove pre-production password login, Google OAuth, posture denial, and API non-interception.
+5. Stop and roll back if any required pre-production check fails.
+6. Create `DTXWeb Production App` with only `/app` and `/app/*`.
+7. Run the complete production matrix.
+8. Prove the Access identity selector and posture selector independently.
+9. Run production browser and desktop-login checks.
+10. Characterize expired Access behavior during SvelteKit client-side navigation.
+11. Record final non-sensitive results and deferred limitations.
 
 ## Pre-production Configuration
 
-In **Zero Trust > Access controls > Applications**:
+Create `DTXWeb Pre-prod` as **Self-hosted and private** for the entire public hostname:
 
-1. Create a **Self-hosted and private** application.
-2. Name it `DTXWeb Pre-prod`.
-3. Add one public hostname for `pre-prod.dtx.hapadona.com` with no path restriction.
-4. Set session duration to `12h`.
-5. Attach the operator `Allow` policy with the serial-number posture requirement.
-6. Leave Service Auth, Managed OAuth, and instant authentication off.
-7. Save the application.
+```text
+pre-prod.dtx.hapadona.com
+```
 
-Do not add `api.pre-prod.dtx.hapadona.com`.
+Set session duration to `12h`, attach the operator `Allow` policy with the serial-number posture requirement, and use the same IdP/instant-auth mode as Perseus. Do not add `api.pre-prod.dtx.hapadona.com`, Service Auth, Managed OAuth, or service tokens.
 
-## Pre-production Verification
+## Pre-production Verification Matrix
 
-Run:
+Run the following with no Access session:
 
 ```bash
 assert_access_redirect https://pre-prod.dtx.hapadona.com/
 assert_access_redirect https://pre-prod.dtx.hapadona.com/login
 assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
 assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
-assert_access_redirect https://pre-prod.dtx.hapadona.com/preview
+assert_access_redirect https://pre-prod.dtx.hapadona.com/preview/1
 assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
 assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
 assert_access_redirect https://pre-prod.dtx.hapadona.com/game
 assert_access_redirect https://pre-prod.dtx.hapadona.com/app
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/
 assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/__data.json
 assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
 ```
 
-Then, on the trusted WARP/Cloudflare One device with the allowed identity:
+Every command must exit `0`. If one fails, disable/delete `DTXWeb Pre-prod` and stop before production.
 
-- enter the pre-production hostname through Access;
-- complete a password login and return to the application;
-- complete Google OAuth and confirm the callback returns behind the same hostname-wide Access gate;
-- confirm normal pre-production API-backed application behavior still works;
-- from a device that fails the serial posture rule, confirm the hostname is denied before DTXWeb loads.
+On the trusted operator device, complete both password login and Google OAuth behind the hostname-wide Access session and confirm an API-backed `/app` page works normally.
 
-If any pre-production check fails, disable/delete `DTXWeb Pre-prod` and stop. Do not create production Access yet.
+From a device that fails the serial posture rule, confirm pre-production is denied before DTXWeb loads.
 
 ## Production Configuration
 
-Only after pre-production verification succeeds:
+Only after all required pre-production checks pass, create `DTXWeb Production App` as **Self-hosted and private** with exactly:
 
-1. Create a **Self-hosted and private** application.
-2. Name it `DTXWeb Production App`.
-3. Add exactly these public-hostname destinations:
-   - `dtx.hapadona.com/app`
-   - `dtx.hapadona.com/app/*`
-4. Set session duration to `12h`.
-5. Attach the operator `Allow` policy with the serial-number posture requirement.
-6. Leave Service Auth, Managed OAuth, and instant authentication off.
-7. Save the application.
+```text
+dtx.hapadona.com/app
+dtx.hapadona.com/app/*
+```
 
-Do not add a hostname-wide `dtx.hapadona.com` destination or any other production path.
+Set session duration to `12h`, attach the same operator `Allow` policy and serial posture requirement, and preserve the Perseus IdP/instant-auth mode. Do not add a hostname-wide production destination, public routes, Service Auth, Managed OAuth, or service tokens.
 
 ## Production Header Matrix
 
-Run:
+Run with no Access session:
 
 ```bash
 assert_access_redirect https://dtx.hapadona.com/app
+assert_access_redirect https://dtx.hapadona.com/app/
 assert_access_redirect https://dtx.hapadona.com/app/score
+assert_access_redirect https://dtx.hapadona.com/app/__data.json
 
 assert_no_access_redirect https://dtx.hapadona.com/
 assert_no_access_redirect https://dtx.hapadona.com/blog
-assert_no_access_redirect https://dtx.hapadona.com/preview
+assert_no_access_redirect https://dtx.hapadona.com/preview/1
 assert_no_access_redirect https://dtx.hapadona.com/editor
 assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
 assert_no_access_redirect https://dtx.hapadona.com/game
@@ -208,47 +238,93 @@ assert_no_access_redirect https://api.dtx.hapadona.com/
 assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
 ```
 
-The public matrix is intentionally broad enough to catch an accidentally hostname-wide or over-broad production destination; `/tool/dtx-to-midi` also catches accidental `/t*`-style scoping.
+Every command must exit `0`. `/app/` is an explicit path-semantics probe; do not assume its behavior from the dashboard string alone. `/app/__data.json` proves SvelteKit data requests are inside the Access boundary. `/preview/1` exercises the real dynamic preview route instead of a 404 prefix.
+
+If any public route or API is intercepted, disable the production application, correct the destinations, and rerun this entire matrix before continuing.
+
+## Production Identity And Posture Verification
+
+Verify the two Access policy clauses independently:
+
+1. Configured operator identity on the trusted device: allowed.
+2. On that same trusted device, use a fresh browser profile/session and authenticate to Access with a second IdP identity that is NOT in the `Include` list: denied by Access.
+3. Configured operator identity from a device that fails the serial posture rule: denied by Access.
+
+A second Supabase account is not a substitute for check 2; the Access identity selector and Supabase session are separate gates.
+
+Do not claim the identity selector verified if no non-allowed IdP identity was actually exercised.
 
 ## Trusted Production Browser Verification
 
-On the trusted WARP/Cloudflare One device with the allowed identity:
+On the trusted operator device:
 
-1. Open production `/app` and pass Access.
-2. With no Supabase session, confirm SvelteKit redirects to public `/login`.
-3. Complete normal Supabase login.
-4. Confirm the browser returns to protected `/app` using the existing Access session.
-5. Confirm a Supabase logout does not remove the Access gate.
+1. Open `/app` and pass Access.
+2. With no Supabase session, confirm DTXWeb redirects to public `/login`.
+3. Complete Supabase login and confirm return to protected `/app` succeeds under the existing Access session.
+4. Sign out of Supabase and confirm `/app` remains Access-protected.
 
-From a Supabase account that does not match the configured Access identity, confirm `/login` can still be public while `/app` remains inaccessible. Do not add a bypass to make that account reach `/app`; operator-only access is intentional.
+Characterize the non-operator dead end separately:
+
+1. Use a Supabase account that does not correspond to the allowed Access identity.
+2. Authenticate on public `/login` and confirm the return to `/app` is denied by Access.
+3. Confirm revisiting `/login` with that Supabase session redirects back to `/app` and no public sign-out UI is reachable.
+4. Recover by clearing the production Drumery/Supabase cookies.
+
+Record this as a known limitation. Do not widen Access to make the non-operator account work.
+
+## Access Session Expiry / Client-side Navigation Check
+
+The root server layout has a server `load`, so client-side navigation uses SvelteKit data requests under paths such as `/app/__data.json`.
+
+On the trusted operator device with a valid Supabase session:
+
+1. Keep a browser tab on a public production page.
+2. End the Access session using the tenant's normal Access logout/session-clearing procedure so a new protected request requires Access again.
+3. Trigger a SvelteKit client-side navigation into `/app` without first doing a full-page protected navigation.
+4. Record what the UI shows when the framework data request encounters Access reauthentication.
+5. Navigate directly/reload `/app` and confirm the browser can complete Access reauthentication and recover.
+
+If client-side navigation shows an opaque fetch error but a direct `/app` reload recovers, document that UX as a deferred follow-up. Do not add a bypass. If the operator cannot recover with a direct browser navigation, disable the production Access application and investigate before acceptance.
 
 ## Production Desktop Login Verification
 
-This is a required production check, not an optional smoke test.
+This is required because standalone desktop development against a deployed web environment also traverses the protected production `/app` handoff in the current operator setup.
 
-On the trusted device:
+### Bundled desktop
 
-1. Start desktop login so the browser opens `/login?redirect=desktop&desktop_callback=...`.
-2. Confirm `/login` remains public.
-3. Complete password login and confirm the return to `/app?redirect=desktop...` passes Access and opens the desktop callback.
+On the trusted operator device:
+
+1. Start desktop login and confirm public `/login?redirect=desktop&desktop_callback=...` loads without Access interception.
+2. Complete password login and confirm the return through protected `/app?redirect=desktop...` succeeds.
+3. Confirm the generated magic link reaches `dtx://auth-callback` and the desktop session authenticates.
 4. Repeat with Google login.
-5. Verify the bundled `dtx://auth-callback` flow.
-6. When a `tauri dev` instance is available, verify its loopback `http://127.0.0.1:<port>/auth-callback` flow in the same browser tab so the `sessionStorage` callback handoff is exercised.
 
-If the browser reaches public `/login` but cannot complete the protected `/app` handoff on the trusted operator device, disable the production Access app and investigate separately. Do not widen the policy or add path bypasses in this slice.
+### Standalone `tauri dev`
+
+Using the current standalone desktop-development setup:
+
+1. Start `bun run dev:desktop` and confirm the browser login target is the expected deployed production web hostname.
+2. Keep the login flow in the same browser tab so `/login` can preserve `desktop_callback` in `sessionStorage`.
+3. Complete password login and confirm protected `/app?redirect=desktop...` passes Access.
+4. Confirm the magic link reaches `http://127.0.0.1:<configured-port>/auth-callback`.
+5. Repeat with Google login.
+
+This check is required when the current `.env` points standalone desktop development at production. If the local operator configuration has deliberately changed, record the actual target and still verify the deployed-environment loopback flow before accepting production Access.
+
+The full local-stack `bun run dev` path is not an Access test: it uses `dev:local-web` and localhost intentionally.
 
 ## Rollback
 
 Pre-production:
 
-- Disable or delete `DTXWeb Pre-prod` if the hostname-wide gate breaks identity, posture, login, OAuth, or route behavior.
+- Disable/delete `DTXWeb Pre-prod` if the hostname-wide gate fails a required check.
 
 Production:
 
-- Disable or delete `DTXWeb Production App` if `/app` or desktop login fails for the trusted operator device.
-- If any public production route is intercepted, disable the application, correct it back to exactly `/app` and `/app/*`, and rerun the full header matrix before re-enabling.
+- Disable/delete `DTXWeb Production App` if the trusted operator cannot use `/app`, cannot recover after Access reauthentication, or cannot complete required desktop login.
+- If a public route or API is intercepted, disable the production application, restore exactly `/app` and `/app/*`, and rerun the entire Production Header Matrix.
 
-If either API hostname is intercepted, remove it from Access. Do not introduce service tokens as an emergency workaround.
+Do not introduce service tokens, API Access, route bypasses, or policy widening as an emergency workaround.
 
 No Worker rollback or code deployment is required for these dashboard-only changes.
 
@@ -258,28 +334,10 @@ No Worker rollback or code deployment is required for these dashboard-only chang
 - https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
 - https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
 - https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
+- https://developers.cloudflare.com/learning-paths/clientless-access/customize-ux/login-page/
 ```
 
-- [ ] **Step 2: Format-check the runbook**
-
-Run:
-
-```bash
-bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-```
-
-Expected: exit `0`.
-
-If formatting differs:
-
-```bash
-bunx prettier --write docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-bunx prettier --check docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
-```
-
-Expected: the second command exits `0`.
-
-- [ ] **Step 3: Review the staged runbook for secrets and scope drift**
+- [ ] **Step 2: Review scope/secrets and commit the runbook**
 
 Run:
 
@@ -287,22 +345,24 @@ Run:
 git diff -- docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
 ```
 
-Expected:
+Confirm:
 
-- no actual operator email;
-- no device serial number;
-- no Access cookie/token;
-- rollout order is pre-production before production;
-- production destinations are only `/app` and `/app/*`;
-- `/tool/*` and `/game` are explicitly public in production;
-- API hostnames remain outside Access.
+- no actual operator email, device serial, Access cookie, JWT, or token is present;
+- the invalid-host harness check fails loudly;
+- the runbook has exactly one pre-production matrix and one production matrix;
+- production destinations remain only `/app` and `/app/*`;
+- `/tool/*`, `/game`, `/preview/1`, `/login`, and `/auth/*` remain public in production;
+- both API hostnames remain outside Access;
+- standalone deployed-environment desktop development and non-operator recovery limitations are documented.
 
-- [ ] **Step 4: Commit the runbook**
+Commit:
 
 ```bash
 git add docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
 git commit -m "docs: add Zero Trust web access runbook"
 ```
+
+The repository's staged Markdown hook runs Prettier during the commit; do not add a separate format-only task unless the hook itself fails.
 
 ---
 
@@ -315,81 +375,41 @@ git commit -m "docs: add Zero Trust web access runbook"
 
 **Interfaces:**
 
-- Consumes: the existing Zero Trust tenant, intended operator identity, trusted-device posture rule, and `pre-prod.dtx.hapadona.com` web hostname.
-- Produces: a verified `DTXWeb Pre-prod` Access application and a go/no-go decision for production.
+- Consumes: the runbook's **Required Policy**, **Header Verification Helpers**, **Pre-production Configuration**, and **Pre-production Verification Matrix** sections.
+- Produces: a verified `DTXWeb Pre-prod` application and a hard go/no-go decision for production.
 
-- [ ] **Step 1: Confirm the Perseus posture components are reusable**
+- [ ] **Step 1: Establish and validate the tenant-specific Access signal**
 
-In Cloudflare Zero Trust, inspect the identity/policy and device posture resources used for Perseus.
+Follow **Required Policy** and **Header Verification Helpers** from the runbook.
 
 Expected:
 
-- the intended operator identity is known to the operator but not copied into git;
-- the serial-number posture rule is selectable in the DTXWeb Zero Trust account; or
-- if the zone is under another Zero Trust account, an equivalent serial list/posture rule is created there before continuing.
+- current Perseus IdP/instant-auth mode is recorded for the operator session;
+- `ACCESS_REDIRECT_RE` matches a known protected Perseus route;
+- production `/` is recognized as currently unprotected;
+- the intentionally invalid hostname causes `http_headers` to exit non-zero.
+
+Do not create either DTXWeb Access application until the harness passes these checks.
 
 - [ ] **Step 2: Create `DTXWeb Pre-prod`**
 
-In **Zero Trust > Access controls > Applications**:
+Follow **Pre-production Configuration** from the runbook exactly.
 
-1. Create a **Self-hosted and private** application.
-2. Name it `DTXWeb Pre-prod`.
-3. Add `pre-prod.dtx.hapadona.com` as the public hostname with no path.
-4. Set session duration to `12h`.
-5. Add the operator `Allow` policy and require the serial-number posture rule.
-6. Leave Service Auth, Managed OAuth, and instant authentication off.
-7. Save.
+Expected: the entire pre-production web hostname is protected and `api.pre-prod.dtx.hapadona.com` is not part of the application.
 
-Expected: every path on the pre-production web hostname is under this application; the pre-production API hostname is not.
+- [ ] **Step 3: Execute the runbook's pre-production verification**
 
-- [ ] **Step 3: Run the unauthenticated pre-production header matrix**
+Run the complete **Pre-production Verification Matrix** from the runbook, then perform its trusted-operator password/Google checks and failed-posture check.
 
-Source the two shell helpers from the runbook, then run:
+Expected: every required matrix command exits `0`; both Supabase login paths work behind Access; failed posture is denied.
 
-```bash
-assert_access_redirect https://pre-prod.dtx.hapadona.com/
-assert_access_redirect https://pre-prod.dtx.hapadona.com/login
-assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
-assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
-assert_access_redirect https://pre-prod.dtx.hapadona.com/preview
-assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
-assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
-assert_access_redirect https://pre-prod.dtx.hapadona.com/game
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
-assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
-```
+- [ ] **Step 4: Make the production go/no-go decision**
 
-Expected: all commands exit `0`.
-
-If any command fails, disable/delete `DTXWeb Pre-prod` and stop before production.
-
-- [ ] **Step 4: Prove trusted-device pre-production login and OAuth**
-
-On the trusted WARP/Cloudflare One device with the configured operator identity:
-
-1. Enter `https://pre-prod.dtx.hapadona.com/` through Access.
-2. Open `/login` under the established Access session.
-3. Complete password login and confirm the existing app flow succeeds.
-4. Log out of Supabase while keeping the Access session.
-5. Complete Google login and confirm `/auth/callback` returns successfully under Access.
-6. Open `/app` and one API-backed page to confirm normal application behavior.
-
-Expected: Access remains the outer hostname gate and both existing Supabase login paths work behind it.
-
-- [ ] **Step 5: Prove posture denial on pre-production**
-
-From a device that does not satisfy the serial posture rule, request the pre-production hostname.
-
-Expected: Cloudflare denies access before DTXWeb loads.
-
-- [ ] **Step 6: Record the pre-production go/no-go**
-
-Proceed only if Steps 3-5 all pass. Otherwise roll back pre-production and stop this implementation before Task 3.
+Proceed only if Step 3 is fully green. Otherwise disable/delete `DTXWeb Pre-prod`, record the non-sensitive failure, and stop before production.
 
 ---
 
-### Task 3: Configure Production `/app` And Prove The Route Boundary
+### Task 3: Configure Production And Prove Both Access Policy Clauses
 
 **Files:**
 
@@ -398,82 +418,56 @@ Proceed only if Steps 3-5 all pass. Otherwise roll back pre-production and stop 
 
 **Interfaces:**
 
-- Consumes: successful Task 2 verification and the same operator identity/posture semantics.
-- Produces: `DTXWeb Production App` with only `/app` and `/app/*`, plus deterministic evidence that public production routes were not captured.
+- Consumes: successful Task 2 verification plus the runbook's **Production Configuration**, **Production Header Matrix**, **Production Identity And Posture Verification**, **Trusted Production Browser Verification**, and **Access Session Expiry / Client-side Navigation Check** sections.
+- Produces: a path-scoped production Access application with route-boundary, identity, posture, and browser-session evidence.
 
-- [ ] **Step 1: Create the production Access application**
+- [ ] **Step 1: Create `DTXWeb Production App`**
 
-In **Zero Trust > Access controls > Applications**:
+Follow **Production Configuration** from the runbook exactly.
 
-1. Create a **Self-hosted and private** application.
-2. Name it `DTXWeb Production App`.
-3. Add exactly:
+Expected: exactly two destinations exist: `/app` and `/app/*`.
 
-```text
-dtx.hapadona.com/app
-dtx.hapadona.com/app/*
-```
+- [ ] **Step 2: Run the single production route matrix**
 
-4. Set session duration to `12h`.
-5. Add the operator `Allow` policy and require the serial-number posture rule.
-6. Leave Service Auth, Managed OAuth, and instant authentication off.
-7. Save.
+Execute the complete **Production Header Matrix** from the runbook.
 
-Expected: no hostname-wide production destination and no third destination.
+Expected: `/app`, `/app/`, `/app/score`, and `/app/__data.json` are intercepted; every public route and both API hostnames are not intercepted; every assertion has a real HTTP response.
 
-- [ ] **Step 2: Run the protected production assertions**
+If any assertion fails, use the runbook's production rollback and do not continue.
 
-```bash
-assert_access_redirect https://dtx.hapadona.com/app
-assert_access_redirect https://dtx.hapadona.com/app/score
-```
+- [ ] **Step 3: Prove Access identity and device posture independently**
 
-Expected: both commands exit `0`.
+Execute **Production Identity And Posture Verification** from the runbook.
 
-- [ ] **Step 3: Run the full public production matrix**
+Expected:
 
-```bash
-assert_no_access_redirect https://dtx.hapadona.com/
-assert_no_access_redirect https://dtx.hapadona.com/blog
-assert_no_access_redirect https://dtx.hapadona.com/preview
-assert_no_access_redirect https://dtx.hapadona.com/editor
-assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
-assert_no_access_redirect https://dtx.hapadona.com/game
-assert_no_access_redirect https://dtx.hapadona.com/login
-assert_no_access_redirect https://dtx.hapadona.com/auth/callback
-```
+- operator identity + trusted device: allowed;
+- non-allowed IdP identity on the same trusted device: denied;
+- operator identity on failed-posture device: denied.
 
-Expected: every command exits `0`.
+A second Supabase account does not satisfy the non-allowed Access-identity check.
 
-If any route shows an Access redirect, disable `DTXWeb Production App` immediately, correct the destination set, and rerun Steps 2-3 before continuing.
+- [ ] **Step 4: Prove browser behavior and document the known non-operator dead end**
 
-- [ ] **Step 4: Prove the operator-only browser behavior**
+Execute **Trusted Production Browser Verification** from the runbook.
 
-On the trusted operator device:
+Expected: operator `/app -> /login -> /app` works; non-operator Supabase login reaches the intended Access denial; revisiting `/login` while still signed in reproduces the documented dead end; clearing production site cookies recovers the browser.
 
-1. Open `/app` and pass Access.
-2. With no Supabase session, confirm DTXWeb sends the browser to public `/login`.
-3. Complete Supabase login and confirm return to protected `/app` succeeds under the existing Access session.
-4. Sign out of Supabase and confirm `/app` remains Access-protected.
+Do not treat the non-operator dead end as a reason to widen Access. The public logout/auth-guard change is deferred.
 
-Expected: Access and Supabase remain independent gates.
+- [ ] **Step 5: Characterize Access-session expiry during client navigation**
 
-Using a Supabase identity that is not the configured Access identity, confirm public `/login` does not grant entry to `/app`.
+Execute **Access Session Expiry / Client-side Navigation Check** from the runbook.
 
-Expected: the user is denied by Access on the `/app` return. This is intentional; do not widen the Access policy.
-
-- [ ] **Step 5: Prove production posture denial**
-
-From a device that fails the serial posture rule, request `https://dtx.hapadona.com/app`.
-
-Expected: denied before DTXWeb loads.
+Expected: the observed client-side behavior is recorded, and a direct protected navigation/reload provides a usable reauthentication path for the operator. If direct recovery fails, roll back production and stop.
 
 ---
 
-### Task 4: Verify Production Desktop Login, APIs, And Final Acceptance
+### Task 4: Verify Production Desktop Development And Final Acceptance
 
 **Files:**
 
+- Reference: `packages/dtx-desktop/package.json`
 - Reference: `packages/dtx-desktop/src/renderer/src/services/authService.ts`
 - Reference: `packages/dtx-web/src/routes/(login)/login/+page.svelte`
 - Reference: `packages/dtx-web/src/routes/(login)/login/+page.server.ts`
@@ -485,72 +479,43 @@ Expected: denied before DTXWeb loads.
 **Interfaces:**
 
 - Consumes: verified pre-production and production Access applications.
-- Produces: final acceptance evidence for the desktop `/login -> /app -> callback` handoff and API exclusion.
+- Produces: final acceptance evidence for deployed-environment desktop auth plus the documented non-operator/local-development consequences.
 
-- [ ] **Step 1: Verify the bundled production desktop login flow**
+- [ ] **Step 1: Run all production desktop checks from the runbook**
 
-On the trusted operator device with the bundled desktop app:
+Execute **Production Desktop Login Verification**, including both bundled `dtx://` and standalone `tauri dev` loopback flows against the deployed production web target used by the current operator setup.
 
-1. Start desktop login.
-2. Confirm the browser opens the public production `/login?redirect=desktop&desktop_callback=...` flow without an Access challenge on `/login`.
-3. Complete password login.
-4. Confirm the browser return to `/app?redirect=desktop...` passes Access.
-5. Confirm the generated magic link reaches `dtx://auth-callback` and the desktop session becomes authenticated.
-6. Repeat the flow with Google login.
+Expected: password and Google login succeed for the trusted operator in both required flows; the loopback callback survives the `/login` `sessionStorage` handoff through protected `/app`.
 
-Expected: both password and Google desktop logins complete through protected `/app` for the trusted operator.
+If the current ignored `.env` has deliberately changed away from production, record the actual target and still exercise a deployed-environment loopback flow before accepting production Access. The full local-stack `dev:local-web` path is not a substitute for this check.
 
-- [ ] **Step 2: Verify the Tauri-development loopback handoff when available**
+- [ ] **Step 2: Re-run durable acceptance sections, not copied commands**
 
-With a `tauri dev` instance running on its configured loopback callback port:
+Re-run the runbook's **Production Header Matrix** and confirm Task 2's pre-production application remains enabled and usable.
 
-1. Start desktop login from that development instance.
-2. Keep the login and callback flow in the same browser tab.
-3. Complete password login and confirm `/app?redirect=desktop...` passes Access.
-4. Confirm the magic link returns to `http://127.0.0.1:<configured-port>/auth-callback`.
-5. Repeat with Google login if practical in the development environment.
+Expected: the single checked-in matrices still pass after the desktop verification; no public/API boundary drift occurred during troubleshooting.
 
-Expected: the loopback callback succeeds, proving the `/login` `sessionStorage` callback handoff survived the Access-gated return to `/app`.
+- [ ] **Step 3: Record final non-sensitive outcomes**
 
-If this fails while bundled `dtx://` succeeds, disable the production Access application and investigate the handoff separately. Do not add an Access bypass in this slice.
-
-- [ ] **Step 3: Re-run both API exclusion assertions**
-
-```bash
-assert_no_access_redirect https://api.dtx.hapadona.com/
-assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
-```
-
-Expected: both commands exit `0`. The APIs may return their own redirect/error/status; they must not redirect into Cloudflare Access.
-
-- [ ] **Step 4: Re-run the production boundary spot check**
-
-```bash
-assert_access_redirect https://dtx.hapadona.com/app
-assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
-assert_no_access_redirect https://dtx.hapadona.com/game
-assert_no_access_redirect https://dtx.hapadona.com/login
-```
-
-Expected: all commands exit `0`.
-
-- [ ] **Step 5: Record final operator verification**
-
-In the implementation notes/PR checklist, record only non-sensitive outcomes:
+Record only outcomes, for example:
 
 ```text
+Header harness invalid-host failure: PASS
 Pre-prod hostname-wide Access: PASS
 Pre-prod password + Google auth: PASS
 Prod /app + /app/* Access: PASS
-Prod public route matrix: PASS
+Prod public/API matrix: PASS
+Prod Access identity selector: PASS
+Prod posture selector: PASS
+Prod operator browser auth: PASS
+Prod non-operator lockout characterized: PASS
+Prod expired-session client navigation characterized: PASS
 Prod bundled desktop login: PASS
-Prod tauri-dev loopback login: PASS or NOT RUN (environment unavailable)
-Prod + pre-prod API exclusion: PASS
-Untrusted-device posture denial: PASS
+Prod standalone tauri-dev loopback login: PASS
 ```
 
-Do not paste cookies, JWTs, operator email addresses, device serial numbers, or screenshots containing those values.
+Do not paste cookies, JWTs, IdP identities, operator email addresses, device serial numbers, or screenshots containing those values.
 
-- [ ] **Step 6: Stop if any required acceptance check is red**
+- [ ] **Step 4: Stop if a required acceptance check is red**
 
-Required checks are all lines above except the Tauri-development loopback line when no development instance is available. A required failure means disable the affected Access application and investigate separately; do not broaden routes or policies in this slice to force a green result.
+A required failure means follow the environment-specific rollback in the runbook and investigate separately. Do not broaden routes/policies, add a service token, or change application code inside this slice merely to force a green result.

--- a/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -1,63 +1,140 @@
-# Cloudflare Zero Trust Web Access Runbook
+# Cloudflare Zero Trust Web Access Runbook (operator-executed)
+
+This runbook owns live DTXWeb Cloudflare Access rollout, verification, and rollback.
+
+Steps that mutate Cloudflare (`pulumi up`, `pulumi destroy`, dashboard disable/delete), require interactive identity login, require a trusted/untrusted physical device, or require visual browser/desktop observation are run by a human operator, not by an implementation agent.
 
 ## Scope And Invariants
 
-DTXWeb uses manually managed Cloudflare Zero Trust Access for two web surfaces:
+DTXWeb Pulumi owns exactly one Access application per stack:
 
-| Application | Protected destination |
-| --- | --- |
-| `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
-| `DTXWeb Production App` | `dtx.hapadona.com/app` |
-| `DTXWeb Production App` | `dtx.hapadona.com/app/*` |
+| Stack | Application | Protected destination |
+| --- | --- | --- |
+| `pre-prod` | `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
+| `production` | `DTXWeb Production App` | `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` |
 
-Production `/app` and production desktop login are intentionally operator-only. The Access identity and trusted-device posture are an outer gate; Supabase remains the inner application-authentication gate.
+Wrangler continues to own Workers/API/runtime infrastructure.
 
-Production Access covers the intended private route family: exact `/app` and descendants under `/app/`. New private production pages MUST live under `/app`; a new private sibling such as `/studio` or `/admin` would be publicly reachable until this Access design is updated. `hooks.server.ts` currently uses the slightly broader `pathname.startsWith('/app')`; do not rely on that string-prefix quirk for new routes.
+Production `/app` and deployed-environment desktop login are intentionally operator-only. Supabase remains the inner application-authentication gate.
 
-A normal Supabase user may reach public `/login`, authenticate successfully, and then be denied when returning to `/app`. If they now hold a Supabase session, the server redirects `/login` back to `/app` and the only current sign-out UI is inside the protected `(app)` layout. The current recovery is to clear the Drumery/Supabase cookies for `dtx.hapadona.com`. A public `/logout` route or changing the authenticated `/login` redirect is a deferred product decision, not part of this dashboard-only slice.
+Production private routes must live at exact `/app` or below `/app/`. The current SvelteKit guard uses the slightly broader `pathname.startsWith('/app')`; do not rely on that string-prefix quirk for new private sibling routes.
 
-Standalone desktop development (`bun run dev:desktop`) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup that points to production, so the ordinary standalone `tauri dev` login is operator-only after this rollout. Pointing it at pre-production does not help a non-operator because pre-production is hostname-wide Access-protected. Non-operator contributors must use the full local stack (`bun run dev`, which uses `dtx-desktop#dev:local-web`) or a separately designed ungated development environment.
+Production `/login` and `/auth/*` remain public because desktop/password/Google flows return through those routes before the protected `/app` handoff.
 
-The web E2E harness can override `PLAYWRIGHT_BASE_URL`, but this slice provides no non-interactive Access credential. Unattended E2E/CI against `pre-prod.dtx.hapadona.com` is therefore unsupported until a separate Access-authentication design is approved.
+Both API hostnames remain outside Access:
 
-This runbook is the durable Zero Trust source of truth. `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is precedent for human-executed Cloudflare operations but remains a historical API-migration checklist.
+- `api.dtx.hapadona.com`
+- `api.pre-prod.dtx.hapadona.com`
 
-## Required Policy
+Do not create service tokens, Service Auth policies, bypass policies, API Access applications, or wider production destinations as troubleshooting shortcuts.
 
-Both Access applications use the same policy semantics:
+## Shared Posture Ownership
 
-- Action: `Allow`
-- Include: the intended operator identity/email used for Perseus access
-- Require: the trusted-device serial-number posture check used for Perseus
-- Session duration: `12h`
-- Service Auth: none
-- Managed OAuth: off
+Perseus owns the trusted-device serial list and device-posture rule. DTXWeb stores only the existing Cloudflare posture-rule resource ID as Pulumi config.
 
-Reuse the existing Perseus identity provider and its current instant-authentication mode. Do not toggle instant authentication merely to make a header test easier.
+If Perseus replaces that posture rule with a new Cloudflare resource, update DTXWeb `devicePostureRuleId` in both stacks before the next DTXWeb preview/apply.
 
-Before rollout, inspect a known protected Perseus route and identify its actual unauthenticated Access signal. The response can differ by client and device posture:
+DTXWeb must never create its own serial list or posture rule in this slice.
 
-- If it returns an Access or direct-IdP redirect, set an uncommitted regex that matches the `Location` value:
+## Pulumi Backend And Secret Handling
 
-  ```bash
-  export ACCESS_REDIRECT_RE='<regex matching the tenant Access redirect Location>'
-  ```
+DTXWeb follows the current Perseus local-backend operating model.
 
-  For the normal Cloudflare Access login page, a suitable value is:
+```bash
+cd packages/infrastructure
+pulumi login --local
+```
 
-  ```bash
-  export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
-  ```
+`pulumi login --local` uses a filesystem backend rooted at the operator's home directory; default state is stored under `~/.pulumi`.
 
-- If it returns HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers, leave `ACCESS_REDIRECT_RE` unset. The helpers below recognize that Access-denial signal directly.
+The repository ignores `Pulumi.*.yaml`, `.pulumi/`, build output, dependencies, and local env files. Do not commit:
 
-If Perseus uses instant authentication, use the observed direct IdP redirect shape when a redirect is present. Keep one identity-provider and instant-authentication mode for the whole DTXWeb rollout.
+- operator email;
+- Cloudflare API token;
+- device serials;
+- Access cookies/JWTs;
+- Pulumi stack config files;
+- Pulumi state exports;
+- screenshots containing security identifiers.
 
-Never commit the operator email, device serial numbers, tenant-specific cookies/tokens, or other credentials.
+Use `accessEmail` as Pulumi secret config. `devicePostureRuleId` is a non-secret Cloudflare resource ID.
+
+## Cloudflare API Credential
+
+Set `CLOUDFLARE_API_TOKEN` in the operator shell using a token scoped to the DTXWeb Cloudflare account with the least privilege needed for these resources.
+
+For Access application creation/update/delete, the required Cloudflare permission is:
+
+```text
+Access: Apps and Policies Write
+```
+
+Do not use a Global API Key for this workflow.
+
+## Establish The Shared Config Values
+
+Before configuring DTXWeb, obtain these values without committing or printing them into PR comments/logs:
+
+- Cloudflare account ID;
+- operator Access email;
+- current Perseus `adminAccessDevicePostureRuleId` output.
+
+When already logged into the correct Perseus backend/production stack, the posture ID can be read with:
+
+```bash
+pulumi stack output adminAccessDevicePostureRuleId
+```
+
+Store the resulting value only in the local DTXWeb Pulumi stack configs.
+
+## Initialize Or Select DTXWeb Stacks
+
+From `packages/infrastructure`:
+
+```bash
+pulumi stack select pre-prod || pulumi stack init pre-prod
+pulumi stack select production || pulumi stack init production
+```
+
+Configure both stacks using shell variables populated locally by the operator:
+
+```bash
+pulumi config set cloudflareAccountId "$DTX_CLOUDFLARE_ACCOUNT_ID" --stack pre-prod
+pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack pre-prod
+pulumi config set devicePostureRuleId "$DTX_DEVICE_POSTURE_RULE_ID" --stack pre-prod
+
+pulumi config set cloudflareAccountId "$DTX_CLOUDFLARE_ACCOUNT_ID" --stack production
+pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack production
+pulumi config set devicePostureRuleId "$DTX_DEVICE_POSTURE_RULE_ID" --stack production
+```
+
+The optional session override is:
+
+```bash
+pulumi config set accessSessionDuration 12h --stack pre-prod
+pulumi config set accessSessionDuration 12h --stack production
+```
+
+Omit it to use the code default of `12h`.
+
+Hostnames and production destinations are not config values.
+
+## Preflight Repository Checks
+
+Before any preview:
+
+```bash
+bun install --frozen-lockfile
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure test:coverage
+.github/scripts/ci-affected-scope.test.sh
+```
+
+All commands must pass.
 
 ## Header Verification Helpers
 
-Use unauthenticated requests with no Access cookies. A request that fails DNS, connection, TLS, or timeout checks MUST fail the assertion instead of being interpreted as an unprotected route.
+Use unauthenticated requests with no Access cookies. A DNS, connection, TLS, or timeout failure must fail loudly rather than count as an unprotected route.
 
 ```bash
 http_headers() {
@@ -114,41 +191,56 @@ assert_no_access_interception() {
 }
 ```
 
-Dry-run the harness before changing DTXWeb:
+Before changing DTXWeb Access:
 
-- `assert_access_intercepted` against a known protected Perseus URL must pass.
-- `assert_no_access_interception https://dtx.hapadona.com/` must pass before production Access exists.
-- `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` must fail non-zero.
+- configure `ACCESS_REDIRECT_RE` only when the tenant's known Perseus flow uses a redirect signal;
+- prove `assert_access_intercepted` passes on a known protected Perseus URL;
+- prove `assert_no_access_interception https://dtx.hapadona.com/` passes before production Access exists;
+- prove `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` exits non-zero.
 
-Do not proceed until the invalid-host check fails loudly.
+Do not continue if the invalid-host test returns success.
 
-## Rollout Order
+# Phase 1 — Pre-production
 
-1. Confirm the Perseus IdP, instant-auth mode, operator identity, and serial posture rule.
-2. Dry-run the header helpers.
-3. Create and verify `DTXWeb Pre-prod`.
-4. Prove pre-production password login, Google OAuth, posture denial, and API non-interception.
-5. Stop and roll back if any required pre-production check fails.
-6. Create `DTXWeb Production App` with only `/app` and `/app/*`.
-7. Run the complete production matrix.
-8. Prove the Access identity selector and posture selector independently.
-9. Run production browser and desktop-login checks.
-10. Characterize expired Access behavior during SvelteKit client-side navigation.
-11. Record final non-sensitive results and deferred limitations.
+Production must not be applied until this entire phase is green.
 
-## Pre-production Configuration
+## 1. Preview Pre-production
 
-Create `DTXWeb Pre-prod` as **Self-hosted and private** for the entire public hostname:
+Run:
 
-```text
-pre-prod.dtx.hapadona.com
+```bash
+pulumi preview --stack pre-prod
 ```
 
-Set session duration to `12h`, attach the operator `Allow` policy with the serial-number posture requirement, and use the same IdP/instant-auth mode as Perseus. Do not add `api.pre-prod.dtx.hapadona.com`, Service Auth, Managed OAuth, or service tokens.
+The preview must create/update only the DTXWeb pre-production Access application.
 
-## Pre-production Verification Matrix
+Expected security shape:
 
-Run the following with no Access session:
+- name: `DTXWeb Pre-prod`;
+- type: self-hosted;
+- hostname-wide destination: `pre-prod.dtx.hapadona.com`;
+- one `allow` policy containing the configured email `Include` and existing posture-rule `Require`;
+- no API hostname;
+- no serial list;
+- no posture rule;
+- no service token;
+- no Worker/storage/runtime resource.
+
+If the preview differs, stop. Do not apply.
+
+## 2. Apply Pre-production — Operator Only
+
+Run only after manually reviewing the preview:
+
+```bash
+pulumi up --stack pre-prod
+```
+
+Review the interactive Pulumi confirmation and approve only the expected pre-production Access application change.
+
+## 3. Pre-production Verification Matrix
+
+With no Access session:
 
 ```bash
 assert_access_intercepted https://pre-prod.dtx.hapadona.com/
@@ -166,26 +258,63 @@ assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/__data.json
 assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
 ```
 
-Every command must exit `0`. If one fails, disable/delete `DTXWeb Pre-prod` and stop before production.
+Every command must exit `0`.
 
-On the trusted operator device, complete both password login and Google OAuth behind the hostname-wide Access session and confirm an API-backed `/app` page works normally.
+## 4. Pre-production Human Checks
 
-From a device that fails the serial posture rule, confirm pre-production is denied before DTXWeb loads.
+On the trusted WARP/Cloudflare One device with the configured operator identity:
 
-## Production Configuration
+1. Enter the pre-production hostname through Access.
+2. Complete password login.
+3. Confirm `/app` works behind Access and can use the API.
+4. Log out of Supabase while keeping Access.
+5. Complete Google OAuth and confirm callback/login still succeeds.
 
-Only after all required pre-production checks pass, create `DTXWeb Production App` as **Self-hosted and private** with exactly:
+From a device that fails the Perseus serial posture rule, confirm the pre-production hostname is denied before DTXWeb loads.
+
+If any required check fails, execute **Rollback — Pre-production** below and do not proceed to production.
+
+# Phase 2 — Production
+
+Start only after Phase 1 is fully green.
+
+## 5. Preview Production
+
+Run:
+
+```bash
+pulumi preview --stack production
+```
+
+The preview must create/update only `DTXWeb Production App` with exactly these destinations:
 
 ```text
 dtx.hapadona.com/app
 dtx.hapadona.com/app/*
 ```
 
-Set session duration to `12h`, attach the same operator `Allow` policy and serial posture requirement, and preserve the Perseus IdP/instant-auth mode. Do not add a hostname-wide production destination, public routes, Service Auth, Managed OAuth, or service tokens.
+Hard stops:
 
-## Production Header Matrix
+- hostname-wide `dtx.hapadona.com` destination;
+- any API destination;
+- any public route destination;
+- new serial list/posture rule;
+- service token/Service Auth;
+- Worker/storage/runtime resource.
 
-Run with no Access session:
+## 6. Apply Production — Operator Only
+
+After manually reviewing the production preview:
+
+```bash
+pulumi up --stack production
+```
+
+Approve only the expected production Access application change.
+
+## 7. Production Header Matrix
+
+With no Access session:
 
 ```bash
 assert_access_intercepted https://dtx.hapadona.com/app
@@ -205,100 +334,144 @@ assert_no_access_interception https://api.dtx.hapadona.com/
 assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
 ```
 
-Every command must exit `0`. `/app/` is an explicit path-semantics probe; do not assume its behavior from the dashboard string alone. `/app/__data.json` proves SvelteKit data requests are inside the Access boundary. `/preview/1` exercises the real dynamic preview route instead of a 404 prefix.
+Every command must exit `0`.
 
-If any public route or API is intercepted, disable the production application, correct the destinations, and rerun this entire matrix before continuing.
+`/app/` is an explicit path-semantics probe. `/app/__data.json` proves framework data requests are inside the gate. `/preview/1` exercises a real public preview route.
 
-## Production Identity And Posture Verification
+## 8. Production Identity And Posture Checks
 
-Verify the two Access policy clauses independently:
+Prove the policy clauses independently:
 
-1. Configured operator identity on the trusted device: allowed.
-2. On that same trusted device, use a fresh browser profile/session and authenticate to Access with a second IdP identity that is NOT in the `Include` list: denied by Access.
-3. Configured operator identity from a device that fails the serial posture rule: denied by Access.
+1. Allowed operator identity + trusted device: allowed.
+2. Same trusted device + fresh browser profile + a second IdP identity not in the policy `Include`: denied by Access.
+3. Allowed operator identity + device that fails posture: denied by Access.
 
-A second Supabase account is not a substitute for check 2; the Access identity selector and Supabase session are separate gates.
+A second Supabase identity is not a substitute for check 2.
 
-Do not claim the identity selector verified if no non-allowed IdP identity was actually exercised.
-
-## Trusted Production Browser Verification
+## 9. Trusted Production Browser Check
 
 On the trusted operator device:
 
 1. Open `/app` and pass Access.
 2. With no Supabase session, confirm DTXWeb redirects to public `/login`.
-3. Complete Supabase login and confirm return to protected `/app` succeeds under the existing Access session.
+3. Complete Supabase login and return to protected `/app`.
 4. Sign out of Supabase and confirm `/app` remains Access-protected.
 
-Characterize the non-operator dead end separately:
+Characterize the expected non-operator dead end separately:
 
-1. Use a Supabase account that does not correspond to the allowed Access identity.
-2. Authenticate on public `/login` and confirm the return to `/app` is denied by Access.
-3. Confirm revisiting `/login` with that Supabase session redirects back to `/app` and no public sign-out UI is reachable.
+1. Sign in on public `/login` with a Supabase account that does not correspond to the allowed Access identity.
+2. Confirm the `/app` return is denied.
+3. Confirm revisiting `/login` while that Supabase session exists redirects back to denied `/app` and no public sign-out UI is reachable.
 4. Recover by clearing the production Drumery/Supabase cookies.
 
-Record this as a known limitation. Do not widen Access to make the non-operator account work.
+Do not widen Access to make the non-operator account work.
 
-## Access Session Expiry / Client-side Navigation Check
-
-The root server layout has a server `load`, so client-side navigation uses SvelteKit data requests under paths such as `/app/__data.json`.
+## 10. Access Session Expiry / Client-side Navigation
 
 On the trusted operator device with a valid Supabase session:
 
-1. Keep a browser tab on a public production page.
-2. End the Access session using the tenant's normal Access logout/session-clearing procedure so a new protected request requires Access again.
-3. Trigger a SvelteKit client-side navigation into `/app` without first doing a full-page protected navigation.
-4. Record what the UI shows when the framework data request encounters Access reauthentication.
-5. Navigate directly/reload `/app` and confirm the browser can complete Access reauthentication and recover.
+1. Keep a tab on a public production page.
+2. End the Access session using the tenant's normal Access logout/session-clearing procedure.
+3. Trigger SvelteKit client-side navigation into `/app`.
+4. Record what the UI displays when the protected data request requires Access again.
+5. Directly navigate/reload `/app` and confirm the operator can reauthenticate and recover.
 
-If client-side navigation shows an opaque fetch error but a direct `/app` reload recovers, document that UX as a deferred follow-up. Do not add a bypass. If the operator cannot recover with a direct browser navigation, disable the production Access application and investigate before acceptance.
+An opaque client-navigation error with successful direct reload is a documented UX follow-up. Failure to recover on direct `/app` navigation is a production acceptance failure.
 
-## Production Desktop Login Verification
-
-This is required because standalone desktop development against a deployed web environment also traverses the protected production `/app` handoff in the current operator setup.
+## 11. Production Desktop Login
 
 ### Bundled desktop
 
-On the trusted operator device:
-
-1. Start desktop login and confirm public `/login?redirect=desktop&desktop_callback=...` loads without Access interception.
-2. Complete password login and confirm the return through protected `/app?redirect=desktop...` succeeds.
-3. Confirm the generated magic link reaches `dtx://auth-callback` and the desktop session authenticates.
+1. Start desktop login and confirm the browser opens public `/login?redirect=desktop&desktop_callback=...` without Access interception.
+2. Complete password login and confirm protected `/app?redirect=desktop...` succeeds.
+3. Confirm `dtx://auth-callback` authenticates the desktop app.
 4. Repeat with Google login.
 
 ### Standalone `tauri dev`
 
-Using the current standalone desktop-development setup:
+Using the current standalone development setup targeting deployed production:
 
-1. Start `bun run dev:desktop` and confirm the browser login target is the expected deployed production web hostname.
-2. Keep the login flow in the same browser tab so `/login` can preserve `desktop_callback` in `sessionStorage`.
-3. Complete password login and confirm protected `/app?redirect=desktop...` passes Access.
-4. Confirm the magic link reaches `http://127.0.0.1:<configured-port>/auth-callback`.
+1. Start `bun run dev:desktop`.
+2. Keep login/callback in the same browser tab.
+3. Complete password login and pass protected `/app`.
+4. Confirm the callback reaches `http://127.0.0.1:<configured-port>/auth-callback`.
 5. Repeat with Google login.
 
-This check is required when the current `.env` points standalone desktop development at production. If the local operator configuration has deliberately changed, record the actual target and still verify the deployed-environment loopback flow before accepting production Access.
+The full local-stack `bun run dev` path is not an Access acceptance test because it intentionally uses localhost.
 
-The full local-stack `bun run dev` path is not an Access test: it uses `dev:local-web` and localhost intentionally.
+# Rollback
 
-## Rollback
+## Rollback — Pre-production
 
-Pre-production:
+Normal state-aware rollback:
 
-- Disable/delete `DTXWeb Pre-prod` if the hostname-wide gate fails a required check.
+```bash
+pulumi preview --destroy --stack pre-prod
+```
 
-Production:
+Confirm the destroy preview deletes **only** `DTXWeb Pre-prod`, then run:
 
-- Disable/delete `DTXWeb Production App` if the trusted operator cannot use `/app`, cannot recover after Access reauthentication, or cannot complete required desktop login.
-- If a public route or API is intercepted, disable the production application, restore exactly `/app` and `/app/*`, and rerun the entire Production Header Matrix.
+```bash
+pulumi destroy --stack pre-prod --yes
+```
 
-Do not introduce service tokens, API Access, route bypasses, or policy widening as an emergency workaround.
+Do not touch production.
 
-No Worker rollback or code deployment is required for these dashboard-only changes.
+## Rollback — Production
 
-## References
+Normal state-aware rollback:
 
-- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
-- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
-- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
-- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
-- https://developers.cloudflare.com/learning-paths/clientless-access/customize-ux/login-page/
+```bash
+pulumi preview --destroy --stack production
+```
+
+Confirm the destroy preview deletes **only** `DTXWeb Production App`, then run:
+
+```bash
+pulumi destroy --stack production --yes
+```
+
+Do not destroy pre-production merely because production failed.
+
+## Emergency Fallback — Pulumi State/Backend Unavailable
+
+If immediate Access removal is necessary but the local Pulumi backend/state cannot be accessed, use the Cloudflare Zero Trust dashboard as the emergency provider-side recovery path:
+
+1. Open **Zero Trust > Access controls > Applications**.
+2. Locate exactly `DTXWeb Pre-prod` or `DTXWeb Production App`.
+3. Disable/delete only the affected DTXWeb application.
+4. Do not alter Perseus posture resources or any other Access application.
+5. Do not create a temporary bypass/service token/wider application.
+
+When Pulumi state becomes available again, reconcile the provider-side deletion before the next `pulumi up`; do not apply stale state blindly.
+
+# Final Non-sensitive Record
+
+Record only outcomes such as:
+
+```text
+Infrastructure unit/coverage checks: PASS
+Affected-scope CI contract: PASS
+Pre-prod Pulumi preview: PASS
+Pre-prod Access apply + verification: PASS
+Production Pulumi preview: PASS
+Production public/protected route matrix: PASS
+Production Access identity selector: PASS
+Production posture selector: PASS
+Production operator browser auth: PASS
+Production expired-session recovery characterized: PASS
+Production bundled desktop login: PASS
+Production standalone tauri-dev login: PASS
+```
+
+Never paste secrets, identities, device serials, Access tokens/cookies/JWTs, or sensitive screenshots into the record.
+
+# References
+
+- Design: `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
+- Operator precedent: `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
+- Perseus Access implementation: `packages/infrastructure/src/admin-access.ts` in the Perseus repository
+- Cloudflare Access application API: https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/applications/methods/create/
+- Pulumi DIY/local backend: https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/
+- Pulumi destroy troubleshooting: https://www.pulumi.com/docs/iac/operations/troubleshooting/destroy-failures/

--- a/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -46,7 +46,7 @@ Before rollout, inspect a known protected Perseus route and identify its actual 
   For the normal Cloudflare Access login page, a suitable value is:
 
   ```bash
-  export ACCESS_REDIRECT_RE='^location: https://[^/]+\\.cloudflareaccess\\.com/cdn-cgi/access/'
+  export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
   ```
 
 - If it returns HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers, leave `ACCESS_REDIRECT_RE` unset. The helpers below recognize that Access-denial signal directly.
@@ -80,13 +80,13 @@ has_access_interception() {
   headers="$1"
 
   if [ -n "${ACCESS_REDIRECT_RE:-}" ] &&
-    printf '%s\\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+    printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
     return 0
   fi
 
-  if printf '%s\\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
-    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
-    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
+  if printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
+    printf '%s\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
+    printf '%s\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
     return 0
   fi
 
@@ -96,7 +96,7 @@ has_access_interception() {
 assert_access_intercepted() {
   url="$1"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\(aud\|domain\):/Ip'
   has_access_interception "$headers" || {
     echo "FAIL: Access did not intercept $url" >&2
     return 1
@@ -106,7 +106,7 @@ assert_access_intercepted() {
 assert_no_access_interception() {
   url="$1"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\(aud\|domain\):/Ip'
   if has_access_interception "$headers"; then
     echo "FAIL: Access unexpectedly intercepted $url" >&2
     return 1

--- a/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -1,59 +1,45 @@
 # Cloudflare Zero Trust Web Access Runbook (operator-executed)
 
-This runbook owns live DTXWeb Cloudflare Access rollout, verification, and rollback.
+This is the live operator procedure for DTXWeb Cloudflare Access. Steps that mutate Cloudflare, require interactive identity/device checks, or require browser observation are performed by a human operator, not by an implementation agent.
 
-Steps that mutate Cloudflare (`pulumi up`, `pulumi destroy`, dashboard disable/delete), require interactive identity login, require a trusted/untrusted physical device, or require visual browser/desktop observation are run by a human operator, not by an implementation agent.
+## Scope
 
-## Scope And Invariants
-
-DTXWeb Pulumi owns exactly one Access application per stack:
-
-| Stack | Application | Protected destination |
+| Stack | Application | Protection scope |
 | --- | --- | --- |
 | `pre-prod` | `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
-| `production` | `DTXWeb Production App` | `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` |
+| `production` | `DTXWeb Production App` | `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` only |
 
-Wrangler continues to own Workers/API/runtime infrastructure.
+Wrangler continues to own Worker/API/runtime infrastructure. Both API hostnames remain outside Access.
 
-Production `/app` and deployed-environment desktop login are intentionally operator-only. Supabase remains the inner application-authentication gate.
+DTXWeb reuses the Perseus-managed device-posture rule by Cloudflare resource ID. Do not create another serial list/posture rule, service token, Service Auth policy, API Access app, bypass policy, or wider production destination.
 
-Production private routes must live at exact `/app` or below `/app/`. The current SvelteKit guard uses the slightly broader `pathname.startsWith('/app')`; do not rely on that string-prefix quirk for new private sibling routes.
+## Production Hold — Better Auth/D1 Cutover
 
-Production `/login` and `/auth/*` remain public because desktop/password/Google flows return through those routes before the protected `/app` handoff.
+**Do not run `pulumi up --stack production` yet.**
 
-Both API hostnames remain outside Access:
+The queued Better Auth/D1 migration removes the current desktop callback/magic-link flow, adds Device Authorization approval at `/app/desktop-auth`, and explicitly schedules reconciliation of PR #221's Zero Trust documents.
 
-- `api.dtx.hapadona.com`
-- `api.pre-prod.dtx.hapadona.com`
+Pre-production Access may be applied and verified now. Production preview may be used as a non-mutating scope check. Production live apply remains blocked until the Better Auth cutover has landed and this runbook has been reconciled with the final Device Authorization/browser acceptance flow.
 
-Do not create service tokens, Service Auth policies, bypass policies, API Access applications, or wider production destinations as troubleshooting shortcuts.
+Removing this hold requires a later reviewed update to this runbook; do not treat the absence of technical errors from `pulumi preview --stack production` as permission to apply.
 
-## Shared Posture Ownership
+## Pulumi Backend And Secrets
 
-Perseus owns the trusted-device serial list and device-posture rule. DTXWeb stores only the existing Cloudflare posture-rule resource ID as Pulumi config.
-
-If Perseus replaces that posture rule with a new Cloudflare resource, update DTXWeb `devicePostureRuleId` in both stacks before the next DTXWeb preview/apply.
-
-DTXWeb must never create its own serial list or posture rule in this slice.
-
-## Pulumi Backend And Secret Handling
-
-DTXWeb follows the current Perseus local-backend operating model.
+From `packages/infrastructure`:
 
 ```bash
-cd packages/infrastructure
 pulumi login --local
 ```
 
-`pulumi login --local` uses a filesystem backend rooted at the operator's home directory; default state is stored under `~/.pulumi`.
+The default local filesystem backend is under the operator's home directory (`~/.pulumi`). The repository also ignores project-local `.pulumi/` defensively.
 
-The repository ignores `Pulumi.*.yaml`, `.pulumi/`, build output, dependencies, and local env files. Do not commit:
+Never commit or paste into PRs/logs:
 
 - operator email;
 - Cloudflare API token;
 - device serials;
 - Access cookies/JWTs;
-- Pulumi stack config files;
+- `Pulumi.<stack>.yaml` files;
 - Pulumi state exports;
 - screenshots containing security identifiers.
 
@@ -61,42 +47,17 @@ Use `accessEmail` as Pulumi secret config. `devicePostureRuleId` is a non-secret
 
 ## Cloudflare API Credential
 
-Set `CLOUDFLARE_API_TOKEN` in the operator shell using a token scoped to the DTXWeb Cloudflare account with the least privilege needed for these resources.
+Set `CLOUDFLARE_API_TOKEN` in the operator shell with the least privilege needed for the Access application lifecycle. Use the Cloudflare Access apps/policies write permission required by the selected provider/API; do not use a Global API Key.
 
-For Access application creation/update/delete, the required Cloudflare permission is:
-
-```text
-Access: Apps and Policies Write
-```
-
-Do not use a Global API Key for this workflow.
-
-## Establish The Shared Config Values
-
-Before configuring DTXWeb, obtain these values without committing or printing them into PR comments/logs:
-
-- Cloudflare account ID;
-- operator Access email;
-- current Perseus `adminAccessDevicePostureRuleId` output.
-
-When already logged into the correct Perseus backend/production stack, the posture ID can be read with:
+## Initialize Or Select Stacks
 
 ```bash
-pulumi stack output adminAccessDevicePostureRuleId
-```
-
-Store the resulting value only in the local DTXWeb Pulumi stack configs.
-
-## Initialize Or Select DTXWeb Stacks
-
-From `packages/infrastructure`:
-
-```bash
+cd packages/infrastructure
 pulumi stack select pre-prod || pulumi stack init pre-prod
 pulumi stack select production || pulumi stack init production
 ```
 
-Configure both stacks using shell variables populated locally by the operator:
+Configure both stacks from local shell variables:
 
 ```bash
 pulumi config set cloudflareAccountId "$DTX_CLOUDFLARE_ACCOUNT_ID" --stack pre-prod
@@ -108,33 +69,68 @@ pulumi config set --secret accessEmail "$DTX_ACCESS_EMAIL" --stack production
 pulumi config set devicePostureRuleId "$DTX_DEVICE_POSTURE_RULE_ID" --stack production
 ```
 
-The optional session override is:
+Optional explicit session duration:
 
 ```bash
 pulumi config set accessSessionDuration 12h --stack pre-prod
 pulumi config set accessSessionDuration 12h --stack production
 ```
 
-Omit it to use the code default of `12h`.
+Hostnames and production destinations are code-owned; do not add them as config.
 
-Hostnames and production destinations are not config values.
+## Preflight — Shared Posture Rule Must Match Perseus
 
-## Preflight Repository Checks
+This check replaces the old "remember to update the ID" instruction.
 
-Before any preview:
+Set `PERSEUS_INFRA_DIR` to the local Perseus `packages/infrastructure` directory. Ensure that directory is logged into the correct Pulumi backend and has the production Perseus stack selected, then run from the DTXWeb infrastructure directory:
+
+```bash
+: "${PERSEUS_INFRA_DIR:?set PERSEUS_INFRA_DIR to Perseus packages/infrastructure}"
+
+PERSEUS_POSTURE_RULE_ID="$(
+  cd "$PERSEUS_INFRA_DIR" &&
+    pulumi stack output adminAccessDevicePostureRuleId
+)" || exit 1
+
+test -n "$PERSEUS_POSTURE_RULE_ID" || {
+  echo 'FAIL: Perseus posture-rule output is empty' >&2
+  exit 1
+}
+
+for stack in pre-prod production; do
+  configured="$(pulumi config get devicePostureRuleId --stack "$stack")" || exit 1
+  if [ "$configured" != "$PERSEUS_POSTURE_RULE_ID" ]; then
+    echo "FAIL: $stack devicePostureRuleId does not match current Perseus rule" >&2
+    exit 1
+  fi
+done
+
+unset configured PERSEUS_POSTURE_RULE_ID
+```
+
+Any mismatch is a hard stop before preview or apply.
+
+## Preflight — Repository Gates And Build
+
+Run from the DTXWeb repository root before every rollout session:
 
 ```bash
 bun install --frozen-lockfile
 bun run --filter=@dtx/infrastructure check
 bun run --filter=@dtx/infrastructure test:coverage
+bun run --filter=@dtx/infrastructure build
 .github/scripts/ci-affected-scope.test.sh
+bun run lint
+bunx prettier --check .
 ```
 
-All commands must pass.
+All commands must pass. `build` is mandatory because `Pulumi.yaml` executes `dist/index.js`; do not preview stale or missing compiled output.
+
+If any infrastructure source changes after this block, rebuild before the next preview.
 
 ## Header Verification Helpers
 
-Use unauthenticated requests with no Access cookies. A DNS, connection, TLS, or timeout failure must fail loudly rather than count as an unprotected route.
+Use unauthenticated requests with no Access cookies. DNS, connection, TLS, and timeout failures must fail loudly rather than count as public/unprotected success.
 
 ```bash
 http_headers() {
@@ -191,54 +187,45 @@ assert_no_access_interception() {
 }
 ```
 
-Before changing DTXWeb Access:
+Before applying DTXWeb Access:
 
-- configure `ACCESS_REDIRECT_RE` only when the tenant's known Perseus flow uses a redirect signal;
-- prove `assert_access_intercepted` passes on a known protected Perseus URL;
+- if the tenant uses redirect-based Access interception, set an uncommitted `ACCESS_REDIRECT_RE` matching the known Perseus flow;
+- prove `assert_access_intercepted` passes against a known protected Perseus URL;
 - prove `assert_no_access_interception https://dtx.hapadona.com/` passes before production Access exists;
 - prove `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` exits non-zero.
 
-Do not continue if the invalid-host test returns success.
+Do not continue if the invalid-host check succeeds.
 
 # Phase 1 — Pre-production
 
-Production must not be applied until this entire phase is green.
-
 ## 1. Preview Pre-production
 
-Run:
+From `packages/infrastructure`, after the build/preflight:
 
 ```bash
 pulumi preview --stack pre-prod
 ```
 
-The preview must create/update only the DTXWeb pre-production Access application.
+The preview must contain only the DTXWeb pre-production Access application with:
 
-Expected security shape:
-
-- name: `DTXWeb Pre-prod`;
-- type: self-hosted;
-- hostname-wide destination: `pre-prod.dtx.hapadona.com`;
-- one `allow` policy containing the configured email `Include` and existing posture-rule `Require`;
+- name `DTXWeb Pre-prod`;
+- self-hosted type;
+- hostname-wide destination `pre-prod.dtx.hapadona.com`;
+- one allow policy using configured email Include + existing posture Require;
 - no API hostname;
-- no serial list;
-- no posture rule;
-- no service token;
-- no Worker/storage/runtime resource.
+- no posture/list/service-token/Worker/storage resource.
 
-If the preview differs, stop. Do not apply.
+Any extra resource or different scope is a hard stop.
 
 ## 2. Apply Pre-production — Operator Only
-
-Run only after manually reviewing the preview:
 
 ```bash
 pulumi up --stack pre-prod
 ```
 
-Review the interactive Pulumi confirmation and approve only the expected pre-production Access application change.
+Review the interactive Pulumi confirmation. Approve only the expected `DTXWeb Pre-prod` Access application change.
 
-## 3. Pre-production Verification Matrix
+## 3. Pre-production Header Matrix
 
 With no Access session:
 
@@ -262,216 +249,94 @@ Every command must exit `0`.
 
 ## 4. Pre-production Human Checks
 
-On the trusted WARP/Cloudflare One device with the configured operator identity:
+On the trusted device with the configured operator identity:
 
-1. Enter the pre-production hostname through Access.
-2. Complete password login.
-3. Confirm `/app` works behind Access and can use the API.
-4. Log out of Supabase while keeping Access.
-5. Complete Google OAuth and confirm callback/login still succeeds.
+1. enter the pre-production hostname through Access;
+2. complete the current web login flow;
+3. confirm `/app` works behind Access and can use the API;
+4. complete the current Google login/OAuth flow;
+5. from a device that fails the shared posture rule, confirm the hostname is denied before DTXWeb loads.
 
-From a device that fails the Perseus serial posture rule, confirm the pre-production hostname is denied before DTXWeb loads.
+The application auth mechanism will change during the queued Better Auth cutover; re-run the relevant pre-production auth acceptance after that migration. The Access hostname-wide boundary itself does not change.
 
-If any required check fails, execute **Rollback — Pre-production** below and do not proceed to production.
+If required Access/header/device checks fail, use the rollback section below.
 
-# Phase 2 — Production
+# Phase 2 — Production (BLOCKED)
 
-Start only after Phase 1 is fully green.
+Production Access is intentionally not applied in this version of the runbook.
 
-## 5. Preview Production
-
-Run:
+A non-mutating preview is allowed after the normal build/preflight:
 
 ```bash
 pulumi preview --stack production
 ```
 
-The preview must create/update only `DTXWeb Production App` with exactly these destinations:
+It must show exactly one `DTXWeb Production App` with only:
 
 ```text
 dtx.hapadona.com/app
 dtx.hapadona.com/app/*
 ```
 
-Hard stops:
+Hard stops include hostname-wide production Access, API/public destinations, posture/list/token resources, or runtime infrastructure.
 
-- hostname-wide `dtx.hapadona.com` destination;
-- any API destination;
-- any public route destination;
-- new serial list/posture rule;
-- service token/Service Auth;
-- Worker/storage/runtime resource.
+**Do not run `pulumi up --stack production`.**
 
-## 6. Apply Production — Operator Only
+Before production apply is allowed, the Better Auth/D1 cutover must land and Task 14 must reconcile this runbook with the final `/app/desktop-auth` Device Authorization flow. That reconciliation must restore the production route matrix plus independent identity/posture, browser, session-expiry, and desktop acceptance checks for the new auth system.
 
-After manually reviewing the production preview:
+# Rollback — Pre-production
 
-```bash
-pulumi up --stack production
-```
+Destroying pre-production Access returns `pre-prod.dtx.hapadona.com` to its prior public state.
 
-Approve only the expected production Access application change.
+Before destroy, determine which Wrangler environment currently serves the pre-production hostname. In particular, `pre-prod-prod-data` binds the same pre-production hostname to an API environment using production D1/R2 resources. If that mode is active, removing Access can make a production-data-backed web surface public.
 
-## 7. Production Header Matrix
+If public exposure is not acceptable, keep Access in place while repairing the rollout or first move the pre-production deployment away from production-backed data. Do not treat Access destroy as a neutral cleanup.
 
-With no Access session:
-
-```bash
-assert_access_intercepted https://dtx.hapadona.com/app
-assert_access_intercepted https://dtx.hapadona.com/app/
-assert_access_intercepted https://dtx.hapadona.com/app/score
-assert_access_intercepted https://dtx.hapadona.com/app/__data.json
-
-assert_no_access_interception https://dtx.hapadona.com/
-assert_no_access_interception https://dtx.hapadona.com/blog
-assert_no_access_interception https://dtx.hapadona.com/preview/1
-assert_no_access_interception https://dtx.hapadona.com/editor
-assert_no_access_interception https://dtx.hapadona.com/tool/dtx-to-midi
-assert_no_access_interception https://dtx.hapadona.com/game
-assert_no_access_interception https://dtx.hapadona.com/login
-assert_no_access_interception https://dtx.hapadona.com/auth/callback
-assert_no_access_interception https://api.dtx.hapadona.com/
-assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
-```
-
-Every command must exit `0`.
-
-`/app/` is an explicit path-semantics probe. `/app/__data.json` proves framework data requests are inside the gate. `/preview/1` exercises a real public preview route.
-
-## 8. Production Identity And Posture Checks
-
-Prove the policy clauses independently:
-
-1. Allowed operator identity + trusted device: allowed.
-2. Same trusted device + fresh browser profile + a second IdP identity not in the policy `Include`: denied by Access.
-3. Allowed operator identity + device that fails posture: denied by Access.
-
-A second Supabase identity is not a substitute for check 2.
-
-## 9. Trusted Production Browser Check
-
-On the trusted operator device:
-
-1. Open `/app` and pass Access.
-2. With no Supabase session, confirm DTXWeb redirects to public `/login`.
-3. Complete Supabase login and return to protected `/app`.
-4. Sign out of Supabase and confirm `/app` remains Access-protected.
-
-Characterize the expected non-operator dead end separately:
-
-1. Sign in on public `/login` with a Supabase account that does not correspond to the allowed Access identity.
-2. Confirm the `/app` return is denied.
-3. Confirm revisiting `/login` while that Supabase session exists redirects back to denied `/app` and no public sign-out UI is reachable.
-4. Recover by clearing the production Drumery/Supabase cookies.
-
-Do not widen Access to make the non-operator account work.
-
-## 10. Access Session Expiry / Client-side Navigation
-
-On the trusted operator device with a valid Supabase session:
-
-1. Keep a tab on a public production page.
-2. End the Access session using the tenant's normal Access logout/session-clearing procedure.
-3. Trigger SvelteKit client-side navigation into `/app`.
-4. Record what the UI displays when the protected data request requires Access again.
-5. Directly navigate/reload `/app` and confirm the operator can reauthenticate and recover.
-
-An opaque client-navigation error with successful direct reload is a documented UX follow-up. Failure to recover on direct `/app` navigation is a production acceptance failure.
-
-## 11. Production Desktop Login
-
-### Bundled desktop
-
-1. Start desktop login and confirm the browser opens public `/login?redirect=desktop&desktop_callback=...` without Access interception.
-2. Complete password login and confirm protected `/app?redirect=desktop...` succeeds.
-3. Confirm `dtx://auth-callback` authenticates the desktop app.
-4. Repeat with Google login.
-
-### Standalone `tauri dev`
-
-Using the current standalone development setup targeting deployed production:
-
-1. Start `bun run dev:desktop`.
-2. Keep login/callback in the same browser tab.
-3. Complete password login and pass protected `/app`.
-4. Confirm the callback reaches `http://127.0.0.1:<configured-port>/auth-callback`.
-5. Repeat with Google login.
-
-The full local-stack `bun run dev` path is not an Access acceptance test because it intentionally uses localhost.
-
-# Rollback
-
-## Rollback — Pre-production
-
-Normal state-aware rollback:
+When public rollback is explicitly acceptable:
 
 ```bash
 pulumi preview --destroy --stack pre-prod
 ```
 
-Confirm the destroy preview deletes **only** `DTXWeb Pre-prod`, then run:
+Confirm the only deletion is `DTXWeb Pre-prod`, then:
 
 ```bash
 pulumi destroy --stack pre-prod --yes
 ```
 
-Do not touch production.
+# Emergency Fallback — Pulumi Backend/State Unavailable
 
-## Rollback — Production
+If immediate Access removal is required but the local Pulumi backend/state cannot be accessed:
 
-Normal state-aware rollback:
+1. open **Zero Trust > Access controls > Applications**;
+2. locate exactly `DTXWeb Pre-prod` (or, after the future production hold is removed, `DTXWeb Production App`);
+3. disable/delete only that DTXWeb application;
+4. do not alter Perseus posture resources or unrelated Access applications;
+5. do not create a bypass/service token/wider application.
 
-```bash
-pulumi preview --destroy --stack production
-```
-
-Confirm the destroy preview deletes **only** `DTXWeb Production App`, then run:
-
-```bash
-pulumi destroy --stack production --yes
-```
-
-Do not destroy pre-production merely because production failed.
-
-## Emergency Fallback — Pulumi State/Backend Unavailable
-
-If immediate Access removal is necessary but the local Pulumi backend/state cannot be accessed, use the Cloudflare Zero Trust dashboard as the emergency provider-side recovery path:
-
-1. Open **Zero Trust > Access controls > Applications**.
-2. Locate exactly `DTXWeb Pre-prod` or `DTXWeb Production App`.
-3. Disable/delete only the affected DTXWeb application.
-4. Do not alter Perseus posture resources or any other Access application.
-5. Do not create a temporary bypass/service token/wider application.
-
-When Pulumi state becomes available again, reconcile the provider-side deletion before the next `pulumi up`; do not apply stale state blindly.
+When Pulumi state is available again, reconcile the provider-side change before any later `pulumi up`.
 
 # Final Non-sensitive Record
 
-Record only outcomes such as:
+Record only outcomes, for example:
 
 ```text
 Infrastructure unit/coverage checks: PASS
 Affected-scope CI contract: PASS
+Private-route boundary test: PASS
+Perseus posture-rule ID matches both DTXWeb stack configs: PASS
 Pre-prod Pulumi preview: PASS
 Pre-prod Access apply + verification: PASS
-Production Pulumi preview: PASS
-Production public/protected route matrix: PASS
-Production Access identity selector: PASS
-Production posture selector: PASS
-Production operator browser auth: PASS
-Production expired-session recovery characterized: PASS
-Production bundled desktop login: PASS
-Production standalone tauri-dev login: PASS
+Production Pulumi preview: PASS or NOT RUN
+Production Access apply: BLOCKED pending Better Auth reconciliation
 ```
 
-Never paste secrets, identities, device serials, Access tokens/cookies/JWTs, or sensitive screenshots into the record.
+Never paste secrets, identities, device serials, Access tokens/cookies/JWTs, or sensitive screenshots.
 
 # References
 
 - Design: `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
 - Implementation plan: `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
 - Operator precedent: `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
+- queued Better Auth/D1 migration plan: Task 9 and Task 14
 - Perseus Access implementation: `packages/infrastructure/src/admin-access.ts` in the Perseus repository
-- Cloudflare Access application API: https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/applications/methods/create/
-- Pulumi DIY/local backend: https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/
-- Pulumi destroy troubleshooting: https://www.pulumi.com/docs/iac/operations/troubleshooting/destroy-failures/

--- a/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -1,0 +1,285 @@
+# Cloudflare Zero Trust Web Access Runbook
+
+## Scope And Invariants
+
+DTXWeb uses manually managed Cloudflare Zero Trust Access for two web surfaces:
+
+| Application | Protected destination |
+| --- | --- |
+| `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
+| `DTXWeb Production App` | `dtx.hapadona.com/app` |
+| `DTXWeb Production App` | `dtx.hapadona.com/app/*` |
+
+Production `/app` and production desktop login are intentionally operator-only. The Access identity and trusted-device posture are an outer gate; Supabase remains the inner application-authentication gate.
+
+Production Access covers the intended private route family: exact `/app` and descendants under `/app/`. New private production pages MUST live under `/app`; a new private sibling such as `/studio` or `/admin` would be publicly reachable until this Access design is updated. `hooks.server.ts` currently uses the slightly broader `pathname.startsWith('/app')`; do not rely on that string-prefix quirk for new routes.
+
+A normal Supabase user may reach public `/login`, authenticate successfully, and then be denied when returning to `/app`. If they now hold a Supabase session, the server redirects `/login` back to `/app` and the only current sign-out UI is inside the protected `(app)` layout. The current recovery is to clear the Drumery/Supabase cookies for `dtx.hapadona.com`. A public `/logout` route or changing the authenticated `/login` redirect is a deferred product decision, not part of this dashboard-only slice.
+
+Standalone desktop development (`bun run dev:desktop`) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup that points to production, so the ordinary standalone `tauri dev` login is operator-only after this rollout. Pointing it at pre-production does not help a non-operator because pre-production is hostname-wide Access-protected. Non-operator contributors must use the full local stack (`bun run dev`, which uses `dtx-desktop#dev:local-web`) or a separately designed ungated development environment.
+
+The web E2E harness can override `PLAYWRIGHT_BASE_URL`, but this slice provides no non-interactive Access credential. Unattended E2E/CI against `pre-prod.dtx.hapadona.com` is therefore unsupported until a separate Access-authentication design is approved.
+
+This runbook is the durable Zero Trust source of truth. `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` is precedent for human-executed Cloudflare operations but remains a historical API-migration checklist.
+
+## Required Policy
+
+Both Access applications use the same policy semantics:
+
+- Action: `Allow`
+- Include: the intended operator identity/email used for Perseus access
+- Require: the trusted-device serial-number posture check used for Perseus
+- Session duration: `12h`
+- Service Auth: none
+- Managed OAuth: off
+
+Reuse the existing Perseus identity provider and its current instant-authentication mode. Do not toggle instant authentication merely to make a header test easier.
+
+Before rollout, inspect a known protected Perseus route and set an uncommitted shell regex that matches the actual unauthenticated Access redirect for this tenant:
+
+```bash
+export ACCESS_REDIRECT_RE='<regex matching this tenant\'s Access redirect Location>'
+```
+
+For a tenant using the normal Cloudflare Access login page, a suitable value is:
+
+```bash
+export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
+```
+
+If Perseus uses instant authentication, set the regex to the known direct IdP redirect shape observed from that existing protected route. Keep one redirect mode for the whole DTXWeb rollout.
+
+Never commit the operator email, device serial numbers, tenant-specific cookies/tokens, or other credentials.
+
+## Header Verification Helpers
+
+Use unauthenticated requests with no Access cookies. A request that fails DNS, connection, TLS, or timeout checks MUST fail the assertion instead of being interpreted as an unprotected route.
+
+```bash
+http_headers() {
+  url="$1"
+  raw="$(curl -sS --max-time 15 -o /dev/null -D - "$url")" || {
+    echo "FAIL: no HTTP response from $url" >&2
+    return 1
+  }
+
+  headers="$(printf '%s\n' "$raw" | tr -d '\r')"
+  printf '%s\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ [0-9]{3}' || {
+    echo "FAIL: no HTTP status line from $url" >&2
+    return 1
+  }
+
+  printf '%s\n' "$headers"
+}
+
+assert_access_redirect() {
+  url="$1"
+  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
+  headers="$(http_headers "$url")" || return 1
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
+  printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE" || {
+    echo "FAIL: Access did not intercept $url" >&2
+    return 1
+  }
+}
+
+assert_no_access_redirect() {
+  url="$1"
+  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
+  headers="$(http_headers "$url")" || return 1
+  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
+  if printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+    echo "FAIL: Access unexpectedly intercepted $url" >&2
+    return 1
+  fi
+}
+```
+
+Dry-run the harness before changing DTXWeb:
+
+- `assert_access_redirect` against a known protected Perseus URL must pass.
+- `assert_no_access_redirect https://dtx.hapadona.com/` must pass before production Access exists.
+- `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` must fail non-zero.
+
+Do not proceed until the invalid-host check fails loudly.
+
+## Rollout Order
+
+1. Confirm the Perseus IdP, instant-auth mode, operator identity, and serial posture rule.
+2. Dry-run the header helpers.
+3. Create and verify `DTXWeb Pre-prod`.
+4. Prove pre-production password login, Google OAuth, posture denial, and API non-interception.
+5. Stop and roll back if any required pre-production check fails.
+6. Create `DTXWeb Production App` with only `/app` and `/app/*`.
+7. Run the complete production matrix.
+8. Prove the Access identity selector and posture selector independently.
+9. Run production browser and desktop-login checks.
+10. Characterize expired Access behavior during SvelteKit client-side navigation.
+11. Record final non-sensitive results and deferred limitations.
+
+## Pre-production Configuration
+
+Create `DTXWeb Pre-prod` as **Self-hosted and private** for the entire public hostname:
+
+```text
+pre-prod.dtx.hapadona.com
+```
+
+Set session duration to `12h`, attach the operator `Allow` policy with the serial-number posture requirement, and use the same IdP/instant-auth mode as Perseus. Do not add `api.pre-prod.dtx.hapadona.com`, Service Auth, Managed OAuth, or service tokens.
+
+## Pre-production Verification Matrix
+
+Run the following with no Access session:
+
+```bash
+assert_access_redirect https://pre-prod.dtx.hapadona.com/
+assert_access_redirect https://pre-prod.dtx.hapadona.com/login
+assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
+assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
+assert_access_redirect https://pre-prod.dtx.hapadona.com/preview/1
+assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
+assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
+assert_access_redirect https://pre-prod.dtx.hapadona.com/game
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
+assert_access_redirect https://pre-prod.dtx.hapadona.com/app/__data.json
+assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+```
+
+Every command must exit `0`. If one fails, disable/delete `DTXWeb Pre-prod` and stop before production.
+
+On the trusted operator device, complete both password login and Google OAuth behind the hostname-wide Access session and confirm an API-backed `/app` page works normally.
+
+From a device that fails the serial posture rule, confirm pre-production is denied before DTXWeb loads.
+
+## Production Configuration
+
+Only after all required pre-production checks pass, create `DTXWeb Production App` as **Self-hosted and private** with exactly:
+
+```text
+dtx.hapadona.com/app
+dtx.hapadona.com/app/*
+```
+
+Set session duration to `12h`, attach the same operator `Allow` policy and serial posture requirement, and preserve the Perseus IdP/instant-auth mode. Do not add a hostname-wide production destination, public routes, Service Auth, Managed OAuth, or service tokens.
+
+## Production Header Matrix
+
+Run with no Access session:
+
+```bash
+assert_access_redirect https://dtx.hapadona.com/app
+assert_access_redirect https://dtx.hapadona.com/app/
+assert_access_redirect https://dtx.hapadona.com/app/score
+assert_access_redirect https://dtx.hapadona.com/app/__data.json
+
+assert_no_access_redirect https://dtx.hapadona.com/
+assert_no_access_redirect https://dtx.hapadona.com/blog
+assert_no_access_redirect https://dtx.hapadona.com/preview/1
+assert_no_access_redirect https://dtx.hapadona.com/editor
+assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
+assert_no_access_redirect https://dtx.hapadona.com/game
+assert_no_access_redirect https://dtx.hapadona.com/login
+assert_no_access_redirect https://dtx.hapadona.com/auth/callback
+assert_no_access_redirect https://api.dtx.hapadona.com/
+assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+```
+
+Every command must exit `0`. `/app/` is an explicit path-semantics probe; do not assume its behavior from the dashboard string alone. `/app/__data.json` proves SvelteKit data requests are inside the Access boundary. `/preview/1` exercises the real dynamic preview route instead of a 404 prefix.
+
+If any public route or API is intercepted, disable the production application, correct the destinations, and rerun this entire matrix before continuing.
+
+## Production Identity And Posture Verification
+
+Verify the two Access policy clauses independently:
+
+1. Configured operator identity on the trusted device: allowed.
+2. On that same trusted device, use a fresh browser profile/session and authenticate to Access with a second IdP identity that is NOT in the `Include` list: denied by Access.
+3. Configured operator identity from a device that fails the serial posture rule: denied by Access.
+
+A second Supabase account is not a substitute for check 2; the Access identity selector and Supabase session are separate gates.
+
+Do not claim the identity selector verified if no non-allowed IdP identity was actually exercised.
+
+## Trusted Production Browser Verification
+
+On the trusted operator device:
+
+1. Open `/app` and pass Access.
+2. With no Supabase session, confirm DTXWeb redirects to public `/login`.
+3. Complete Supabase login and confirm return to protected `/app` succeeds under the existing Access session.
+4. Sign out of Supabase and confirm `/app` remains Access-protected.
+
+Characterize the non-operator dead end separately:
+
+1. Use a Supabase account that does not correspond to the allowed Access identity.
+2. Authenticate on public `/login` and confirm the return to `/app` is denied by Access.
+3. Confirm revisiting `/login` with that Supabase session redirects back to `/app` and no public sign-out UI is reachable.
+4. Recover by clearing the production Drumery/Supabase cookies.
+
+Record this as a known limitation. Do not widen Access to make the non-operator account work.
+
+## Access Session Expiry / Client-side Navigation Check
+
+The root server layout has a server `load`, so client-side navigation uses SvelteKit data requests under paths such as `/app/__data.json`.
+
+On the trusted operator device with a valid Supabase session:
+
+1. Keep a browser tab on a public production page.
+2. End the Access session using the tenant's normal Access logout/session-clearing procedure so a new protected request requires Access again.
+3. Trigger a SvelteKit client-side navigation into `/app` without first doing a full-page protected navigation.
+4. Record what the UI shows when the framework data request encounters Access reauthentication.
+5. Navigate directly/reload `/app` and confirm the browser can complete Access reauthentication and recover.
+
+If client-side navigation shows an opaque fetch error but a direct `/app` reload recovers, document that UX as a deferred follow-up. Do not add a bypass. If the operator cannot recover with a direct browser navigation, disable the production Access application and investigate before acceptance.
+
+## Production Desktop Login Verification
+
+This is required because standalone desktop development against a deployed web environment also traverses the protected production `/app` handoff in the current operator setup.
+
+### Bundled desktop
+
+On the trusted operator device:
+
+1. Start desktop login and confirm public `/login?redirect=desktop&desktop_callback=...` loads without Access interception.
+2. Complete password login and confirm the return through protected `/app?redirect=desktop...` succeeds.
+3. Confirm the generated magic link reaches `dtx://auth-callback` and the desktop session authenticates.
+4. Repeat with Google login.
+
+### Standalone `tauri dev`
+
+Using the current standalone desktop-development setup:
+
+1. Start `bun run dev:desktop` and confirm the browser login target is the expected deployed production web hostname.
+2. Keep the login flow in the same browser tab so `/login` can preserve `desktop_callback` in `sessionStorage`.
+3. Complete password login and confirm protected `/app?redirect=desktop...` passes Access.
+4. Confirm the magic link reaches `http://127.0.0.1:<configured-port>/auth-callback`.
+5. Repeat with Google login.
+
+This check is required when the current `.env` points standalone desktop development at production. If the local operator configuration has deliberately changed, record the actual target and still verify the deployed-environment loopback flow before accepting production Access.
+
+The full local-stack `bun run dev` path is not an Access test: it uses `dev:local-web` and localhost intentionally.
+
+## Rollback
+
+Pre-production:
+
+- Disable/delete `DTXWeb Pre-prod` if the hostname-wide gate fails a required check.
+
+Production:
+
+- Disable/delete `DTXWeb Production App` if the trusted operator cannot use `/app`, cannot recover after Access reauthentication, or cannot complete required desktop login.
+- If a public route or API is intercepted, disable the production application, restore exactly `/app` and `/app/*`, and rerun the entire Production Header Matrix.
+
+Do not introduce service tokens, API Access, route bypasses, or policy widening as an emergency workaround.
+
+No Worker rollback or code deployment is required for these dashboard-only changes.
+
+## References
+
+- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
+- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
+- https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
+- https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
+- https://developers.cloudflare.com/learning-paths/clientless-access/customize-ux/login-page/

--- a/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
+++ b/docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md
@@ -35,19 +35,23 @@ Both Access applications use the same policy semantics:
 
 Reuse the existing Perseus identity provider and its current instant-authentication mode. Do not toggle instant authentication merely to make a header test easier.
 
-Before rollout, inspect a known protected Perseus route and set an uncommitted shell regex that matches the actual unauthenticated Access redirect for this tenant:
+Before rollout, inspect a known protected Perseus route and identify its actual unauthenticated Access signal. The response can differ by client and device posture:
 
-```bash
-export ACCESS_REDIRECT_RE='<regex matching this tenant\'s Access redirect Location>'
-```
+- If it returns an Access or direct-IdP redirect, set an uncommitted regex that matches the `Location` value:
 
-For a tenant using the normal Cloudflare Access login page, a suitable value is:
+  ```bash
+  export ACCESS_REDIRECT_RE='<regex matching the tenant Access redirect Location>'
+  ```
 
-```bash
-export ACCESS_REDIRECT_RE='^location: https://[^/]+\.cloudflareaccess\.com/cdn-cgi/access/'
-```
+  For the normal Cloudflare Access login page, a suitable value is:
 
-If Perseus uses instant authentication, set the regex to the known direct IdP redirect shape observed from that existing protected route. Keep one redirect mode for the whole DTXWeb rollout.
+  ```bash
+  export ACCESS_REDIRECT_RE='^location: https://[^/]+\\.cloudflareaccess\\.com/cdn-cgi/access/'
+  ```
+
+- If it returns HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers, leave `ACCESS_REDIRECT_RE` unset. The helpers below recognize that Access-denial signal directly.
+
+If Perseus uses instant authentication, use the observed direct IdP redirect shape when a redirect is present. Keep one identity-provider and instant-authentication mode for the whole DTXWeb rollout.
 
 Never commit the operator email, device serial numbers, tenant-specific cookies/tokens, or other credentials.
 
@@ -72,23 +76,38 @@ http_headers() {
   printf '%s\n' "$headers"
 }
 
-assert_access_redirect() {
+has_access_interception() {
+  headers="$1"
+
+  if [ -n "${ACCESS_REDIRECT_RE:-}" ] &&
+    printf '%s\\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+    return 0
+  fi
+
+  if printf '%s\\n' "$headers" | grep -Eq '^HTTP/[0-9.]+ 403' &&
+    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-aud:' &&
+    printf '%s\\n' "$headers" | grep -Eiq '^cf-access-domain:'; then
+    return 0
+  fi
+
+  return 1
+}
+
+assert_access_intercepted() {
   url="$1"
-  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
-  printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE" || {
+  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  has_access_interception "$headers" || {
     echo "FAIL: Access did not intercept $url" >&2
     return 1
   }
 }
 
-assert_no_access_redirect() {
+assert_no_access_interception() {
   url="$1"
-  : "${ACCESS_REDIRECT_RE:?set ACCESS_REDIRECT_RE from the current Perseus Access flow}"
   headers="$(http_headers "$url")" || return 1
-  printf '%s\n' "$headers" | sed -n '1p;/^location:/Ip'
-  if printf '%s\n' "$headers" | grep -Eiq "$ACCESS_REDIRECT_RE"; then
+  printf '%s\\n' "$headers" | sed -n '1p;/^location:/Ip;/^cf-access-\\(aud\\|domain\\):/Ip'
+  if has_access_interception "$headers"; then
     echo "FAIL: Access unexpectedly intercepted $url" >&2
     return 1
   fi
@@ -97,8 +116,8 @@ assert_no_access_redirect() {
 
 Dry-run the harness before changing DTXWeb:
 
-- `assert_access_redirect` against a known protected Perseus URL must pass.
-- `assert_no_access_redirect https://dtx.hapadona.com/` must pass before production Access exists.
+- `assert_access_intercepted` against a known protected Perseus URL must pass.
+- `assert_no_access_interception https://dtx.hapadona.com/` must pass before production Access exists.
 - `http_headers https://this-host-does-not-exist-zzz.hapadona.com/` must fail non-zero.
 
 Do not proceed until the invalid-host check fails loudly.
@@ -132,19 +151,19 @@ Set session duration to `12h`, attach the operator `Allow` policy with the seria
 Run the following with no Access session:
 
 ```bash
-assert_access_redirect https://pre-prod.dtx.hapadona.com/
-assert_access_redirect https://pre-prod.dtx.hapadona.com/login
-assert_access_redirect https://pre-prod.dtx.hapadona.com/auth/callback
-assert_access_redirect https://pre-prod.dtx.hapadona.com/blog
-assert_access_redirect https://pre-prod.dtx.hapadona.com/preview/1
-assert_access_redirect https://pre-prod.dtx.hapadona.com/editor
-assert_access_redirect https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
-assert_access_redirect https://pre-prod.dtx.hapadona.com/game
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/score
-assert_access_redirect https://pre-prod.dtx.hapadona.com/app/__data.json
-assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/login
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/auth/callback
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/blog
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/preview/1
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/editor
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/tool/dtx-to-midi
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/game
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/score
+assert_access_intercepted https://pre-prod.dtx.hapadona.com/app/__data.json
+assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
 ```
 
 Every command must exit `0`. If one fails, disable/delete `DTXWeb Pre-prod` and stop before production.
@@ -169,21 +188,21 @@ Set session duration to `12h`, attach the same operator `Allow` policy and seria
 Run with no Access session:
 
 ```bash
-assert_access_redirect https://dtx.hapadona.com/app
-assert_access_redirect https://dtx.hapadona.com/app/
-assert_access_redirect https://dtx.hapadona.com/app/score
-assert_access_redirect https://dtx.hapadona.com/app/__data.json
+assert_access_intercepted https://dtx.hapadona.com/app
+assert_access_intercepted https://dtx.hapadona.com/app/
+assert_access_intercepted https://dtx.hapadona.com/app/score
+assert_access_intercepted https://dtx.hapadona.com/app/__data.json
 
-assert_no_access_redirect https://dtx.hapadona.com/
-assert_no_access_redirect https://dtx.hapadona.com/blog
-assert_no_access_redirect https://dtx.hapadona.com/preview/1
-assert_no_access_redirect https://dtx.hapadona.com/editor
-assert_no_access_redirect https://dtx.hapadona.com/tool/dtx-to-midi
-assert_no_access_redirect https://dtx.hapadona.com/game
-assert_no_access_redirect https://dtx.hapadona.com/login
-assert_no_access_redirect https://dtx.hapadona.com/auth/callback
-assert_no_access_redirect https://api.dtx.hapadona.com/
-assert_no_access_redirect https://api.pre-prod.dtx.hapadona.com/
+assert_no_access_interception https://dtx.hapadona.com/
+assert_no_access_interception https://dtx.hapadona.com/blog
+assert_no_access_interception https://dtx.hapadona.com/preview/1
+assert_no_access_interception https://dtx.hapadona.com/editor
+assert_no_access_interception https://dtx.hapadona.com/tool/dtx-to-midi
+assert_no_access_interception https://dtx.hapadona.com/game
+assert_no_access_interception https://dtx.hapadona.com/login
+assert_no_access_interception https://dtx.hapadona.com/auth/callback
+assert_no_access_interception https://api.dtx.hapadona.com/
+assert_no_access_interception https://api.pre-prod.dtx.hapadona.com/
 ```
 
 Every command must exit `0`. `/app/` is an explicit path-semantics probe; do not assume its behavior from the dashboard string alone. `/app/__data.json` proves SvelteKit data requests are inside the Access boundary. `/preview/1` exercises the real dynamic preview route instead of a 404 prefix.

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -13,14 +13,16 @@ The Zero Trust configuration is managed manually in the Cloudflare dashboard. Th
 ## Goals
 
 - Make production `/app` and production desktop login intentionally operator-only behind Cloudflare Access.
-- Keep the production public site outside Access, including `/`, `/blog`, `/preview`, `/editor`, `/tool/*`, `/game`, `/login`, and `/auth/*`.
+- Keep the production public site outside Access, including `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, and `/auth/*`.
 - Require Cloudflare Access for every route served by `pre-prod.dtx.hapadona.com`.
 - Reuse the same configured operator identity and trusted-device serial-number posture model used for Perseus.
 - Preserve Supabase authentication as an independent inner gate after Access allows a request.
 - Keep `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` outside Access.
 - Roll out pre-production first, then production only after the pre-production gate and auth round-trip are verified.
-- Verify route boundaries from HTTP response headers in addition to browser smoke tests.
-- Document the dashboard configuration, verification matrix, and rollback procedure in a dedicated operator runbook.
+- Verify both policy clauses independently: the configured Access identity and the trusted-device posture requirement.
+- Make route-boundary checks fail loudly when the request itself fails.
+- Characterize Access-session expiry during SvelteKit client-side navigation instead of discovering that behavior after rollout.
+- Document desktop-development, non-operator lockout, E2E, and private-route invariants in a dedicated operator runbook.
 
 ## Non-Goals
 
@@ -28,9 +30,11 @@ The Zero Trust configuration is managed manually in the Cloudflare dashboard. Th
 - Protect the entire production `dtx.hapadona.com` hostname.
 - Protect either API hostname.
 - Make production `/app` available to every Supabase user.
+- Add a public logout route or otherwise change the current non-operator recovery behavior in this slice.
 - Replace Supabase authentication.
 - Add Worker-side validation of `CF_Authorization` or Access JWTs.
-- Add Cloudflare Access service tokens for desktop, API, CLI, or CI traffic.
+- Add Cloudflare Access service tokens for desktop, API, CLI, E2E, or CI traffic.
+- Make pre-production an unattended E2E target in this slice.
 - Protect preview/development Worker URLs outside the named custom hostnames.
 - Change SvelteKit, GraphQL API, or desktop application code in this slice.
 
@@ -38,24 +42,33 @@ The Zero Trust configuration is managed manually in the Cloudflare dashboard. Th
 
 `packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and pre-production to `pre-prod.dtx.hapadona.com`. The web application uses separate API hostnames: `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com`.
 
-`packages/dtx-web/src/hooks.server.ts` treats paths beginning with `/app` as the Supabase-authenticated application family. An unauthenticated request to `/app` is redirected to public `/login`, and successful web login returns to `/app` or another validated `/app/*` destination.
+`packages/dtx-web/src/hooks.server.ts` currently treats any pathname beginning with `/app` as Supabase-authenticated. The intended private route family for this design is narrower and matches the existing redirect validator: exact `/app` or descendants under `/app/`. Production Access therefore protects `/app` and `/app/*`. No current route relies on the broader `/app...` string-prefix behavior.
 
-The desktop flow also starts at public `/login` and finishes through `/app?redirect=desktop...`. Password login redirects there directly; Google OAuth does the same through the auth callback. The login page preserves the desktop callback in `sessionStorage` so the `/app` page can hand the magic link back to either the bundled `dtx://` callback or the Tauri-development loopback callback.
+This dependency is an operating invariant: any new private production page must live at `/app` or below `/app/`, or the Access design must be revisited before shipping it. A new private sibling such as `/studio` or `/admin` would otherwise be public at the edge. A future `/appstore`-style route would also expose the current mismatch between `startsWith('/app')` and the Access destination family and should be handled as a separate routing cleanup rather than silently treated as protected.
 
-Because production `/app` sits behind a single-operator Access policy, that desktop handoff is also operator-only. Public `/login` is an entry form, not a bypass around Access. A non-operator Supabase user may authenticate successfully and then be denied when the browser returns to `/app`; that is the intended product behavior for this slice.
+The desktop flow starts at web `/login` and finishes through `/app?redirect=desktop...`. Password login redirects there directly; Google OAuth does the same through the auth callback. The login page preserves the desktop callback in `sessionStorage` so the `/app` page can hand the magic link back to either the bundled `dtx://` callback or the Tauri-development loopback callback.
+
+Standalone desktop development (`bun run dev:desktop`, which runs the desktop package `dev` script) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup that value points at production, so ordinary standalone `tauri dev` authentication traverses production `/login` and production `/app`. The full local-stack command (`bun run dev`) is different: it uses `dtx-desktop#dev:local-web`, which overrides the web and API URLs to localhost. After this Access change, authentication against either deployed web environment is operator-only; non-operator contributors must use the full local stack or another separately designed ungated development environment.
+
+Because production `/app` sits behind a single-operator Access policy, public `/login` is an entry form, not an Access bypass. A non-operator Supabase user may authenticate successfully and then be denied when the browser returns to `/app`.
+
+That state currently has no UI recovery path. `hooks.server.ts` redirects an already-authenticated visitor from `/login` to `/app`, while the only current sign-out control lives inside the Access-protected `(app)` layout. A signed-in non-operator therefore cannot use the production UI to return to `/login` or sign out; they must clear the Drumery/Supabase cookies for the production web origin. A public logout route or a change to the authenticated `/login` redirect is an explicit deferred product decision, not part of this dashboard-only slice.
 
 The repository already uses human-executed Cloudflare runbooks, for example `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`. That file is a historical API-migration cutover checklist, so Zero Trust gets its own durable runbook rather than mixing permanent security operations into the completed Phase 4 migration document.
+
+The web E2E harness supports overriding `PLAYWRIGHT_BASE_URL`, but current CI runs against Playwright-managed localhost servers. Hostname-wide pre-production Access means this slice does not support unattended E2E against `pre-prod.dtx.hapadona.com`; doing so later requires a separate Access-authentication strategy and is intentionally deferred.
 
 ## Protection Matrix
 
 | Surface | Cloudflare Access | Notes |
 | --- | --- | --- |
-| `dtx.hapadona.com/app` | Protected | Operator-only; exact parent must be covered. |
-| `dtx.hapadona.com/app/*` | Protected | Operator-only descendants. |
+| `dtx.hapadona.com/app` | Protected | Operator-only exact parent. |
+| `dtx.hapadona.com/app/` | Protected | Explicitly verify path semantics during rollout. |
+| `dtx.hapadona.com/app/*` | Protected | Operator-only descendants, including SvelteKit data requests. |
 | `dtx.hapadona.com/` | Public | Landing page. |
 | `dtx.hapadona.com/blog/*` | Public | Public content. |
-| `dtx.hapadona.com/preview/*` | Public | Public preview surface. |
-| `dtx.hapadona.com/editor/*` | Public | Public editor surface. |
+| `dtx.hapadona.com/preview/*` | Public | Verify with a real route such as `/preview/1`. |
+| `dtx.hapadona.com/editor` | Public | Public editor surface. |
 | `dtx.hapadona.com/tool/*` | Public | Public tools, including `/tool/dtx-to-midi`. |
 | `dtx.hapadona.com/game` | Public | Public game entry. |
 | `dtx.hapadona.com/login` | Public | Web and desktop login entry. |
@@ -65,7 +78,7 @@ The repository already uses human-executed Cloudflare runbooks, for example `doc
 | `api.dtx.hapadona.com/*` | Outside Access | Existing API auth remains authoritative. |
 | `api.pre-prod.dtx.hapadona.com/*` | Outside Access | Existing API auth remains authoritative. |
 
-Cloudflare Access application paths can protect either an entire hostname or selected paths. Production records both `/app` and `/app/*` explicitly so the parent and descendants are both protected.
+Cloudflare Access application paths can protect either an entire hostname or selected paths. Production records both `/app` and `/app/*` explicitly because Cloudflare documents that a wildcard sub-path does not replace the exact parent rule. The rollout also probes `/app/` directly instead of assuming how the trailing-slash request is normalized or matched.
 
 ## Access Applications
 
@@ -75,7 +88,7 @@ Create `DTXWeb Pre-prod` first as a self-hosted public-hostname application for:
 
 - `pre-prod.dtx.hapadona.com`
 
-There is no path bypass. `/`, `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, `/tool/*`, `/game`, `/app`, and future routes on that web hostname all pass through Access.
+There is no path bypass. `/`, `/login`, `/auth/*`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/app`, SvelteKit data requests, and future routes on that web hostname all pass through Access.
 
 Do not include `api.pre-prod.dtx.hapadona.com`.
 
@@ -99,32 +112,39 @@ Both applications use the same policy semantics:
 
 Prefer the existing account-level serial-number list/posture rule when DTXWeb is in the same Zero Trust account. If it is not reusable because the zone is under a different Zero Trust account, create an equivalent list/posture rule there using the same intended trusted devices. Do not weaken the posture requirement.
 
-Do not add a Service Auth policy or service token. API and other non-browser traffic stay outside these Access applications.
+Verify the two policy clauses separately. A failed-posture device proves only the `Require` rule. The production rollout must also use the trusted device with a second IdP identity that is not in the `Include` list and confirm Access denies it.
+
+Do not change the account's instant-authentication setting merely to make `curl` output easier to recognize. During setup, record whether the reused Perseus login method uses the Cloudflare Access login page or instant authentication, then use the same mode for both DTXWeb applications and configure the verification helper to recognize that tenant's actual Access redirect target.
+
+Do not add Service Auth, Managed OAuth, or service tokens. API and other non-browser traffic stay outside these Access applications.
 
 ## Rollout Order
 
 1. Add the dedicated DTXWeb Zero Trust operator runbook.
-2. Confirm the intended operator identity and serial-number posture rule are available without copying personal identifiers into git.
-3. Create the hostname-wide pre-production Access application.
-4. Verify pre-production interception, trusted-device admission, posture denial, Supabase password login, Google OAuth callback behavior, and API non-interception.
-5. If any pre-production check fails, disable/remove the pre-production Access app and stop. Do not touch production.
-6. Create the production application with only `/app` and `/app/*`.
-7. Run the complete production header matrix, including `/tool/*` and `/game`, before considering the rollout accepted.
-8. Run the trusted-device production browser and desktop-login checks, including the Tauri-development loopback callback path.
-9. Re-run API non-interception checks and record the final state in the operator runbook/checklist.
+2. Record the current Perseus identity provider, instant-authentication mode, intended operator identity, and serial-number posture rule without copying personal identifiers into git.
+3. Harden and dry-run the runbook's HTTP verification helpers against both a reachable URL and an intentionally invalid hostname; the invalid hostname must fail.
+4. Create the hostname-wide pre-production Access application.
+5. Run the runbook's complete pre-production verification section, including password login, Google OAuth, posture denial, and API non-interception.
+6. If any pre-production check fails, disable/remove the pre-production Access app and stop. Do not touch production.
+7. Create the production application with only `/app` and `/app/*`.
+8. Run the runbook's complete production header matrix, including `/app/`, `/app/__data.json`, the real `/preview/1` route, `/tool/*`, `/game`, and both API exclusions.
+9. Verify the Access `Include` identity rule independently on the trusted device with a non-allowed IdP identity.
+10. Run the trusted-device production browser and desktop-login checks, including standalone `tauri dev` against production.
+11. Characterize an expired Access session during a SvelteKit client-side navigation to `/app` and record the observed recovery behavior.
+12. Record final non-sensitive outcomes and deferred limitations.
 
-## Request Flows
+## Request Flows And Consequences
 
 ### Production browser
 
-1. Browser requests `/app` or `/app/*`.
+1. Browser requests `/app` or a descendant.
 2. Cloudflare Access evaluates the operator identity and device posture.
 3. A denied request never reaches DTXWeb.
 4. An allowed request reaches SvelteKit and the existing Supabase guard.
 5. Without a Supabase session, SvelteKit redirects to public `/login`.
 6. After Supabase login, the browser returns to protected `/app` and must still satisfy the Access gate.
 
-A normal Supabase user who does not match the Access policy is intentionally denied at step 2 or when returning to `/app` after public login.
+A normal Supabase user who does not match the Access policy is intentionally denied when returning to `/app`. If they now hold a Supabase session, `/login` will redirect them back into the denied `/app` surface and the current UI offers no public logout. Clearing the production Supabase cookies is the documented recovery until a separate logout UX decision is implemented.
 
 ### Production desktop login
 
@@ -134,11 +154,19 @@ A normal Supabase user who does not match the Access policy is intentionally den
 4. Cloudflare Access gates that `/app` return.
 5. Only the configured operator on a trusted device can reach the `/app` handoff that generates and forwards the desktop magic link.
 
-Verification must cover both a bundled `dtx://auth-callback` flow and, when available, a `tauri dev` loopback callback in the same browser tab because the loopback path depends on the preserved callback state.
+Standalone `tauri dev` using a deployed `VITE_DTX_SERVER_URL` is therefore operator-only. In the current operator setup it targets production and is a required production acceptance check. The full local-stack `dev:local-web` path remains available without Cloudflare Access because it explicitly uses localhost.
+
+### SvelteKit client-side navigation
+
+The root server layout has a server `load`, so SvelteKit client-side navigation uses framework data requests such as `/app/__data.json`. Those requests are within `/app/*` and must be Access-protected too.
+
+Cloudflare checks every request for a valid application token. When a long-lived tab loses its Access session, a client-side data request may encounter the Access reauthentication redirect instead of normal SvelteKit data. The rollout must deliberately expire/logout the Access session and navigate client-side from a public production page into `/app`, record what the user sees, and confirm a direct reload of `/app` provides a usable reauthentication path. Any opaque fetch-error UX is a documented limitation/follow-up, not a reason to widen the Access destinations.
 
 ### Pre-production
 
 Any request to `pre-prod.dtx.hapadona.com` reaches Access first. Once the browser has a valid Access session, the existing Supabase login and callback routes on that same hostname run normally behind the gate.
+
+Because no non-interactive Access credential is introduced, unattended Playwright/CI use of the pre-production hostname is unsupported by this slice even though the harness can point `PLAYWRIGHT_BASE_URL` at another host.
 
 ### API traffic
 
@@ -150,51 +178,42 @@ Implementation creates one focused runbook:
 
 - `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
 
-The runbook records the two applications, operator-only product intent, pre-production-first rollout, exact production destinations, policy semantics, header-based verification matrix, trusted-device browser/desktop checks, API exclusions, and rollback.
+The runbook is the single executable source of truth for dashboard configuration, header helpers, route matrices, browser/desktop checks, known limitations, and rollback. The implementation plan references named runbook sections rather than restating their command blocks.
 
 Do not edit the historical Phase 4 API migration runbook except for a future independent documentation cleanup; it is useful precedent for human-executed Cloudflare operations but not the ownership location for this permanent Access configuration.
 
 No source or deployment code changes are planned. If verification shows that SvelteKit, desktop, API, or routing code must change for this approved model to work, stop this slice and create a separate follow-up rather than widening scope.
 
-## Verification
+## Verification Requirements
 
-### Header-based boundary checks
+The durable runbook must make a missing HTTP response fail loudly. A DNS failure, connection failure, or timeout may not count as a successful `assert_no_access_redirect` result.
 
-For unauthenticated requests, inspect response headers rather than relying only on what a browser appears to show. Cloudflare's normal Access login flow returns an interception redirect; the durable failure signal for routes that must remain public is a `Location` pointing to the account's `cloudflareaccess.com/cdn-cgi/access/` flow.
+The runbook owns one pre-production matrix and one production matrix. The implementation plan must invoke those sections rather than duplicate their commands.
 
-Run the matrix with `curl -sS -o /dev/null -D - <url>` and inspect the status plus `Location` header.
+The production matrix must include:
 
-Pre-production must show Access interception for representative routes across the hostname, including `/`, `/login`, `/auth/callback`, `/blog`, `/preview`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/app`, and `/app/score`.
+- protected: `/app`, `/app/`, `/app/score`, `/app/__data.json`;
+- public: `/`, `/blog`, `/preview/1`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/login`, `/auth/callback`;
+- outside Access: both API hostnames.
 
-Production must show Access interception for `/app` and `/app/score`, while these must not return a Cloudflare Access `Location`:
+The policy checks must independently prove:
 
-- `/`
-- `/blog`
-- `/preview`
-- `/editor`
-- `/tool/dtx-to-midi`
-- `/game`
-- `/login`
-- `/auth/callback`
+- allowed identity + trusted posture passes;
+- trusted device + non-allowed IdP identity is denied;
+- allowed identity on a device that fails posture is denied.
 
-Both API hostnames must also avoid a Cloudflare Access `Location`; their application-specific HTTP status is otherwise irrelevant to this boundary check.
+The browser checks must cover:
 
-If the Zero Trust account uses instant authentication and therefore redirects directly to the identity provider instead of the Cloudflare Access login page, use the equivalent known Access redirect behavior for that tenant plus the browser checks below; do not mistake an application redirect for Access interception.
-
-### Trusted browser and desktop checks
-
-On the WARP/Cloudflare One-enrolled trusted device with the configured operator identity:
-
-- prove pre-production login and callback flows before production configuration;
-- prove production `/app -> /login -> /app` still works as two independent gates;
-- prove production desktop login returns through protected `/app` and reaches the desktop callback;
-- specifically exercise the Tauri-development loopback callback when available so the `sessionStorage` handoff is tested, not just the bundled `dtx://` path.
-
-### Denial check
-
-From a device that fails the serial-number posture rule, protected pre-production and production surfaces must be denied before DTXWeb loads.
+- pre-production password and Google login before production is configured;
+- production `/app -> /login -> /app` for the operator;
+- bundled desktop login;
+- standalone Tauri-development loopback login against production in the current operator setup;
+- expired/logged-out Access session during client-side navigation into `/app`;
+- non-operator production login dead-end and documented cookie-clearing recovery.
 
 ## Failure Handling And Rollback
+
+If the verification harness cannot prove a real HTTP response, fix the harness before using it to approve any Access change.
 
 If pre-production identity, posture, login, callback, or route-boundary checks fail, disable/delete `DTXWeb Pre-prod` and stop before production.
 
@@ -204,6 +223,8 @@ If either API hostname is intercepted, remove the API hostname from Access. Do n
 
 If the trusted production desktop flow cannot complete the `/login -> /app -> desktop` handoff, disable the production Access application and investigate separately. Do not widen the Access policy or add a bypass to make the test pass.
 
+Known/documented UX limitations such as the non-operator sign-out dead end or expired-session client-navigation behavior should be recorded as deferred follow-ups unless they prevent the trusted operator from recovering via normal browser reauthentication.
+
 Rollback is dashboard-only: disable or delete the relevant Access application. No Worker rollback or code deployment is required.
 
 ## References
@@ -212,3 +233,4 @@ Rollback is dashboard-only: disable or delete the relevant Access application. N
 - Cloudflare self-hosted public applications: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
 - Cloudflare Access policies: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
 - Cloudflare Access authorization cookie: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
+- Cloudflare Access login page / instant authentication: https://developers.cloudflare.com/learning-paths/clientless-access/customize-ux/login-page/

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -2,416 +2,211 @@
 
 ## Summary
 
-DTXWeb will manage its Cloudflare Zero Trust Access applications with a small Pulumi package modeled on the proven Perseus Access implementation.
+DTXWeb will manage Cloudflare Zero Trust Access with a small Pulumi workspace that owns **Access applications only**. Existing Workers, APIs, D1, R2, routes, bindings, and runtime deployment remain on Wrangler.
 
-The package owns **Access only**. Wrangler remains the owner of DTXWeb Workers, API deployment, D1, R2, service bindings, routes, runtime variables, and application secrets.
+One Pulumi program serves exactly two stacks:
 
-Production protects only exact `/app` plus descendants under `/app/`. This is intentionally an operator-only surface: the configured Access identity must match the intended operator and the request must satisfy the existing Perseus trusted-device posture rule. Production `/login`, `/auth/*`, the rest of the public web site, and both API hostnames remain outside Access.
+| Stack | Application | Code-owned protection scope |
+| --- | --- | --- |
+| `pre-prod` | `DTXWeb Pre-prod` | entire `pre-prod.dtx.hapadona.com` hostname |
+| `production` | `DTXWeb Production App` | `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*` only |
 
-Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is always previewed and proven before production is applied.
+Production host/path scope is not Pulumi config. This prevents a stack-config typo from broadening Access over the public production site.
 
-DTXWeb does not create another serial-number list or device-posture rule. Perseus remains the owner of trusted-device membership; DTXWeb consumes the existing Perseus posture-rule resource ID as Pulumi configuration.
-
-The infrastructure code, tests, CI wiring, and Pulumi previews are implementation work. **Live `pulumi up`, live acceptance, and rollback/destroy are operator-executed runbook procedures, not agent implementation-plan steps.**
+DTXWeb reuses the existing Perseus-managed Cloudflare device-posture rule by resource ID. DTXWeb does not create another serial list or posture rule and does not use a cross-repo `StackReference`.
 
 ## Goals
 
-- Manage DTXWeb Cloudflare Access declaratively with Pulumi rather than dashboard-created configuration.
-- Follow the proven Perseus `ZeroTrustAccessApplication` + inline policy shape where it applies.
-- Reuse the existing Perseus device-posture rule ID instead of duplicating its serial list or posture rule.
-- Make production `/app` and production desktop login intentionally operator-only behind Cloudflare Access.
-- Keep production `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, `/auth/*`, and other intended public routes outside Access.
-- Require Cloudflare Access for every route served by `pre-prod.dtx.hapadona.com`.
-- Keep `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` outside Access.
-- Preserve Supabase authentication as an independent inner gate after Access allows a request.
-- Use separate `pre-prod` and `production` Pulumi stacks so rollout and rollback are environment-specific.
-- Make stack name determine hostname/path scope so ordinary config cannot accidentally broaden production Access.
-- Wire `@dtx/infrastructure` into the repository's fail-closed affected-scope CI and coverage workflow.
-- Reuse DTXWeb's current TypeScript/Vitest/Node type major versions instead of importing Perseus's newer JS test toolchain.
-- Keep one checked-in runbook as the live operator source of truth for preview, apply, verification, emergency fallback, and rollback.
+- Manage the two DTXWeb Access applications declaratively with Pulumi.
+- Keep production public routes and both API hostnames outside Access.
+- Make production `/app` an operator-only outer gate while retaining the application authentication system as the inner gate.
+- Protect the entire pre-production web hostname, including the `pre-prod-prod-data` deployment mode that can bind the pre-production web surface to production-backed API data.
+- Reuse the existing Perseus posture-rule ID without duplicating trusted-device ownership.
+- Enforce the production private-route boundary in CI instead of relying only on documentation.
+- Reuse the repository's existing affected-scope, unit/coverage, lint, formatting, and typecheck gates.
+- Keep live Cloudflare mutations operator-executed.
 
 ## Non-Goals
 
-- Migrate DTXWeb Worker or API deployment from Wrangler to Pulumi.
-- Manage D1, R2, KV, Workers, routes, service bindings, runtime environment variables, or application secrets with Pulumi in this slice.
-- Create or manage the shared trusted-device serial-number list in DTXWeb.
-- Create a DTXWeb-specific device-posture rule.
-- Add a Pulumi `StackReference` dependency on the Perseus stack.
-- Protect the entire production `dtx.hapadona.com` hostname.
+- Migrate Worker/API/runtime infrastructure from Wrangler to Pulumi.
+- Create a DTXWeb trusted-device list or posture rule.
+- Add a `StackReference` to Perseus.
+- Add Service Auth, service tokens, CLI Access applications, Managed OAuth, or Worker-side Access JWT validation.
 - Protect either API hostname.
-- Make production `/app` available to every Supabase user.
-- Add a public logout route or change the current non-operator recovery behavior.
-- Replace Supabase authentication.
-- Add Worker-side validation of `CF_Authorization` or Access JWTs.
-- Add Cloudflare Access service tokens, Service Auth policies, CLI applications, or Managed OAuth.
-- Copy Perseus's CLI/service-token/Worker/storage resources.
-- Make pre-production an unattended E2E target.
-- Add GitHub Actions deployment of Pulumi resources.
-- Let an agent execute live `pulumi up` or `pulumi destroy` as part of the implementation plan.
-- Change code under `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
+- Protect production routes outside `/app`.
+- Add GitHub Actions deployment for Pulumi.
+- Add or change runtime application authentication behavior in this slice.
 
-## Existing Context
+## Resource Ownership
 
-### DTXWeb routing and deployment
+Add `packages/infrastructure` with the same Pulumi Cloudflare resource family used by Perseus, limited to `cloudflare.ZeroTrustAccessApplication` plus its inline browser policy.
 
-`packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and pre-production to `pre-prod.dtx.hapadona.com`. The GraphQL API uses separate hostnames: `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com`.
+The Access policy is:
 
-`packages/dtx-web/src/hooks.server.ts` currently treats any pathname beginning with `/app` as Supabase-authenticated. The intended private route family for this design is narrower: exact `/app` or descendants under `/app/`. Production Access therefore protects `/app` and `/app/*`.
+- decision: `allow`;
+- include: configured operator email;
+- require: configured existing device-posture rule ID;
+- session duration: `12h` by default.
 
-Any new private production page must live at `/app` or below `/app/`, or this Access design must be revised before shipping it. The broader `pathname.startsWith('/app')` application guard must not be used to justify new `/app...` sibling-style routes.
+Reuse these browser application flags from the Perseus implementation:
 
-### Desktop authentication
+- `appLauncherVisible: false`;
+- `allowAuthenticateViaWarp: false`;
+- `enableBindingCookie: true`;
+- `httpOnlyCookieAttribute: true`;
+- `pathCookieAttribute: false`.
 
-Desktop login begins on public `/login` and completes through `/app?redirect=desktop...`. Password and Google OAuth both return through the protected `/app` handoff.
+Do not copy Perseus service-token, CLI, Worker, storage, or deployment resources.
 
-Standalone `bun run dev:desktop` consumes `VITE_DTX_SERVER_URL` from the ignored root `.env`; in the current operator setup this targets production. Full local-stack `bun run dev` instead uses `dtx-desktop#dev:local-web` and localhost.
+## Pulumi Configuration
 
-After this Access change, authentication against deployed production or pre-production is operator-only. Non-operator contributors use the full local stack or a separately designed ungated development environment.
+Both stacks accept only:
 
-### Non-operator production lockout
+- `cloudflareAccountId` — plain config;
+- `accessEmail` — secret config;
+- `devicePostureRuleId` — plain config containing the current Perseus-managed Cloudflare posture-rule ID;
+- `accessSessionDuration` — optional, default `12h`.
 
-A non-operator Supabase user can authenticate on public `/login` and then be denied by Access when the browser returns to `/app`.
+Hostnames and destinations are code constants selected by `pulumi.getStack()`. Any stack other than `pre-prod` or `production` fails before resource registration.
 
-If they now hold a Supabase session, revisiting `/login` redirects them back to `/app`, while the current sign-out control is inside the protected application layout. Clearing the Drumery/Supabase cookies for the production origin is the documented recovery. A public logout route is a separate product/code decision.
+Use the local Pulumi backend for this slice. `pulumi login --local` stores its default filesystem backend under the operator's home directory; stack config files and any project-local `.pulumi/` state remain ignored by git.
 
-### Perseus precedent
+## Shared Posture Ownership
 
-Perseus already manages Cloudflare Access with `@pulumi/cloudflare`. Its browser-admin application uses `ZeroTrustAccessApplication`, an email `Include` rule, a device-posture `Require` rule, a `12h` default session, and hardened application/cookie flags.
+Perseus remains the source of truth for trusted-device membership and exports `adminAccessDevicePostureRuleId`. DTXWeb copies that Cloudflare resource ID into both stack configs.
 
-Perseus owns the trusted-device serial-number list and posture rule and exports `adminAccessDevicePostureRuleId`. DTXWeb reuses that existing Cloudflare rule ID as config.
+Because this is a cross-repo foreign key, every operator preflight must compare the current Perseus output with both DTXWeb stack config values. A mismatch is a hard stop before preview or apply.
 
-Perseus's CLI application, service token, `non_identity` policy, Worker resources, storage resources, and deployment workflows solve different requirements and are not copied.
+This deliberately avoids a `StackReference`: DTXWeb and Perseus remain independently deployable and do not depend on the same Pulumi backend/project identity.
 
-### Existing CI contract
+## Private Route Invariant
 
-`.github/scripts/ci-affected-scope.sh` validates every Turbo package against a hardcoded fail-closed package allowlist and separately decides whether unit tests are affected.
+Cloudflare production Access covers only exact `/app` and descendants under `/app/`.
 
-Adding `@dtx/infrastructure` without updating that script would make an infrastructure-only PR fail as an unknown package. The package must also participate in `unit_affected`, because `.github/workflows/unit-test.yml` only installs dependencies and runs unit coverage when that detector returns `true`.
+The SvelteKit authenticated route group currently lives under `packages/dtx-web/src/routes/(app)/app`. Add a small test under the `(app)` route group that derives URL paths for route-bearing files and asserts every emitted path is either `/app` or starts with `/app/`.
 
-The unit workflow runs root `bun run test:coverage`. Therefore `@dtx/infrastructure` must expose `test:coverage`, not only `test`.
+A future private `/admin`, `/studio`, or other route outside `/app` must therefore fail CI instead of silently shipping outside Access.
 
-`.github/scripts/ci-affected-scope.test.sh` and its JSON fixtures are the existing contract tests for this fail-closed detector and must gain infrastructure coverage.
-
-### Existing operator precedent
-
-`docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` explicitly marks interactive/live Cloudflare steps as operator-executed. This design keeps that boundary: agents may author/test the Pulumi program and produce previews when credentials/config are already available, but live Cloudflare mutations and human browser/device observations stay in the runbook.
-
-## Architecture
-
-### Infrastructure workspace
-
-Add:
-
-```text
-packages/infrastructure/
-├── .gitignore
-├── Pulumi.yaml
-├── package.json
-├── README.md
-├── tsconfig.json
-├── vitest.config.ts
-└── src/
-    ├── access.ts
-    ├── access.test.ts
-    └── index.ts
-```
-
-The root workspace list adds `packages/infrastructure`.
-
-The package is intentionally Access-only. It contains no Worker build/deploy logic and no storage resources.
-
-### Toolchain
-
-Reuse the Pulumi provider floors already proven in Perseus:
-
-- `@pulumi/pulumi` `^3.144.0`
-- `@pulumi/cloudflare` `^6.13.0`
-
-Align development tooling with DTXWeb instead of Perseus:
-
-- TypeScript `^5.8.3`
-- Vitest `^3.1.4`
-- `@vitest/coverage-v8` `^3.0.0`
-- `@types/node` `^20.11.25`
-
-Do not introduce Vitest 4, TypeScript 5.9, or Node type major 22 merely because Perseus currently uses them.
-
-`packages/infrastructure/package.json` exposes only repository-safe scripts such as `build`, `check`, `test`, and `test:coverage`. Do not add unscoped `pulumi:up`, `pulumi:destroy`, or `pulumi:preview` scripts that operate on whichever stack happens to be selected.
-
-Operational docs invoke the Pulumi CLI directly and always name `--stack`.
-
-### Pulumi project and supported stacks
-
-`Pulumi.yaml` defines:
-
-```yaml
-name: dtxweb-infrastructure
-runtime: nodejs
-description: DTXWeb Cloudflare Access infrastructure managed by Pulumi
-main: dist/index.js
-```
-
-One program supports exactly:
-
-- `pre-prod`
-- `production`
-
-Any other `pulumi.getStack()` value fails before a Cloudflare resource is registered.
-
-### `pre-prod` stack
-
-Creates exactly one `ZeroTrustAccessApplication` named `DTXWeb Pre-prod` for:
-
-```text
-pre-prod.dtx.hapadona.com
-```
-
-No API hostname is included.
-
-### `production` stack
-
-Creates exactly one `ZeroTrustAccessApplication` named `DTXWeb Production App` with exactly:
-
-```text
-dtx.hapadona.com/app
-dtx.hapadona.com/app/*
-```
-
-Hostname and destinations are code-owned, not Pulumi configuration.
-
-### Pulumi configuration
-
-Both stacks require:
-
-- `cloudflareAccountId` — plain config.
-- `accessEmail` — Pulumi secret config.
-- `devicePostureRuleId` — plain config containing the existing Perseus-managed rule ID.
-- `accessSessionDuration` — optional; defaults to `12h`.
-
-DTXWeb does not use `StackReference`. If Perseus replaces its posture rule and the Cloudflare ID changes, the operator updates `devicePostureRuleId` in both DTXWeb stacks before the next preview/apply.
-
-### Access resource construction
-
-`src/access.ts` owns pure builders plus one resource factory.
-
-Reuse these Perseus browser-application flags:
-
-```ts
-{
-  appLauncherVisible: false,
-  allowAuthenticateViaWarp: false,
-  enableBindingCookie: true,
-  httpOnlyCookieAttribute: true,
-  pathCookieAttribute: false
-}
-```
-
-Each Access application has one inline policy:
-
-- name: `Allow configured operator on trusted device`
-- decision: `allow`
-- precedence: `1`
-- `includes`: configured email identity
-- `requires`: configured existing posture-rule ID
-
-No posture/list/token resource is created by DTXWeb.
-
-### Local state and config
-
-Follow the same local-backend operating model as Perseus, but document it accurately.
-
-`pulumi login --local` is equivalent to a filesystem backend rooted at the operator's home directory, with default state under `~/.pulumi`. Stack config files created in the project (`Pulumi.<stack>.yaml`) are ignored and not committed.
-
-`packages/infrastructure/.gitignore` includes at least:
-
-```text
-Pulumi.*.yaml
-.pulumi/
-node_modules/
-dist/
-.env
-.env.local
-```
-
-The `.pulumi/` ignore is defensive for explicitly project-local filesystem backends; it is not a claim that `pulumi login --local` stores default state in the repository.
-
-Because state is local-machine-owned, the runbook must include both normal Pulumi rollback and an emergency Cloudflare dashboard delete/disable path if state/backend access is unavailable.
+The existing `pathname.startsWith('/app')` guard is slightly broader than the Access scope; aligning that runtime guard is a separate cleanup and is not required here.
 
 ## CI Integration
 
-Task implementation must update:
+`@dtx/infrastructure` must participate in the existing CI contract:
 
-- `.github/scripts/ci-affected-scope.sh`
-- `.github/scripts/ci-affected-scope.test.sh`
-- `.github/scripts/fixtures/turbo-infrastructure.json`
+- add it to the fail-closed package allowlist in `.github/scripts/ci-affected-scope.sh`;
+- mark it as unit-affected;
+- add a Turbo fixture and detector test;
+- expose `test:coverage` so root `bun run test:coverage` executes its tests;
+- add `bun run --filter=@dtx/infrastructure check` to the existing lint/typecheck workflow;
+- extend `../../tsconfig.base.json` from the infrastructure package;
+- run repository lint and `prettier --check .` in final implementation verification.
 
-The detector allowlist gains:
+Use the repository's current TypeScript/Vitest/Node-types major versions. Reuse Perseus's Pulumi and Cloudflare provider floors, not its unrelated JS toolchain versions.
 
-```text
-@dtx/infrastructure:packages/infrastructure
-```
+## Testing Focus
 
-`@dtx/infrastructure` also sets `unit_affected=true`.
+The tests should pin security-sensitive behavior rather than duplicate generic provider validation.
 
-The detector tests add an infrastructure-only fixture and assert:
+Keep tests for:
 
-- `unit` => `true`
-- `lint` => `true`
+- exact pre-production hostname-wide definition;
+- exact production destinations (`/app`, `/app/*`) and absence of hostname-wide production Access;
+- unsupported stack rejection;
+- default session duration and browser flags;
+- email normalization;
+- the real secret-input path by passing a `pulumi.Output<string>` through the email normalization path;
+- route-tree agreement under `src/routes/(app)`;
+- affected-scope CI behavior for `@dtx/infrastructure`.
 
-`@dtx/infrastructure` defines:
+Do not add bespoke blank-string validators for account ID or posture-rule ID. Pulumi config presence, provider validation, preview review, and the posture-ID preflight are sufficient for those values.
 
-```json
-"test:coverage": "vitest --run --coverage"
-```
+Implement email normalization through one path for both string and secret input (for example, always `pulumi.output(input).apply(normalizeAccessEmail)`) rather than maintaining separate string/output branches.
 
-so the existing root `bun run test:coverage` workflow executes the Access unit tests.
+## Deployment Sequence
 
-No new CI workflow is needed.
+### Phase 1 — implementation and pre-production
 
-## Protection Matrix
+1. Implement `packages/infrastructure`, CI wiring, the route-boundary test, and operator documentation.
+2. Run static/unit/coverage/lint/format verification.
+3. Build `dist/index.js` before every Pulumi preview because `Pulumi.yaml` points at compiled output.
+4. Produce non-mutating previews when authenticated local stack config is available.
+5. Human operator applies `pre-prod` and runs the hostname-wide acceptance matrix.
 
-| Surface | Access |
-| --- | --- |
-| `dtx.hapadona.com/app` | Protected |
-| `dtx.hapadona.com/app/` | Protected; verify explicitly |
-| `dtx.hapadona.com/app/*` | Protected |
-| Production routes outside `/app` | Public |
-| `pre-prod.dtx.hapadona.com/*` | Protected |
-| `api.dtx.hapadona.com/*` | Outside Access |
-| `api.pre-prod.dtx.hapadona.com/*` | Outside Access |
+### Phase 2 — production hold for Better Auth
 
-Production verification includes real public examples `/`, `/blog`, `/preview/1`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/login`, and `/auth/callback`.
+A queued Better Auth/D1 migration removes the current desktop magic-link callback flow and introduces Device Authorization approval at `/app/desktop-auth`. Its cutover plan explicitly schedules reconciliation of this Zero Trust spec/plan/runbook after PR #221 lands.
 
-## Testing And Implementation Gates
+Therefore **do not apply the production Access stack before that Better Auth cutover and documentation reconciliation are complete**. The production scope (`/app` + `/app/*`) remains the intended boundary, but the final browser/desktop acceptance procedure must describe the auth flow that will actually ship.
 
-### Unit tests
+Production preview may be used as a non-mutating scope check, but `pulumi up --stack production` remains blocked until the Better Auth reconciliation removes this hold.
 
-`src/access.test.ts` tests pure builders without contacting Cloudflare.
+## Operator Boundary
 
-At minimum:
+Implementation agents may edit code/docs, run local tests, build the Pulumi program, and run non-mutating previews when credentials/config are already available.
 
-- pre-prod is hostname-wide and never includes the API hostname;
-- production destinations are exactly `/app` and `/app/*`;
-- unsupported stack names throw;
-- malformed/multiple email values throw;
-- blank account ID and posture-rule ID throw;
-- the policy uses the normalized email in `includes`;
-- the policy references the supplied posture-rule ID in `requires`;
-- default session duration is `12h`;
-- hardened flags match the approved values;
-- production cannot become hostname-wide through config.
+The checked-in runbook owns all live operations. Human operators perform:
 
-### CI contract tests
-
-Run `.github/scripts/ci-affected-scope.test.sh` and prove infrastructure-only changes select the unit gate rather than failing closed or skipping unit coverage.
-
-### Repository checks
-
-Run:
-
-```bash
-bun install
-bun run --filter=@dtx/infrastructure check
-bun run --filter=@dtx/infrastructure test:coverage
-.github/scripts/ci-affected-scope.test.sh
-```
-
-Then run the relevant root checks if practical.
-
-### Pulumi preview gate
-
-Before any live apply, the operator or an authenticated implementation environment runs explicit-stack previews.
-
-Pre-prod preview must show only one `DTXWeb Pre-prod` Access application.
-
-Production preview must show only one `DTXWeb Production App` and exactly `/app` plus `/app/*` destinations.
-
-A preview showing a hostname-wide production app, API destination, new posture/list resource, service token, or unrelated resource is a hard stop.
-
-**The implementation plan ends at tested code, rewritten runbook, and successful/non-run preview evidence. It does not contain `pulumi up` or `pulumi destroy` execution steps.**
-
-## Operator Runbook Boundary
-
-`docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` is marked operator-executed.
-
-It owns:
-
-1. Pulumi local-backend login and stack/config setup.
-2. Obtaining the current Perseus posture-rule ID.
-3. Explicit-stack previews.
-4. `pulumi up --stack pre-prod`.
-5. Pre-prod HTTP/browser/posture acceptance.
-6. Only after pre-prod is green, `pulumi up --stack production`.
-7. Production route, identity, posture, browser, session-expiry, bundled desktop, and standalone Tauri-dev acceptance.
-8. Normal stack-specific rollback.
-9. Emergency Cloudflare dashboard disable/delete when Pulumi state/backend access is unavailable.
-
-Agents may prepare or verify non-mutating artifacts, but live applies/destroys and human browser/device observations are operator actions.
+- `pulumi up`;
+- `pulumi destroy`;
+- identity/device posture checks;
+- browser/desktop observations;
+- emergency Cloudflare dashboard disable/delete.
 
 ## Rollback
 
-### Normal Pulumi rollback
+Normal rollback uses the stack that owns the one Access application:
 
-For the affected stack, the operator first reviews:
+- preview destroy for the explicit stack;
+- confirm the one named DTXWeb Access application is the only deletion;
+- destroy that stack.
 
-```bash
-pulumi preview --destroy --stack <pre-prod|production>
-```
+If the local Pulumi backend/state is unavailable and immediate Access removal is required, the operator may disable/delete exactly the named DTXWeb Access application in the Cloudflare dashboard, then reconcile Pulumi state before any later apply.
 
-The preview must show exactly one deletion: the corresponding DTXWeb Access application.
+Removing pre-production Access returns `pre-prod.dtx.hapadona.com` to its prior public state. If the `pre-prod-prod-data` deployment mode is active, that public web hostname can be bound to the API environment using production D1/R2 resources. Treat pre-production Access removal as a security-impacting rollback, not a neutral cleanup.
 
-Then the operator may run:
+## Risks
 
-```bash
-pulumi destroy --stack <pre-prod|production> --yes
-```
+### Shared posture-rule drift
 
-### Emergency fallback without usable state
+Perseus can replace the posture-rule resource, leaving a stale DTXWeb resource ID. Mitigation: compare the current Perseus output with both DTXWeb stack configs on every operator preflight and stop on mismatch.
 
-If the local Pulumi backend/state is unavailable and immediate Access removal is necessary, the operator uses Cloudflare Zero Trust dashboard controls to disable/delete the named application:
+### Operator-machine concentration
 
-- `DTXWeb Pre-prod`, or
-- `DTXWeb Production App`.
+The local Pulumi backend and the trusted posture-satisfying device may live on the same machine. Hardware loss can remove both the normal state-aware rollback path and the trusted DTXWeb login path. Mitigation: keep the named-application Cloudflare dashboard removal procedure as the emergency provider-side recovery path.
 
-Do not create a bypass policy, service token, API Access app, or broader route as an emergency workaround.
+### Pre-production rollback exposure
 
-If Pulumi state later becomes available after a manual provider-side deletion, reconcile it before any future `pulumi up` (for example through the appropriate refresh/import/recovery procedure) rather than blindly applying stale state.
+Destroying the pre-production Access application makes the pre-production hostname public again. This matters especially when `pre-prod-prod-data` is serving the hostname against production-backed API data. The runbook must call out that consequence before destroy.
+
+### Auth migration sequencing
+
+Production desktop/browser auth is being redesigned by the queued Better Auth/D1 cutover. Applying production Access before that cutover would force two acceptance procedures and risk validating a flow that is about to disappear. Mitigation: apply pre-production now; hold production apply until the Better Auth reconciliation lands.
 
 ## Repository Changes
 
-Expected implementation changes:
+Expected implementation files:
 
-- `package.json`
-- `bun.lock`
-- `.github/scripts/ci-affected-scope.sh`
-- `.github/scripts/ci-affected-scope.test.sh`
-- `.github/scripts/fixtures/turbo-infrastructure.json`
-- `packages/infrastructure/.gitignore`
-- `packages/infrastructure/Pulumi.yaml`
-- `packages/infrastructure/package.json`
-- `packages/infrastructure/tsconfig.json`
-- `packages/infrastructure/vitest.config.ts`
-- `packages/infrastructure/src/access.ts`
-- `packages/infrastructure/src/access.test.ts`
-- `packages/infrastructure/src/index.ts`
-- `packages/infrastructure/README.md`
-- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-- `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
+- `package.json`, `bun.lock`;
+- `.github/scripts/ci-affected-scope.sh`;
+- `.github/scripts/ci-affected-scope.test.sh`;
+- `.github/scripts/fixtures/turbo-infrastructure.json`;
+- `.github/workflows/lint-and-format.yml`;
+- `packages/dtx-web/src/routes/(app)/private-route-boundary.test.ts`;
+- `packages/infrastructure/**`;
+- this spec, implementation plan, and operator runbook.
 
-No application/API/desktop source files change.
+No runtime source changes are planned under `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
 
 ## References
 
-Repository precedent:
+Repository:
 
-- Perseus `packages/infrastructure/src/admin-access.ts`
-- Perseus `packages/infrastructure/src/admin-access.test.ts`
-- Perseus `packages/infrastructure/src/index.ts`
-- Perseus `packages/infrastructure/Pulumi.yaml`
-- Perseus `packages/infrastructure/package.json`
 - DTXWeb `.github/scripts/ci-affected-scope.sh`
-- DTXWeb `.github/scripts/ci-affected-scope.test.sh`
-- DTXWeb `.github/workflows/unit-test.yml`
-- DTXWeb `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
+- DTXWeb `.github/workflows/lint-and-format.yml`
+- DTXWeb `packages/dtx-web/wrangler.jsonc`
+- DTXWeb `packages/dtx-api/wrangler.jsonc`
+- Perseus `packages/infrastructure/src/admin-access.ts`
+- Perseus `packages/infrastructure/src/index.ts`
+- queued Better Auth/D1 migration plan, Task 9 and Task 14
 
-Current Pulumi local-backend and recovery behavior should be verified against Pulumi's official state/backend and destroy-troubleshooting documentation during implementation.
+Cloudflare/Pulumi provider details must still be checked against the selected provider version during implementation if current typings differ from the referenced Perseus shape.

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -6,7 +6,7 @@ DTXWeb will manage its Cloudflare Zero Trust Access applications with Pulumi, us
 
 Production protects only `/app` and its descendants. This is intentionally an operator-only surface: the configured Access identity must match the intended operator and the request must satisfy the existing Perseus trusted-device posture rule. Other Supabase users may still reach public `/login`, but they cannot enter production `/app` or complete desktop login against production.
 
-Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is deployed and verified first. Production is not applied until the pre-production Access stack passes the documented identity, posture, browser-auth, desktop, and route-boundary checks.
+Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is deployed and verified first. Production is not applied until the pre-production Access stack passes the documented identity, posture, browser-auth, and route-boundary checks.
 
 DTXWeb gets a small `packages/infrastructure` workspace that owns only the two Access applications. Existing Worker/API deployment remains on Wrangler. This slice does not migrate Workers, D1, R2, service bindings, secrets, or runtime deployment into Pulumi.
 
@@ -87,6 +87,7 @@ Add a dedicated workspace:
 
 ```text
 packages/infrastructure/
+├── .gitignore
 ├── Pulumi.yaml
 ├── package.json
 ├── README.md
@@ -102,18 +103,17 @@ The package is intentionally Access-only. It has no Worker build/deployment logi
 
 The root workspace list adds `packages/infrastructure` so Bun installs and repository checks include the package naturally.
 
-Use the same dependency family as Perseus for the initial implementation:
+Use the same dependency versions currently working in Perseus for the initial implementation unless DTXWeb dependency resolution requires a compatible update:
 
-- `@pulumi/pulumi`
-- `@pulumi/cloudflare`
-- TypeScript
-- Vitest
-
-The exact dependency versions should match the currently working Perseus infrastructure package unless repository compatibility requires a newer version during implementation.
+- `@pulumi/pulumi` `^3.144.0`
+- `@pulumi/cloudflare` `^6.13.0`
+- `typescript` `^5.9.0`
+- `vitest` `^4.0.18`
+- `@types/node` `^22.10.0`
 
 ### Pulumi project
 
-`Pulumi.yaml` defines one DTXWeb infrastructure project, for example:
+`Pulumi.yaml` defines one DTXWeb infrastructure project:
 
 ```yaml
 name: dtxweb-infrastructure
@@ -130,6 +130,25 @@ One program serves exactly two supported stacks:
 Any other `pulumi.getStack()` value fails loudly before creating resources.
 
 This is intentional. Stack-specific hostname/path scope is code-owned rather than freely configurable.
+
+### State and local stack configuration
+
+Match the current Perseus operational model for this slice: local Pulumi usage with stack configuration excluded from git.
+
+`packages/infrastructure/.gitignore` includes at least:
+
+```text
+Pulumi.*.yaml
+.pulumi/
+node_modules/
+dist/
+.env
+.env.local
+```
+
+The operator configures both stacks locally with `pulumi config set` commands. No stack config file, encrypted secret value, or local state directory is committed.
+
+This slice does not add CI deployment, so reproducing the stack on another machine requires re-establishing the local Pulumi backend/login plus the documented config values.
 
 ## Stack Model
 
@@ -211,21 +230,21 @@ Both stacks use one inline policy:
 
 The policy mirrors the proven Perseus browser-admin policy shape but references the pre-existing posture rule directly.
 
-### Application builder
+### Stack definition and application builder
 
-The builder accepts:
+Keep stack selection testable as pure data. A helper such as `getAccessStackDefinition(stackName)` returns the immutable application name, domain, and destinations for `pre-prod` or `production` and throws for any other stack.
+
+The application builder accepts:
 
 - account ID;
-- application name;
-- primary domain;
-- fixed destination list;
+- stack definition;
 - operator email;
 - existing posture-rule ID;
 - optional session duration.
 
 It returns `cloudflare.ZeroTrustAccessApplicationArgs`.
 
-Stack-specific code supplies the destination list. No caller may supply arbitrary production paths from Pulumi config.
+No destination or hostname comes from Pulumi config.
 
 ### Resource ownership
 
@@ -270,9 +289,18 @@ Pulumi manages only Access. Wrangler remains the runtime deployment tool.
 
 ### Initial setup
 
-Configure both DTXWeb stacks with the Cloudflare account ID, secret Access email, reused Perseus posture-rule ID, and optional session duration.
+Use the same local-backend pattern as Perseus:
 
-No secret value or device serial is committed.
+```bash
+cd packages/infrastructure
+pulumi login --local
+pulumi stack init pre-prod
+pulumi stack init production
+```
+
+If either stack already exists locally, select it rather than recreating it.
+
+Configure both stacks with the Cloudflare account ID, secret Access email, reused Perseus posture-rule ID, and optional session duration. The implementation runbook will contain the exact commands without real values.
 
 ### Pre-production first
 
@@ -281,7 +309,7 @@ No secret value or device serial is committed.
 3. Review the preview and confirm it creates only the hostname-wide `DTXWeb Pre-prod` Access application.
 4. Run `pulumi up -s pre-prod`.
 5. Execute the complete pre-production verification section from the runbook.
-6. If any required check fails, run the environment-specific rollback before proceeding.
+6. If any required check fails, run the pre-production rollback immediately.
 
 Production must not be applied before pre-production is green.
 
@@ -310,9 +338,9 @@ At minimum, test:
 - default session duration is `12h`;
 - hardened application flags match the intended values;
 - unsupported stack names fail loudly;
-- invalid/empty email or posture-rule config fails before deployment if validation helpers are introduced.
+- empty/invalid email and empty posture-rule ID fail before deployment.
 
-The tests should follow the Perseus pattern of separating pure builders from Pulumi resource creation so most security-sensitive behavior is deterministic and unit-testable.
+Follow the Perseus pattern of separating pure builders from Pulumi resource creation so the security-sensitive shape is deterministic and unit-testable.
 
 ### Static verification
 
@@ -359,13 +387,29 @@ The browser checks cover:
 
 Rollback is stack-specific and does not touch Worker/API deployment.
 
-If pre-production fails required acceptance, remove/disable only the pre-production Access application through Pulumi. Production remains untouched.
+Because each stack owns exactly one Cloudflare resource in this slice, the rollback procedure is explicit:
 
-If production fails required acceptance, remove/disable only the production Access application through Pulumi. Pre-production remains available for further diagnosis.
+```bash
+pulumi preview --destroy -s pre-prod
+pulumi destroy -s pre-prod --yes
+```
 
-The implementation plan must choose one explicit Pulumi rollback procedure and document it safely. Do not use a broad infrastructure destroy command that could affect unrelated resources if the package later grows.
+for pre-production, or:
 
-Because this package owns only Access applications in this slice, rollback requires no Worker redeploy and no application-code rollback.
+```bash
+pulumi preview --destroy -s production
+pulumi destroy -s production --yes
+```
+
+for production.
+
+Before running `destroy`, the operator must review the destroy preview and confirm the only deletion is the corresponding DTXWeb Access application. If the infrastructure package later owns additional resources, this rollback procedure must be redesigned before those resources ship.
+
+If pre-production fails required acceptance, destroy only the `pre-prod` stack's Access application. Production remains untouched.
+
+If production fails required acceptance, destroy only the `production` stack's Access application. Pre-production remains available for further diagnosis.
+
+Rollback requires no Worker redeploy and no application-code rollback.
 
 Do not add a service token, API Access application, bypass policy, or widened destination as an emergency workaround.
 
@@ -377,14 +421,15 @@ Never commit:
 - device serial numbers;
 - Access cookies or JWTs;
 - Cloudflare API tokens;
-- Pulumi secret ciphertext files if the chosen backend/config workflow does not intend them for source control;
+- `Pulumi.<stack>.yaml` files for this local-stack workflow;
+- `.pulumi/` local state;
 - screenshots containing security identifiers.
 
-`accessEmail` is Pulumi secret configuration.
+`accessEmail` is set with Pulumi secret configuration.
 
 `devicePostureRuleId` is plain configuration, but it must refer to the existing Perseus-managed rule and must never be replaced with a freshly created DTXWeb rule as part of this slice.
 
-The Cloudflare API token used for Pulumi must have only the permissions needed to manage the intended Access application resources and read/reference the relevant account-level Access resources. Permission setup belongs in the implementation/runbook, not application source.
+The Cloudflare API token used for Pulumi should be scoped to the least privilege needed to manage the intended Access application resources. The exact token permission checklist must be verified against the provider/Cloudflare API during implementation and recorded in the runbook rather than guessed in application source.
 
 ## Operational Consequences
 
@@ -408,15 +453,16 @@ The existing production Supabase/UI behavior is unchanged. Signed-in non-operato
 
 ## Repository Changes
 
-The implementation is expected to modify only infrastructure/workspace/documentation files, approximately:
+The implementation is expected to modify only infrastructure/workspace/documentation files:
 
 - `package.json` — add `packages/infrastructure` workspace and optional convenience scripts if justified by the implementation plan.
 - `bun.lock` — dependency resolution.
+- `packages/infrastructure/.gitignore` — ignore local stack config/state, dependencies, build output, and env files.
 - `packages/infrastructure/Pulumi.yaml` — Pulumi project metadata.
 - `packages/infrastructure/package.json` — Pulumi/Cloudflare/TypeScript/Vitest package definition.
 - `packages/infrastructure/tsconfig.json`.
 - `packages/infrastructure/vitest.config.ts`.
-- `packages/infrastructure/src/access.ts` — Access builders/resource factory.
+- `packages/infrastructure/src/access.ts` — stack definitions, Access builders, and resource factory.
 - `packages/infrastructure/src/access.test.ts` — unit tests.
 - `packages/infrastructure/src/index.ts` — stack selection and resource creation.
 - `packages/infrastructure/README.md` — local config/preview/apply instructions.
@@ -443,8 +489,10 @@ Repository precedent:
 - Perseus `packages/infrastructure/src/admin-access.ts`
 - Perseus `packages/infrastructure/src/admin-access.test.ts`
 - Perseus `packages/infrastructure/src/index.ts`
+- Perseus `packages/infrastructure/src/config.ts`
 - Perseus `packages/infrastructure/Pulumi.yaml`
 - Perseus `packages/infrastructure/package.json`
+- Perseus `packages/infrastructure/.gitignore`
 - Perseus `packages/infrastructure/README.md`
 
 Cloudflare/Pulumi behavior should be verified against current provider and Cloudflare documentation during implementation if the working Perseus resource shape no longer typechecks against the selected provider version.

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -114,7 +114,7 @@ Prefer the existing account-level serial-number list/posture rule when DTXWeb is
 
 Verify the two policy clauses separately. A failed-posture device proves only the `Require` rule. The production rollout must also use the trusted device with a second IdP identity that is not in the `Include` list and confirm Access denies it.
 
-Do not change the account's instant-authentication setting merely to make `curl` output easier to recognize. During setup, record whether the reused Perseus login method uses the Cloudflare Access login page or instant authentication, then use the same mode for both DTXWeb applications and configure the verification helper to recognize that tenant's actual Access redirect target.
+Do not change the account's instant-authentication setting merely to make `curl` output easier to recognize. During setup, record whether the reused Perseus login method uses the Cloudflare Access login page or instant authentication, then use the same mode for both DTXWeb applications and configure the verification helper to recognize that tenant's actual Access interception signal: a redirect when present, or HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers.
 
 Do not add Service Auth, Managed OAuth, or service tokens. API and other non-browser traffic stay outside these Access applications.
 
@@ -186,7 +186,7 @@ No source or deployment code changes are planned. If verification shows that Sve
 
 ## Verification Requirements
 
-The durable runbook must make a missing HTTP response fail loudly. A DNS failure, connection failure, or timeout may not count as a successful `assert_no_access_redirect` result.
+The durable runbook must make a missing HTTP response fail loudly. A DNS failure, connection failure, or timeout may not count as a successful `assert_no_access_interception` result.
 
 The runbook owns one pre-production matrix and one production matrix. The implementation plan must invoke those sections rather than duplicate their commands.
 

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -1,0 +1,166 @@
+# Cloudflare Zero Trust Web Access Design
+
+## Summary
+
+DTXWeb will use Cloudflare Zero Trust Access as an outer access gate for the authenticated web application surface while preserving the public website and existing Supabase authentication flow.
+
+Production will protect only the authenticated application routes under `/app`. Pre-production will protect the entire web hostname. The GraphQL API hostnames remain outside Cloudflare Access so web and desktop API clients do not need service tokens or Access-specific request headers.
+
+The Zero Trust configuration will be managed manually in the Cloudflare dashboard. This slice does not introduce Pulumi, Terraform, CI deployment, Worker-side Access JWT validation, or any other infrastructure-as-code layer.
+
+## Goals
+
+- Require Cloudflare Access before users can reach production `/app` routes.
+- Keep production public routes such as `/`, `/blog`, `/preview`, `/editor`, `/login`, and `/auth/*` outside Cloudflare Access.
+- Require Cloudflare Access for every route served by `pre-prod.dtx.hapadona.com`.
+- Reuse the same identity and trusted-device posture model already used for Perseus admin access.
+- Preserve the existing Supabase application authentication as an independent inner gate.
+- Keep both production and pre-production API hostnames outside Cloudflare Access.
+- Document the intended dashboard configuration and verification procedure in the repository so future manual edits have a source of truth.
+
+## Non-Goals
+
+- Add Pulumi, Terraform, or another infrastructure-as-code system to DTXWeb.
+- Protect the entire production `dtx.hapadona.com` hostname.
+- Protect `api.dtx.hapadona.com` or `api.pre-prod.dtx.hapadona.com`.
+- Replace Supabase authentication.
+- Add Worker-side validation of `CF_Authorization` or Access JWTs.
+- Add Cloudflare Access service tokens for desktop, API, CLI, or CI traffic.
+- Protect preview/development Worker URLs outside the named production and pre-production custom hostnames.
+- Change SvelteKit, GraphQL API, or desktop application code as part of this slice.
+
+## Existing Context
+
+`packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and the pre-production web Worker to `pre-prod.dtx.hapadona.com`. The web application calls a separate GraphQL API at `api.dtx.hapadona.com` in production and `api.pre-prod.dtx.hapadona.com` in pre-production.
+
+`packages/dtx-web/src/hooks.server.ts` already treats `/app` as the application-authenticated route family. An unauthenticated request to `/app` is redirected to the public `/login` route, after which the existing Supabase flow returns the browser to `/app`.
+
+The desktop login flow also opens the web `/login` route and eventually returns through `/app?redirect=desktop...`. Production `/login` therefore must stay public while `/app` is Access-protected.
+
+The repository documents Cloudflare Worker deployments as manual and currently has no infrastructure deployment package or CI workflow. Zero Trust should follow that operating model for now.
+
+## Protection Matrix
+
+| Surface | Cloudflare Access | Notes |
+| --- | --- | --- |
+| `dtx.hapadona.com/app` | Protected | Exact parent route must be covered. |
+| `dtx.hapadona.com/app/*` | Protected | Covers all descendants explicitly. |
+| `dtx.hapadona.com/` | Public | Landing page remains public. |
+| `dtx.hapadona.com/blog/*` | Public | Public content remains public. |
+| `dtx.hapadona.com/preview/*` | Public | Public tool remains public. |
+| `dtx.hapadona.com/editor/*` | Public | Public tool remains public. |
+| `dtx.hapadona.com/login` | Public | Required by normal web and desktop login entry flows. |
+| `dtx.hapadona.com/auth/*` | Public | Supabase/OAuth callback routes remain public. |
+| Other production web routes outside `/app` | Public | Do not broaden the production application accidentally. |
+| `pre-prod.dtx.hapadona.com/*` | Protected | Entire pre-production web hostname is private. |
+| `api.dtx.hapadona.com/*` | Public to Access | Existing API/application auth remains authoritative. |
+| `api.pre-prod.dtx.hapadona.com/*` | Public to Access | Existing API/application auth remains authoritative. |
+
+Cloudflare documents that a wildcard path such as `/app/*` does not cover the parent `/app`. The production Access application therefore records both the exact parent and wildcard descendant destinations instead of relying on path inheritance.
+
+## Access Applications
+
+### Production
+
+Create one self-hosted public-hostname Access application named `DTXWeb Production App` with exactly these destinations:
+
+- `dtx.hapadona.com/app`
+- `dtx.hapadona.com/app/*`
+
+Do not add a hostname-wide production destination. Do not add `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, or other public routes.
+
+### Pre-production
+
+Create a second self-hosted public-hostname Access application named `DTXWeb Pre-prod` for the entire hostname:
+
+- `pre-prod.dtx.hapadona.com`
+
+No path exception is required. Because the entire hostname is protected, `/`, `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, `/app`, and future routes on the pre-production web hostname all require Access first.
+
+## Access Policy
+
+Both applications use the same policy semantics:
+
+- Action: `Allow`.
+- Include: the intended operator identity/email used for the existing Perseus Zero Trust access.
+- Require: the trusted-device serial-number posture check used for Perseus.
+- Session duration: `12h`, matching the existing Perseus Access configuration.
+
+Prefer reusing the existing account-level device serial list/posture rule when it is available in the same Cloudflare Zero Trust account. If the DTXWeb zone is managed in a different Zero Trust account, create an equivalent serial-number list and posture rule using the same intended trusted devices rather than weakening the requirement.
+
+Do not add a Service Auth policy or service token. The protected surfaces are browser routes, and API/desktop non-browser traffic remains outside Access.
+
+## Request Flows
+
+### Production web application
+
+1. Browser requests `https://dtx.hapadona.com/app` or a descendant.
+2. Cloudflare Access evaluates identity and device posture.
+3. A denied request never reaches DTXWeb.
+4. An allowed request reaches SvelteKit.
+5. SvelteKit applies the existing Supabase session guard.
+6. If the user lacks a Supabase session, SvelteKit redirects to public `/login`.
+7. After login, the browser returns to `/app`; the existing Cloudflare Access session allows it through the outer gate again.
+
+Public production routes skip steps 2-3 entirely because they are not part of the Access application.
+
+### Pre-production web application
+
+1. Any request to `pre-prod.dtx.hapadona.com` reaches Cloudflare Access first.
+2. After Access succeeds, the existing DTXWeb route and Supabase behavior runs normally.
+3. OAuth/login callbacks on the same pre-production hostname remain behind Access, but the browser already has an Access session from entering the site.
+
+### API traffic
+
+Requests to production and pre-production GraphQL API hostnames do not pass through these Access applications. Existing Supabase/API authorization remains unchanged, and desktop/API clients do not need Cloudflare service credentials.
+
+## Repository Changes
+
+The implementation should add one operator runbook documenting:
+
+- the two Access application names and exact destinations;
+- policy requirements;
+- the public/protected route matrix;
+- dashboard setup steps;
+- verification commands and browser checks;
+- rollback steps;
+- the explicit rule that email addresses and device serial numbers must not be committed.
+
+No application or deployment code should change unless implementation verification reveals an existing bug that prevents the approved design. Such a bug is outside this slice and should be handled separately instead of silently expanding scope.
+
+## Verification
+
+Verify from a browser without a current Access session:
+
+- production `/app` prompts for or redirects through Cloudflare Access;
+- a production `/app/*` descendant also requires Access;
+- production `/`, `/blog`, `/preview`, `/editor`, `/login`, and `/auth/*` do not trigger Cloudflare Access;
+- every tested route on `pre-prod.dtx.hapadona.com` requires Access;
+- both API hostnames do not trigger Cloudflare Access.
+
+Verify from the allowed identity on the trusted device:
+
+- production `/app` passes Access and continues into the existing Supabase behavior;
+- an unauthenticated Supabase session can still go `/app` -> `/login` -> `/app` successfully;
+- the production desktop browser-login flow can enter through public `/login` and return through protected `/app`;
+- pre-production login and callback flows work after the hostname-wide Access gate;
+- public production routes remain usable without a Cloudflare Access session.
+
+Verify from a device that does not satisfy the posture rule that protected production and pre-production surfaces are denied before DTXWeb loads.
+
+## Failure Handling And Rollback
+
+If production public routes become Access-protected, remove the overly broad destination immediately and restore the production application to only `/app` plus `/app/*`.
+
+If pre-production authentication callbacks fail, first confirm the browser retains a valid Access session across the OAuth redirect. Do not make `/auth/*` public on pre-production without a separate design decision; the approved policy is hostname-wide protection.
+
+If API or desktop non-browser traffic begins receiving Access challenges, remove the API hostname from Access. Service-token support is explicitly outside this slice.
+
+Rollback consists of disabling or deleting the two DTXWeb Access applications. No Worker rollback or code deploy should be necessary because the application binaries are unchanged.
+
+## References
+
+- Cloudflare Access application paths: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
+- Cloudflare self-hosted public applications: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
+- Cloudflare Access policies: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
+- Cloudflare ZTNA policy design and device posture: https://developers.cloudflare.com/reference-architecture/design-guides/designing-ztna-access-policies/

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -2,165 +2,213 @@
 
 ## Summary
 
-DTXWeb will use Cloudflare Zero Trust Access as an outer access gate for the authenticated web application surface while preserving the public website and existing Supabase authentication flow.
+DTXWeb will use Cloudflare Zero Trust Access as an outer gate for private web surfaces while keeping the public production site and both GraphQL API hostnames outside Access.
 
-Production will protect only the authenticated application routes under `/app`. Pre-production will protect the entire web hostname. The GraphQL API hostnames remain outside Cloudflare Access so web and desktop API clients do not need service tokens or Access-specific request headers.
+Production protects only `/app` and its descendants. This is intentionally an operator-only surface: the Perseus-style Access policy allows the configured operator identity on a trusted device, so other Supabase users can still reach public `/login` but cannot enter production `/app` or complete desktop login against production.
 
-The Zero Trust configuration will be managed manually in the Cloudflare dashboard. This slice does not introduce Pulumi, Terraform, CI deployment, Worker-side Access JWT validation, or any other infrastructure-as-code layer.
+Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is configured and verified first so identity, device posture, Supabase login/OAuth, and rollback are proven before the production path-scoped application is created.
+
+The Zero Trust configuration is managed manually in the Cloudflare dashboard. This slice does not introduce Pulumi, Terraform, CI deployment, Worker-side Access JWT validation, service tokens, or application-code changes.
 
 ## Goals
 
-- Require Cloudflare Access before users can reach production `/app` routes.
-- Keep production public routes such as `/`, `/blog`, `/preview`, `/editor`, `/login`, and `/auth/*` outside Cloudflare Access.
+- Make production `/app` and production desktop login intentionally operator-only behind Cloudflare Access.
+- Keep the production public site outside Access, including `/`, `/blog`, `/preview`, `/editor`, `/tool/*`, `/game`, `/login`, and `/auth/*`.
 - Require Cloudflare Access for every route served by `pre-prod.dtx.hapadona.com`.
-- Reuse the same identity and trusted-device posture model already used for Perseus admin access.
-- Preserve the existing Supabase application authentication as an independent inner gate.
-- Keep both production and pre-production API hostnames outside Cloudflare Access.
-- Document the intended dashboard configuration and verification procedure in the repository so future manual edits have a source of truth.
+- Reuse the same configured operator identity and trusted-device serial-number posture model used for Perseus.
+- Preserve Supabase authentication as an independent inner gate after Access allows a request.
+- Keep `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` outside Access.
+- Roll out pre-production first, then production only after the pre-production gate and auth round-trip are verified.
+- Verify route boundaries from HTTP response headers in addition to browser smoke tests.
+- Document the dashboard configuration, verification matrix, and rollback procedure in a dedicated operator runbook.
 
 ## Non-Goals
 
-- Add Pulumi, Terraform, or another infrastructure-as-code system to DTXWeb.
+- Add Pulumi, Terraform, or another infrastructure-as-code system.
 - Protect the entire production `dtx.hapadona.com` hostname.
-- Protect `api.dtx.hapadona.com` or `api.pre-prod.dtx.hapadona.com`.
+- Protect either API hostname.
+- Make production `/app` available to every Supabase user.
 - Replace Supabase authentication.
 - Add Worker-side validation of `CF_Authorization` or Access JWTs.
 - Add Cloudflare Access service tokens for desktop, API, CLI, or CI traffic.
-- Protect preview/development Worker URLs outside the named production and pre-production custom hostnames.
-- Change SvelteKit, GraphQL API, or desktop application code as part of this slice.
+- Protect preview/development Worker URLs outside the named custom hostnames.
+- Change SvelteKit, GraphQL API, or desktop application code in this slice.
 
 ## Existing Context
 
-`packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and the pre-production web Worker to `pre-prod.dtx.hapadona.com`. The web application calls a separate GraphQL API at `api.dtx.hapadona.com` in production and `api.pre-prod.dtx.hapadona.com` in pre-production.
+`packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and pre-production to `pre-prod.dtx.hapadona.com`. The web application uses separate API hostnames: `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com`.
 
-`packages/dtx-web/src/hooks.server.ts` already treats `/app` as the application-authenticated route family. An unauthenticated request to `/app` is redirected to the public `/login` route, after which the existing Supabase flow returns the browser to `/app`.
+`packages/dtx-web/src/hooks.server.ts` treats paths beginning with `/app` as the Supabase-authenticated application family. An unauthenticated request to `/app` is redirected to public `/login`, and successful web login returns to `/app` or another validated `/app/*` destination.
 
-The desktop login flow also opens the web `/login` route and eventually returns through `/app?redirect=desktop...`. Production `/login` therefore must stay public while `/app` is Access-protected.
+The desktop flow also starts at public `/login` and finishes through `/app?redirect=desktop...`. Password login redirects there directly; Google OAuth does the same through the auth callback. The login page preserves the desktop callback in `sessionStorage` so the `/app` page can hand the magic link back to either the bundled `dtx://` callback or the Tauri-development loopback callback.
 
-The repository documents Cloudflare Worker deployments as manual and currently has no infrastructure deployment package or CI workflow. Zero Trust should follow that operating model for now.
+Because production `/app` sits behind a single-operator Access policy, that desktop handoff is also operator-only. Public `/login` is an entry form, not a bypass around Access. A non-operator Supabase user may authenticate successfully and then be denied when the browser returns to `/app`; that is the intended product behavior for this slice.
+
+The repository already uses human-executed Cloudflare runbooks, for example `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`. That file is a historical API-migration cutover checklist, so Zero Trust gets its own durable runbook rather than mixing permanent security operations into the completed Phase 4 migration document.
 
 ## Protection Matrix
 
 | Surface | Cloudflare Access | Notes |
 | --- | --- | --- |
-| `dtx.hapadona.com/app` | Protected | Exact parent route must be covered. |
-| `dtx.hapadona.com/app/*` | Protected | Covers all descendants explicitly. |
-| `dtx.hapadona.com/` | Public | Landing page remains public. |
-| `dtx.hapadona.com/blog/*` | Public | Public content remains public. |
-| `dtx.hapadona.com/preview/*` | Public | Public tool remains public. |
-| `dtx.hapadona.com/editor/*` | Public | Public tool remains public. |
-| `dtx.hapadona.com/login` | Public | Required by normal web and desktop login entry flows. |
-| `dtx.hapadona.com/auth/*` | Public | Supabase/OAuth callback routes remain public. |
-| Other production web routes outside `/app` | Public | Do not broaden the production application accidentally. |
-| `pre-prod.dtx.hapadona.com/*` | Protected | Entire pre-production web hostname is private. |
-| `api.dtx.hapadona.com/*` | Public to Access | Existing API/application auth remains authoritative. |
-| `api.pre-prod.dtx.hapadona.com/*` | Public to Access | Existing API/application auth remains authoritative. |
+| `dtx.hapadona.com/app` | Protected | Operator-only; exact parent must be covered. |
+| `dtx.hapadona.com/app/*` | Protected | Operator-only descendants. |
+| `dtx.hapadona.com/` | Public | Landing page. |
+| `dtx.hapadona.com/blog/*` | Public | Public content. |
+| `dtx.hapadona.com/preview/*` | Public | Public preview surface. |
+| `dtx.hapadona.com/editor/*` | Public | Public editor surface. |
+| `dtx.hapadona.com/tool/*` | Public | Public tools, including `/tool/dtx-to-midi`. |
+| `dtx.hapadona.com/game` | Public | Public game entry. |
+| `dtx.hapadona.com/login` | Public | Web and desktop login entry. |
+| `dtx.hapadona.com/auth/*` | Public | Supabase/OAuth callbacks. |
+| Other production web paths outside `/app` | Public | Do not broaden production Access. |
+| `pre-prod.dtx.hapadona.com/*` | Protected | Entire pre-production web hostname. |
+| `api.dtx.hapadona.com/*` | Outside Access | Existing API auth remains authoritative. |
+| `api.pre-prod.dtx.hapadona.com/*` | Outside Access | Existing API auth remains authoritative. |
 
-Cloudflare documents that a wildcard path such as `/app/*` does not cover the parent `/app`. The production Access application therefore records both the exact parent and wildcard descendant destinations instead of relying on path inheritance.
+Cloudflare Access application paths can protect either an entire hostname or selected paths. Production records both `/app` and `/app/*` explicitly so the parent and descendants are both protected.
 
 ## Access Applications
 
+### Pre-production
+
+Create `DTXWeb Pre-prod` first as a self-hosted public-hostname application for:
+
+- `pre-prod.dtx.hapadona.com`
+
+There is no path bypass. `/`, `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, `/tool/*`, `/game`, `/app`, and future routes on that web hostname all pass through Access.
+
+Do not include `api.pre-prod.dtx.hapadona.com`.
+
 ### Production
 
-Create one self-hosted public-hostname Access application named `DTXWeb Production App` with exactly these destinations:
+Only after the pre-production checks pass, create `DTXWeb Production App` with exactly:
 
 - `dtx.hapadona.com/app`
 - `dtx.hapadona.com/app/*`
 
-Do not add a hostname-wide production destination. Do not add `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, or other public routes.
-
-### Pre-production
-
-Create a second self-hosted public-hostname Access application named `DTXWeb Pre-prod` for the entire hostname:
-
-- `pre-prod.dtx.hapadona.com`
-
-No path exception is required. Because the entire hostname is protected, `/`, `/login`, `/auth/*`, `/blog`, `/preview`, `/editor`, `/app`, and future routes on the pre-production web hostname all require Access first.
+Do not add a hostname-wide production destination or any public path.
 
 ## Access Policy
 
 Both applications use the same policy semantics:
 
 - Action: `Allow`.
-- Include: the intended operator identity/email used for the existing Perseus Zero Trust access.
+- Include: the intended operator identity/email used for Perseus access.
 - Require: the trusted-device serial-number posture check used for Perseus.
-- Session duration: `12h`, matching the existing Perseus Access configuration.
+- Session duration: `12h`.
 
-Prefer reusing the existing account-level device serial list/posture rule when it is available in the same Cloudflare Zero Trust account. If the DTXWeb zone is managed in a different Zero Trust account, create an equivalent serial-number list and posture rule using the same intended trusted devices rather than weakening the requirement.
+Prefer the existing account-level serial-number list/posture rule when DTXWeb is in the same Zero Trust account. If it is not reusable because the zone is under a different Zero Trust account, create an equivalent list/posture rule there using the same intended trusted devices. Do not weaken the posture requirement.
 
-Do not add a Service Auth policy or service token. The protected surfaces are browser routes, and API/desktop non-browser traffic remains outside Access.
+Do not add a Service Auth policy or service token. API and other non-browser traffic stay outside these Access applications.
+
+## Rollout Order
+
+1. Add the dedicated DTXWeb Zero Trust operator runbook.
+2. Confirm the intended operator identity and serial-number posture rule are available without copying personal identifiers into git.
+3. Create the hostname-wide pre-production Access application.
+4. Verify pre-production interception, trusted-device admission, posture denial, Supabase password login, Google OAuth callback behavior, and API non-interception.
+5. If any pre-production check fails, disable/remove the pre-production Access app and stop. Do not touch production.
+6. Create the production application with only `/app` and `/app/*`.
+7. Run the complete production header matrix, including `/tool/*` and `/game`, before considering the rollout accepted.
+8. Run the trusted-device production browser and desktop-login checks, including the Tauri-development loopback callback path.
+9. Re-run API non-interception checks and record the final state in the operator runbook/checklist.
 
 ## Request Flows
 
-### Production web application
+### Production browser
 
-1. Browser requests `https://dtx.hapadona.com/app` or a descendant.
-2. Cloudflare Access evaluates identity and device posture.
+1. Browser requests `/app` or `/app/*`.
+2. Cloudflare Access evaluates the operator identity and device posture.
 3. A denied request never reaches DTXWeb.
-4. An allowed request reaches SvelteKit.
-5. SvelteKit applies the existing Supabase session guard.
-6. If the user lacks a Supabase session, SvelteKit redirects to public `/login`.
-7. After login, the browser returns to `/app`; the existing Cloudflare Access session allows it through the outer gate again.
+4. An allowed request reaches SvelteKit and the existing Supabase guard.
+5. Without a Supabase session, SvelteKit redirects to public `/login`.
+6. After Supabase login, the browser returns to protected `/app` and must still satisfy the Access gate.
 
-Public production routes skip steps 2-3 entirely because they are not part of the Access application.
+A normal Supabase user who does not match the Access policy is intentionally denied at step 2 or when returning to `/app` after public login.
 
-### Pre-production web application
+### Production desktop login
 
-1. Any request to `pre-prod.dtx.hapadona.com` reaches Cloudflare Access first.
-2. After Access succeeds, the existing DTXWeb route and Supabase behavior runs normally.
-3. OAuth/login callbacks on the same pre-production hostname remain behind Access, but the browser already has an Access session from entering the site.
+1. Desktop opens public `/login?redirect=desktop&desktop_callback=...`.
+2. `/login` preserves the callback for the post-login handoff.
+3. Password or Google login returns the browser to `/app?redirect=desktop...`.
+4. Cloudflare Access gates that `/app` return.
+5. Only the configured operator on a trusted device can reach the `/app` handoff that generates and forwards the desktop magic link.
+
+Verification must cover both a bundled `dtx://auth-callback` flow and, when available, a `tauri dev` loopback callback in the same browser tab because the loopback path depends on the preserved callback state.
+
+### Pre-production
+
+Any request to `pre-prod.dtx.hapadona.com` reaches Access first. Once the browser has a valid Access session, the existing Supabase login and callback routes on that same hostname run normally behind the gate.
 
 ### API traffic
 
-Requests to production and pre-production GraphQL API hostnames do not pass through these Access applications. Existing Supabase/API authorization remains unchanged, and desktop/API clients do not need Cloudflare service credentials.
+Requests to the two GraphQL API hostnames do not pass through these Access applications. Existing Supabase/API authorization stays unchanged and API/desktop callers require no Cloudflare Access credential.
 
 ## Repository Changes
 
-The implementation should add one operator runbook documenting:
+Implementation creates one focused runbook:
 
-- the two Access application names and exact destinations;
-- policy requirements;
-- the public/protected route matrix;
-- dashboard setup steps;
-- verification commands and browser checks;
-- rollback steps;
-- the explicit rule that email addresses and device serial numbers must not be committed.
+- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
 
-No application or deployment code should change unless implementation verification reveals an existing bug that prevents the approved design. Such a bug is outside this slice and should be handled separately instead of silently expanding scope.
+The runbook records the two applications, operator-only product intent, pre-production-first rollout, exact production destinations, policy semantics, header-based verification matrix, trusted-device browser/desktop checks, API exclusions, and rollback.
+
+Do not edit the historical Phase 4 API migration runbook except for a future independent documentation cleanup; it is useful precedent for human-executed Cloudflare operations but not the ownership location for this permanent Access configuration.
+
+No source or deployment code changes are planned. If verification shows that SvelteKit, desktop, API, or routing code must change for this approved model to work, stop this slice and create a separate follow-up rather than widening scope.
 
 ## Verification
 
-Verify from a browser without a current Access session:
+### Header-based boundary checks
 
-- production `/app` prompts for or redirects through Cloudflare Access;
-- a production `/app/*` descendant also requires Access;
-- production `/`, `/blog`, `/preview`, `/editor`, `/login`, and `/auth/*` do not trigger Cloudflare Access;
-- every tested route on `pre-prod.dtx.hapadona.com` requires Access;
-- both API hostnames do not trigger Cloudflare Access.
+For unauthenticated requests, inspect response headers rather than relying only on what a browser appears to show. Cloudflare's normal Access login flow returns an interception redirect; the durable failure signal for routes that must remain public is a `Location` pointing to the account's `cloudflareaccess.com/cdn-cgi/access/` flow.
 
-Verify from the allowed identity on the trusted device:
+Run the matrix with `curl -sS -o /dev/null -D - <url>` and inspect the status plus `Location` header.
 
-- production `/app` passes Access and continues into the existing Supabase behavior;
-- an unauthenticated Supabase session can still go `/app` -> `/login` -> `/app` successfully;
-- the production desktop browser-login flow can enter through public `/login` and return through protected `/app`;
-- pre-production login and callback flows work after the hostname-wide Access gate;
-- public production routes remain usable without a Cloudflare Access session.
+Pre-production must show Access interception for representative routes across the hostname, including `/`, `/login`, `/auth/callback`, `/blog`, `/preview`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/app`, and `/app/score`.
 
-Verify from a device that does not satisfy the posture rule that protected production and pre-production surfaces are denied before DTXWeb loads.
+Production must show Access interception for `/app` and `/app/score`, while these must not return a Cloudflare Access `Location`:
+
+- `/`
+- `/blog`
+- `/preview`
+- `/editor`
+- `/tool/dtx-to-midi`
+- `/game`
+- `/login`
+- `/auth/callback`
+
+Both API hostnames must also avoid a Cloudflare Access `Location`; their application-specific HTTP status is otherwise irrelevant to this boundary check.
+
+If the Zero Trust account uses instant authentication and therefore redirects directly to the identity provider instead of the Cloudflare Access login page, use the equivalent known Access redirect behavior for that tenant plus the browser checks below; do not mistake an application redirect for Access interception.
+
+### Trusted browser and desktop checks
+
+On the WARP/Cloudflare One-enrolled trusted device with the configured operator identity:
+
+- prove pre-production login and callback flows before production configuration;
+- prove production `/app -> /login -> /app` still works as two independent gates;
+- prove production desktop login returns through protected `/app` and reaches the desktop callback;
+- specifically exercise the Tauri-development loopback callback when available so the `sessionStorage` handoff is tested, not just the bundled `dtx://` path.
+
+### Denial check
+
+From a device that fails the serial-number posture rule, protected pre-production and production surfaces must be denied before DTXWeb loads.
 
 ## Failure Handling And Rollback
 
-If production public routes become Access-protected, remove the overly broad destination immediately and restore the production application to only `/app` plus `/app/*`.
+If pre-production identity, posture, login, callback, or route-boundary checks fail, disable/delete `DTXWeb Pre-prod` and stop before production.
 
-If pre-production authentication callbacks fail, first confirm the browser retains a valid Access session across the OAuth redirect. Do not make `/auth/*` public on pre-production without a separate design decision; the approved policy is hostname-wide protection.
+If any production public route is intercepted, disable `DTXWeb Production App` immediately and correct its destinations before re-enabling it. The accepted production destination set is only `/app` and `/app/*`.
 
-If API or desktop non-browser traffic begins receiving Access challenges, remove the API hostname from Access. Service-token support is explicitly outside this slice.
+If either API hostname is intercepted, remove the API hostname from Access. Do not add service tokens as a workaround in this slice.
 
-Rollback consists of disabling or deleting the two DTXWeb Access applications. No Worker rollback or code deploy should be necessary because the application binaries are unchanged.
+If the trusted production desktop flow cannot complete the `/login -> /app -> desktop` handoff, disable the production Access application and investigate separately. Do not widen the Access policy or add a bypass to make the test pass.
+
+Rollback is dashboard-only: disable or delete the relevant Access application. No Worker rollback or code deployment is required.
 
 ## References
 
 - Cloudflare Access application paths: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
 - Cloudflare self-hosted public applications: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
 - Cloudflare Access policies: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
-- Cloudflare ZTNA policy design and device posture: https://developers.cloudflare.com/reference-architecture/design-guides/designing-ztna-access-policies/
+- Cloudflare Access authorization cookie: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -2,88 +2,105 @@
 
 ## Summary
 
-DTXWeb will manage its Cloudflare Zero Trust Access applications with Pulumi, using the same Cloudflare provider and Access-resource shape already proven in Perseus, while keeping the DTXWeb slice deliberately narrower.
+DTXWeb will manage its Cloudflare Zero Trust Access applications with a small Pulumi package modeled on the proven Perseus Access implementation.
 
-Production protects only `/app` and its descendants. This is intentionally an operator-only surface: the configured Access identity must match the intended operator and the request must satisfy the existing Perseus trusted-device posture rule. Other Supabase users may still reach public `/login`, but they cannot enter production `/app` or complete desktop login against production.
+The package owns **Access only**. Wrangler remains the owner of DTXWeb Workers, API deployment, D1, R2, service bindings, routes, runtime variables, and application secrets.
 
-Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is deployed and verified first. Production is not applied until the pre-production Access stack passes the documented identity, posture, browser-auth, and route-boundary checks.
+Production protects only exact `/app` plus descendants under `/app/`. This is intentionally an operator-only surface: the configured Access identity must match the intended operator and the request must satisfy the existing Perseus trusted-device posture rule. Production `/login`, `/auth/*`, the rest of the public web site, and both API hostnames remain outside Access.
 
-DTXWeb gets a small `packages/infrastructure` workspace that owns only the two Access applications. Existing Worker/API deployment remains on Wrangler. This slice does not migrate Workers, D1, R2, service bindings, secrets, or runtime deployment into Pulumi.
+Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is always previewed and proven before production is applied.
 
 DTXWeb does not create another serial-number list or device-posture rule. Perseus remains the owner of trusted-device membership; DTXWeb consumes the existing Perseus posture-rule resource ID as Pulumi configuration.
 
+The infrastructure code, tests, CI wiring, and Pulumi previews are implementation work. **Live `pulumi up`, live acceptance, and rollback/destroy are operator-executed runbook procedures, not agent implementation-plan steps.**
+
 ## Goals
 
-- Manage DTXWeb Cloudflare Access declaratively with Pulumi rather than manual dashboard configuration.
-- Follow the proven Perseus Access implementation shape where it applies.
-- Reuse the existing Perseus device-posture rule ID instead of duplicating its serial list or rule.
+- Manage DTXWeb Cloudflare Access declaratively with Pulumi rather than dashboard-created configuration.
+- Follow the proven Perseus `ZeroTrustAccessApplication` + inline policy shape where it applies.
+- Reuse the existing Perseus device-posture rule ID instead of duplicating its serial list or posture rule.
 - Make production `/app` and production desktop login intentionally operator-only behind Cloudflare Access.
-- Keep the production public site outside Access, including `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, and `/auth/*`.
+- Keep production `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, `/auth/*`, and other intended public routes outside Access.
 - Require Cloudflare Access for every route served by `pre-prod.dtx.hapadona.com`.
-- Preserve Supabase authentication as an independent inner gate after Access allows a request.
 - Keep `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` outside Access.
-- Make pre-production and production separate Pulumi stacks so rollout and rollback are environment-specific.
-- Make the stack name determine the hostname and protection scope so ordinary configuration cannot accidentally broaden production Access.
-- Roll out pre-production first, then production only after the pre-production gate and auth round-trip are verified.
-- Verify the Access identity `Include` clause independently from the device-posture `Require` clause.
-- Keep the existing operator runbook as the durable acceptance/rollback procedure, updated to use Pulumi preview/apply instead of dashboard clicks.
+- Preserve Supabase authentication as an independent inner gate after Access allows a request.
+- Use separate `pre-prod` and `production` Pulumi stacks so rollout and rollback are environment-specific.
+- Make stack name determine hostname/path scope so ordinary config cannot accidentally broaden production Access.
+- Wire `@dtx/infrastructure` into the repository's fail-closed affected-scope CI and coverage workflow.
+- Reuse DTXWeb's current TypeScript/Vitest/Node type major versions instead of importing Perseus's newer JS test toolchain.
+- Keep one checked-in runbook as the live operator source of truth for preview, apply, verification, emergency fallback, and rollback.
 
 ## Non-Goals
 
 - Migrate DTXWeb Worker or API deployment from Wrangler to Pulumi.
 - Manage D1, R2, KV, Workers, routes, service bindings, runtime environment variables, or application secrets with Pulumi in this slice.
 - Create or manage the shared trusted-device serial-number list in DTXWeb.
-- Create or manage a second DTXWeb-specific device-posture rule.
+- Create a DTXWeb-specific device-posture rule.
 - Add a Pulumi `StackReference` dependency on the Perseus stack.
 - Protect the entire production `dtx.hapadona.com` hostname.
 - Protect either API hostname.
 - Make production `/app` available to every Supabase user.
-- Add a public logout route or otherwise change the current non-operator recovery behavior in this slice.
+- Add a public logout route or change the current non-operator recovery behavior.
 - Replace Supabase authentication.
 - Add Worker-side validation of `CF_Authorization` or Access JWTs.
 - Add Cloudflare Access service tokens, Service Auth policies, CLI applications, or Managed OAuth.
-- Copy Perseus's admin CLI/service-token resources.
-- Make pre-production an unattended E2E target in this slice.
-- Add GitHub Actions deployment for the new Pulumi package in this slice.
-- Change SvelteKit, GraphQL API, or desktop application code.
+- Copy Perseus's CLI/service-token/Worker/storage resources.
+- Make pre-production an unattended E2E target.
+- Add GitHub Actions deployment of Pulumi resources.
+- Let an agent execute live `pulumi up` or `pulumi destroy` as part of the implementation plan.
+- Change code under `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
 
 ## Existing Context
 
 ### DTXWeb routing and deployment
 
-`packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and pre-production to `pre-prod.dtx.hapadona.com`. The web application uses separate API hostnames: `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com`.
+`packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and pre-production to `pre-prod.dtx.hapadona.com`. The GraphQL API uses separate hostnames: `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com`.
 
 `packages/dtx-web/src/hooks.server.ts` currently treats any pathname beginning with `/app` as Supabase-authenticated. The intended private route family for this design is narrower: exact `/app` or descendants under `/app/`. Production Access therefore protects `/app` and `/app/*`.
 
-This dependency is an operating invariant: any new private production page must live at `/app` or below `/app/`, or the Access design must be revisited before shipping it. A new private sibling such as `/studio` or `/admin` would otherwise be public at the edge. The current `pathname.startsWith('/app')` guard is slightly broader than the intended Access family and must not be used to justify new `/app...` sibling-style routes.
+Any new private production page must live at `/app` or below `/app/`, or this Access design must be revised before shipping it. The broader `pathname.startsWith('/app')` application guard must not be used to justify new `/app...` sibling-style routes.
 
 ### Desktop authentication
 
-The desktop flow starts at web `/login` and finishes through `/app?redirect=desktop...`. Password login redirects there directly; Google OAuth does the same through the auth callback. The login page preserves the desktop callback in `sessionStorage` so the `/app` page can hand the magic link back to either the bundled `dtx://` callback or the Tauri-development loopback callback.
+Desktop login begins on public `/login` and completes through `/app?redirect=desktop...`. Password and Google OAuth both return through the protected `/app` handoff.
 
-Standalone desktop development (`bun run dev:desktop`) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup it points at production, so standalone `tauri dev` authentication traverses production `/login` and protected production `/app`. The full local-stack command (`bun run dev`) instead uses `dtx-desktop#dev:local-web` and localhost.
+Standalone `bun run dev:desktop` consumes `VITE_DTX_SERVER_URL` from the ignored root `.env`; in the current operator setup this targets production. Full local-stack `bun run dev` instead uses `dtx-desktop#dev:local-web` and localhost.
 
-After this Access change, authentication against either deployed web environment is operator-only. Non-operator contributors must use the full local stack or another separately designed ungated development environment.
+After this Access change, authentication against deployed production or pre-production is operator-only. Non-operator contributors use the full local stack or a separately designed ungated development environment.
 
 ### Non-operator production lockout
 
-Because production `/app` sits behind a single-operator Access policy, public `/login` is an entry form, not an Access bypass. A non-operator Supabase user may authenticate successfully and then be denied when the browser returns to `/app`.
+A non-operator Supabase user can authenticate on public `/login` and then be denied by Access when the browser returns to `/app`.
 
-That state currently has no UI recovery path. `hooks.server.ts` redirects an already-authenticated visitor from `/login` to `/app`, while the only current sign-out control lives inside the Access-protected `(app)` layout. A signed-in non-operator therefore must clear the Drumery/Supabase cookies for the production origin. A public logout route or a change to the authenticated `/login` redirect is an explicit deferred product decision.
+If they now hold a Supabase session, revisiting `/login` redirects them back to `/app`, while the current sign-out control is inside the protected application layout. Clearing the Drumery/Supabase cookies for the production origin is the documented recovery. A public logout route is a separate product/code decision.
 
 ### Perseus precedent
 
-Perseus already manages Cloudflare Zero Trust Access with `@pulumi/cloudflare`. Its infrastructure package creates a `ZeroTrustAccessApplication` with inline policies, uses an email `Include` selector, requires a device-posture rule, defaults the Access session to `12h`, and applies hardened cookie/application flags.
+Perseus already manages Cloudflare Access with `@pulumi/cloudflare`. Its browser-admin application uses `ZeroTrustAccessApplication`, an email `Include` rule, a device-posture `Require` rule, a `12h` default session, and hardened application/cookie flags.
 
-Perseus also owns the trusted-device serial-number list and device-posture rule and exports `adminAccessDevicePostureRuleId` from its Pulumi program. DTXWeb will reuse that existing Cloudflare posture-rule resource ID instead of reproducing the list/rule ownership.
+Perseus owns the trusted-device serial-number list and posture rule and exports `adminAccessDevicePostureRuleId`. DTXWeb reuses that existing Cloudflare rule ID as config.
 
-Perseus's later CLI application, service token, `non_identity` Service Auth policy, Worker resources, R2/KV/D1 resources, and deployment workflow solve different product requirements and are not part of this design.
+Perseus's CLI application, service token, `non_identity` policy, Worker resources, storage resources, and deployment workflows solve different requirements and are not copied.
+
+### Existing CI contract
+
+`.github/scripts/ci-affected-scope.sh` validates every Turbo package against a hardcoded fail-closed package allowlist and separately decides whether unit tests are affected.
+
+Adding `@dtx/infrastructure` without updating that script would make an infrastructure-only PR fail as an unknown package. The package must also participate in `unit_affected`, because `.github/workflows/unit-test.yml` only installs dependencies and runs unit coverage when that detector returns `true`.
+
+The unit workflow runs root `bun run test:coverage`. Therefore `@dtx/infrastructure` must expose `test:coverage`, not only `test`.
+
+`.github/scripts/ci-affected-scope.test.sh` and its JSON fixtures are the existing contract tests for this fail-closed detector and must gain infrastructure coverage.
+
+### Existing operator precedent
+
+`docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md` explicitly marks interactive/live Cloudflare steps as operator-executed. This design keeps that boundary: agents may author/test the Pulumi program and produce previews when credentials/config are already available, but live Cloudflare mutations and human browser/device observations stay in the runbook.
 
 ## Architecture
 
-### DTXWeb infrastructure workspace
+### Infrastructure workspace
 
-Add a dedicated workspace:
+Add:
 
 ```text
 packages/infrastructure/
@@ -99,21 +116,33 @@ packages/infrastructure/
     └── index.ts
 ```
 
-The package is intentionally Access-only. It has no Worker build/deployment logic and no storage resources.
+The root workspace list adds `packages/infrastructure`.
 
-The root workspace list adds `packages/infrastructure` so Bun installs and repository checks include the package naturally.
+The package is intentionally Access-only. It contains no Worker build/deploy logic and no storage resources.
 
-Use the same dependency versions currently working in Perseus for the initial implementation unless DTXWeb dependency resolution requires a compatible update:
+### Toolchain
+
+Reuse the Pulumi provider floors already proven in Perseus:
 
 - `@pulumi/pulumi` `^3.144.0`
 - `@pulumi/cloudflare` `^6.13.0`
-- `typescript` `^5.9.0`
-- `vitest` `^4.0.18`
-- `@types/node` `^22.10.0`
 
-### Pulumi project
+Align development tooling with DTXWeb instead of Perseus:
 
-`Pulumi.yaml` defines one DTXWeb infrastructure project:
+- TypeScript `^5.8.3`
+- Vitest `^3.1.4`
+- `@vitest/coverage-v8` `^3.0.0`
+- `@types/node` `^20.11.25`
+
+Do not introduce Vitest 4, TypeScript 5.9, or Node type major 22 merely because Perseus currently uses them.
+
+`packages/infrastructure/package.json` exposes only repository-safe scripts such as `build`, `check`, `test`, and `test:coverage`. Do not add unscoped `pulumi:up`, `pulumi:destroy`, or `pulumi:preview` scripts that operate on whichever stack happens to be selected.
+
+Operational docs invoke the Pulumi CLI directly and always name `--stack`.
+
+### Pulumi project and supported stacks
+
+`Pulumi.yaml` defines:
 
 ```yaml
 name: dtxweb-infrastructure
@@ -122,18 +151,76 @@ description: DTXWeb Cloudflare Access infrastructure managed by Pulumi
 main: dist/index.js
 ```
 
-One program serves exactly two supported stacks:
+One program supports exactly:
 
 - `pre-prod`
 - `production`
 
-Any other `pulumi.getStack()` value fails loudly before creating resources.
+Any other `pulumi.getStack()` value fails before a Cloudflare resource is registered.
 
-This is intentional. Stack-specific hostname/path scope is code-owned rather than freely configurable.
+### `pre-prod` stack
 
-### State and local stack configuration
+Creates exactly one `ZeroTrustAccessApplication` named `DTXWeb Pre-prod` for:
 
-Match the current Perseus operational model for this slice: local Pulumi usage with stack configuration excluded from git.
+```text
+pre-prod.dtx.hapadona.com
+```
+
+No API hostname is included.
+
+### `production` stack
+
+Creates exactly one `ZeroTrustAccessApplication` named `DTXWeb Production App` with exactly:
+
+```text
+dtx.hapadona.com/app
+dtx.hapadona.com/app/*
+```
+
+Hostname and destinations are code-owned, not Pulumi configuration.
+
+### Pulumi configuration
+
+Both stacks require:
+
+- `cloudflareAccountId` — plain config.
+- `accessEmail` — Pulumi secret config.
+- `devicePostureRuleId` — plain config containing the existing Perseus-managed rule ID.
+- `accessSessionDuration` — optional; defaults to `12h`.
+
+DTXWeb does not use `StackReference`. If Perseus replaces its posture rule and the Cloudflare ID changes, the operator updates `devicePostureRuleId` in both DTXWeb stacks before the next preview/apply.
+
+### Access resource construction
+
+`src/access.ts` owns pure builders plus one resource factory.
+
+Reuse these Perseus browser-application flags:
+
+```ts
+{
+  appLauncherVisible: false,
+  allowAuthenticateViaWarp: false,
+  enableBindingCookie: true,
+  httpOnlyCookieAttribute: true,
+  pathCookieAttribute: false
+}
+```
+
+Each Access application has one inline policy:
+
+- name: `Allow configured operator on trusted device`
+- decision: `allow`
+- precedence: `1`
+- `includes`: configured email identity
+- `requires`: configured existing posture-rule ID
+
+No posture/list/token resource is created by DTXWeb.
+
+### Local state and config
+
+Follow the same local-backend operating model as Perseus, but document it accurately.
+
+`pulumi login --local` is equivalent to a filesystem backend rooted at the operator's home directory, with default state under `~/.pulumi`. Stack config files created in the project (`Pulumi.<stack>.yaml`) are ignored and not committed.
 
 `packages/infrastructure/.gitignore` includes at least:
 
@@ -146,341 +233,172 @@ dist/
 .env.local
 ```
 
-The operator configures both stacks locally with `pulumi config set` commands. No stack config file, encrypted secret value, or local state directory is committed.
+The `.pulumi/` ignore is defensive for explicitly project-local filesystem backends; it is not a claim that `pulumi login --local` stores default state in the repository.
 
-This slice does not add CI deployment, so reproducing the stack on another machine requires re-establishing the local Pulumi backend/login plus the documented config values.
+Because state is local-machine-owned, the runbook must include both normal Pulumi rollback and an emergency Cloudflare dashboard delete/disable path if state/backend access is unavailable.
 
-## Stack Model
+## CI Integration
 
-### `pre-prod`
+Task implementation must update:
 
-Creates one `ZeroTrustAccessApplication` named `DTXWeb Pre-prod` covering the entire web hostname:
+- `.github/scripts/ci-affected-scope.sh`
+- `.github/scripts/ci-affected-scope.test.sh`
+- `.github/scripts/fixtures/turbo-infrastructure.json`
 
-```text
-pre-prod.dtx.hapadona.com
-```
-
-There is no path bypass. All current and future routes on that web hostname are behind Access.
-
-`api.pre-prod.dtx.hapadona.com` is not a destination and remains outside Access.
-
-### `production`
-
-Creates one `ZeroTrustAccessApplication` named `DTXWeb Production App` with exactly these destinations:
+The detector allowlist gains:
 
 ```text
-dtx.hapadona.com/app
-dtx.hapadona.com/app/*
+@dtx/infrastructure:packages/infrastructure
 ```
 
-The production program must not accept arbitrary destination configuration. A hostname-wide production Access application cannot be produced by changing stack config alone.
+`@dtx/infrastructure` also sets `unit_affected=true`.
 
-`api.dtx.hapadona.com` and all production web routes outside `/app` remain outside Access.
+The detector tests add an infrastructure-only fixture and assert:
 
-## Pulumi Configuration
+- `unit` => `true`
+- `lint` => `true`
 
-Both stacks require the same small set of values:
+`@dtx/infrastructure` defines:
 
-- `cloudflareAccountId` — Cloudflare account ID; plain configuration.
-- `accessEmail` — the allowed operator Access identity/email; Pulumi secret.
-- `devicePostureRuleId` — the existing Perseus Cloudflare device-posture rule ID; plain configuration.
-- `accessSessionDuration` — optional; defaults to `12h`.
-
-The production and pre-production hostnames are not config values.
-
-The allowed identity is secret because the repository should not publish the operator email. The posture-rule ID is a Cloudflare resource identifier rather than a device serial or credential and does not need Pulumi-secret handling.
-
-### Reusing the Perseus posture-rule ID
-
-The operator obtains the current `adminAccessDevicePostureRuleId` from the Perseus Pulumi stack and writes that value into both DTXWeb stacks as `devicePostureRuleId`.
-
-DTXWeb does not use `pulumi.StackReference` for this dependency. A direct stack reference would couple DTXWeb to the exact Perseus Pulumi backend, organization/project name, and stack identity. Passing the stable Cloudflare resource ID as DTXWeb configuration keeps deployment of the two repositories independent while preserving Perseus as the owner of trusted-device membership.
-
-If Perseus ever replaces the posture rule and its resource ID changes, the DTXWeb stack config must be updated before the next DTXWeb `pulumi up`. This is an explicit operational dependency and belongs in the runbook.
-
-## Access Resource Construction
-
-`src/access.ts` owns pure builders plus the small resource factory.
-
-### Shared application flags
-
-Reuse the relevant hardened application flags from Perseus:
-
-```ts
-{
-  appLauncherVisible: false,
-  allowAuthenticateViaWarp: false,
-  enableBindingCookie: true,
-  httpOnlyCookieAttribute: true,
-  pathCookieAttribute: false
-}
+```json
+"test:coverage": "vitest --run --coverage"
 ```
 
-Do not import or copy CLI/service-token-specific behavior.
+so the existing root `bun run test:coverage` workflow executes the Access unit tests.
 
-### Access policy
-
-Both stacks use one inline policy:
-
-- name: `Allow configured operator on trusted device`
-- decision: `allow`
-- precedence: `1`
-- `includes`: configured email identity
-- `requires`: configured existing device-posture rule ID
-
-The policy mirrors the proven Perseus browser-admin policy shape but references the pre-existing posture rule directly.
-
-### Stack definition and application builder
-
-Keep stack selection testable as pure data. A helper such as `getAccessStackDefinition(stackName)` returns the immutable application name, domain, and destinations for `pre-prod` or `production` and throws for any other stack.
-
-The application builder accepts:
-
-- account ID;
-- stack definition;
-- operator email;
-- existing posture-rule ID;
-- optional session duration.
-
-It returns `cloudflare.ZeroTrustAccessApplicationArgs`.
-
-No destination or hostname comes from Pulumi config.
-
-### Resource ownership
-
-DTXWeb owns only:
-
-- `DTXWeb Pre-prod` Access application in the `pre-prod` stack;
-- `DTXWeb Production App` Access application in the `production` stack.
-
-DTXWeb explicitly does not own:
-
-- Perseus device serial list;
-- Perseus device-posture rule;
-- Access identity provider configuration;
-- service tokens;
-- Service Auth policies;
-- API hostnames;
-- Workers or storage resources.
+No new CI workflow is needed.
 
 ## Protection Matrix
 
-| Surface | Cloudflare Access | Owner |
-| --- | --- | --- |
-| `dtx.hapadona.com/app` | Protected | DTXWeb production Pulumi stack |
-| `dtx.hapadona.com/app/` | Protected; verify explicitly | DTXWeb production Pulumi stack |
-| `dtx.hapadona.com/app/*` | Protected | DTXWeb production Pulumi stack |
-| `dtx.hapadona.com/` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/blog/*` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/preview/*` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/editor` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/tool/*` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/game` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/login` | Public | Existing Worker deployment |
-| `dtx.hapadona.com/auth/*` | Public | Existing Worker deployment |
-| Other production web paths outside `/app` | Public | Existing Worker deployment |
-| `pre-prod.dtx.hapadona.com/*` | Protected | DTXWeb pre-prod Pulumi stack |
-| `api.dtx.hapadona.com/*` | Outside Access | Existing API deployment |
-| `api.pre-prod.dtx.hapadona.com/*` | Outside Access | Existing API deployment |
+| Surface | Access |
+| --- | --- |
+| `dtx.hapadona.com/app` | Protected |
+| `dtx.hapadona.com/app/` | Protected; verify explicitly |
+| `dtx.hapadona.com/app/*` | Protected |
+| Production routes outside `/app` | Public |
+| `pre-prod.dtx.hapadona.com/*` | Protected |
+| `api.dtx.hapadona.com/*` | Outside Access |
+| `api.pre-prod.dtx.hapadona.com/*` | Outside Access |
 
-## Deployment Workflow
+Production verification includes real public examples `/`, `/blog`, `/preview/1`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/login`, and `/auth/callback`.
 
-Pulumi manages only Access. Wrangler remains the runtime deployment tool.
-
-### Initial setup
-
-Use the same local-backend pattern as Perseus:
-
-```bash
-cd packages/infrastructure
-pulumi login --local
-pulumi stack init pre-prod
-pulumi stack init production
-```
-
-If either stack already exists locally, select it rather than recreating it.
-
-Configure both stacks with the Cloudflare account ID, secret Access email, reused Perseus posture-rule ID, and optional session duration. The implementation runbook will contain the exact commands without real values.
-
-### Pre-production first
-
-1. Build/typecheck/test the infrastructure package.
-2. Run `pulumi preview -s pre-prod`.
-3. Review the preview and confirm it creates only the hostname-wide `DTXWeb Pre-prod` Access application.
-4. Run `pulumi up -s pre-prod`.
-5. Execute the complete pre-production verification section from the runbook.
-6. If any required check fails, run the pre-production rollback immediately.
-
-Production must not be applied before pre-production is green.
-
-### Production
-
-1. Run `pulumi preview -s production`.
-2. Review the preview and confirm the application has exactly `/app` and `/app/*` destinations.
-3. Run `pulumi up -s production`.
-4. Execute the complete production route, identity, posture, browser, session-expiry, and desktop verification sections from the runbook.
-
-Do not use `pulumi up` without an explicit stack in operational documentation for this feature.
-
-## Testing Strategy
+## Testing And Implementation Gates
 
 ### Unit tests
 
-`src/access.test.ts` tests builders without contacting Cloudflare.
+`src/access.test.ts` tests pure builders without contacting Cloudflare.
 
-At minimum, test:
+At minimum:
 
-- production destinations are exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`;
-- pre-production destination is hostname-wide and does not include the API hostname;
-- production cannot become hostname-wide through configuration;
-- policy contains the normalized configured email in `includes`;
-- policy references the provided posture-rule ID in `requires`;
+- pre-prod is hostname-wide and never includes the API hostname;
+- production destinations are exactly `/app` and `/app/*`;
+- unsupported stack names throw;
+- malformed/multiple email values throw;
+- blank account ID and posture-rule ID throw;
+- the policy uses the normalized email in `includes`;
+- the policy references the supplied posture-rule ID in `requires`;
 - default session duration is `12h`;
-- hardened application flags match the intended values;
-- unsupported stack names fail loudly;
-- empty/invalid email and empty posture-rule ID fail before deployment.
+- hardened flags match the approved values;
+- production cannot become hostname-wide through config.
 
-Follow the Perseus pattern of separating pure builders from Pulumi resource creation so the security-sensitive shape is deterministic and unit-testable.
+### CI contract tests
 
-### Static verification
+Run `.github/scripts/ci-affected-scope.test.sh` and prove infrastructure-only changes select the unit gate rather than failing closed or skipping unit coverage.
 
-Run the package TypeScript check and unit tests before any preview.
+### Repository checks
 
-The root repository check should include the new workspace through normal workspace/turbo integration where practical; do not add unrelated CI redesign merely for this package.
+Run:
 
-### Pulumi preview as a safety gate
+```bash
+bun install
+bun run --filter=@dtx/infrastructure check
+bun run --filter=@dtx/infrastructure test:coverage
+.github/scripts/ci-affected-scope.test.sh
+```
 
-`pulumi preview` is required before each environment apply.
+Then run the relevant root checks if practical.
 
-Pre-production preview must show only the intended pre-production Access application.
+### Pulumi preview gate
 
-Production preview must show only the intended production Access application and exactly the two path destinations. A preview that shows hostname-wide production Access, an API destination, a new posture rule/list, or a service token is a hard stop.
+Before any live apply, the operator or an authenticated implementation environment runs explicit-stack previews.
 
-## Runtime Verification Requirements
+Pre-prod preview must show only one `DTXWeb Pre-prod` Access application.
 
-The existing runbook remains the owner of live acceptance commands and browser checks. It is rewritten from dashboard instructions to Pulumi preview/apply/rollback instructions.
+Production preview must show only one `DTXWeb Production App` and exactly `/app` plus `/app/*` destinations.
 
-The route-boundary helper must fail loudly if DNS, connection, TLS, or timeout fails; a request that never received an HTTP response cannot count as a successful public-route assertion.
+A preview showing a hostname-wide production app, API destination, new posture/list resource, service token, or unrelated resource is a hard stop.
 
-The production matrix must include:
+**The implementation plan ends at tested code, rewritten runbook, and successful/non-run preview evidence. It does not contain `pulumi up` or `pulumi destroy` execution steps.**
 
-- protected: `/app`, `/app/`, `/app/score`, `/app/__data.json`;
-- public: `/`, `/blog`, `/preview/1`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/login`, `/auth/callback`;
-- outside Access: both API hostnames.
+## Operator Runbook Boundary
 
-The policy checks independently prove:
+`docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` is marked operator-executed.
 
-- allowed identity + trusted posture passes;
-- trusted device + non-allowed IdP identity is denied;
-- allowed identity on a device that fails posture is denied.
+It owns:
 
-The browser checks cover:
+1. Pulumi local-backend login and stack/config setup.
+2. Obtaining the current Perseus posture-rule ID.
+3. Explicit-stack previews.
+4. `pulumi up --stack pre-prod`.
+5. Pre-prod HTTP/browser/posture acceptance.
+6. Only after pre-prod is green, `pulumi up --stack production`.
+7. Production route, identity, posture, browser, session-expiry, bundled desktop, and standalone Tauri-dev acceptance.
+8. Normal stack-specific rollback.
+9. Emergency Cloudflare dashboard disable/delete when Pulumi state/backend access is unavailable.
 
-- pre-production password and Google login before production is applied;
-- production `/app -> /login -> /app` for the operator;
-- bundled desktop login;
-- standalone Tauri-development loopback login against deployed production in the current operator setup;
-- expired/logged-out Access session during SvelteKit client-side navigation into `/app`;
-- non-operator production login dead-end and documented cookie-clearing recovery.
+Agents may prepare or verify non-mutating artifacts, but live applies/destroys and human browser/device observations are operator actions.
 
 ## Rollback
 
-Rollback is stack-specific and does not touch Worker/API deployment.
+### Normal Pulumi rollback
 
-Because each stack owns exactly one Cloudflare resource in this slice, the rollback procedure is explicit:
-
-```bash
-pulumi preview --destroy -s pre-prod
-pulumi destroy -s pre-prod --yes
-```
-
-for pre-production, or:
+For the affected stack, the operator first reviews:
 
 ```bash
-pulumi preview --destroy -s production
-pulumi destroy -s production --yes
+pulumi preview --destroy --stack <pre-prod|production>
 ```
 
-for production.
+The preview must show exactly one deletion: the corresponding DTXWeb Access application.
 
-Before running `destroy`, the operator must review the destroy preview and confirm the only deletion is the corresponding DTXWeb Access application. If the infrastructure package later owns additional resources, this rollback procedure must be redesigned before those resources ship.
+Then the operator may run:
 
-If pre-production fails required acceptance, destroy only the `pre-prod` stack's Access application. Production remains untouched.
+```bash
+pulumi destroy --stack <pre-prod|production> --yes
+```
 
-If production fails required acceptance, destroy only the `production` stack's Access application. Pre-production remains available for further diagnosis.
+### Emergency fallback without usable state
 
-Rollback requires no Worker redeploy and no application-code rollback.
+If the local Pulumi backend/state is unavailable and immediate Access removal is necessary, the operator uses Cloudflare Zero Trust dashboard controls to disable/delete the named application:
 
-Do not add a service token, API Access application, bypass policy, or widened destination as an emergency workaround.
+- `DTXWeb Pre-prod`, or
+- `DTXWeb Production App`.
 
-## Security And Secret Handling
+Do not create a bypass policy, service token, API Access app, or broader route as an emergency workaround.
 
-Never commit:
-
-- operator email;
-- device serial numbers;
-- Access cookies or JWTs;
-- Cloudflare API tokens;
-- `Pulumi.<stack>.yaml` files for this local-stack workflow;
-- `.pulumi/` local state;
-- screenshots containing security identifiers.
-
-`accessEmail` is set with Pulumi secret configuration.
-
-`devicePostureRuleId` is plain configuration, but it must refer to the existing Perseus-managed rule and must never be replaced with a freshly created DTXWeb rule as part of this slice.
-
-The Cloudflare API token used for Pulumi should be scoped to the least privilege needed to manage the intended Access application resources. The exact token permission checklist must be verified against the provider/Cloudflare API during implementation and recorded in the runbook rather than guessed in application source.
-
-## Operational Consequences
-
-### Shared posture ownership
-
-Perseus controls trusted-device membership. Changing the Perseus serial list affects DTXWeb because both applications require the same posture rule.
-
-If the posture rule is replaced rather than updated in place, DTXWeb's `devicePostureRuleId` config becomes stale and must be changed before the next DTXWeb deployment.
-
-### Desktop development
-
-Standalone desktop auth against production or pre-production is operator-only. Full local-stack development remains the non-operator path.
-
-### Pre-production automation
-
-This slice adds no non-interactive Access credential. Unattended E2E/CI against the Access-protected pre-production hostname remains unsupported even though Playwright can target another base URL.
-
-### Non-operator logout dead end
-
-The existing production Supabase/UI behavior is unchanged. Signed-in non-operators can become trapped between public `/login` redirect behavior and Access denial at `/app`; clearing production site cookies remains the documented recovery until a separate product/code change is approved.
+If Pulumi state later becomes available after a manual provider-side deletion, reconcile it before any future `pulumi up` (for example through the appropriate refresh/import/recovery procedure) rather than blindly applying stale state.
 
 ## Repository Changes
 
-The implementation is expected to modify only infrastructure/workspace/documentation files:
+Expected implementation changes:
 
-- `package.json` — add `packages/infrastructure` workspace and optional convenience scripts if justified by the implementation plan.
-- `bun.lock` — dependency resolution.
-- `packages/infrastructure/.gitignore` — ignore local stack config/state, dependencies, build output, and env files.
-- `packages/infrastructure/Pulumi.yaml` — Pulumi project metadata.
-- `packages/infrastructure/package.json` — Pulumi/Cloudflare/TypeScript/Vitest package definition.
-- `packages/infrastructure/tsconfig.json`.
-- `packages/infrastructure/vitest.config.ts`.
-- `packages/infrastructure/src/access.ts` — stack definitions, Access builders, and resource factory.
-- `packages/infrastructure/src/access.test.ts` — unit tests.
-- `packages/infrastructure/src/index.ts` — stack selection and resource creation.
-- `packages/infrastructure/README.md` — local config/preview/apply instructions.
-- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` — Pulumi-based rollout, verification, and rollback.
-- `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md` — rewritten implementation plan after this spec is approved.
+- `package.json`
+- `bun.lock`
+- `.github/scripts/ci-affected-scope.sh`
+- `.github/scripts/ci-affected-scope.test.sh`
+- `.github/scripts/fixtures/turbo-infrastructure.json`
+- `packages/infrastructure/.gitignore`
+- `packages/infrastructure/Pulumi.yaml`
+- `packages/infrastructure/package.json`
+- `packages/infrastructure/tsconfig.json`
+- `packages/infrastructure/vitest.config.ts`
+- `packages/infrastructure/src/access.ts`
+- `packages/infrastructure/src/access.test.ts`
+- `packages/infrastructure/src/index.ts`
+- `packages/infrastructure/README.md`
+- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+- `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
 
-No changes are planned under `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
-
-## Superseded Manual-Configuration Design
-
-The earlier version of this design used two manually configured dashboard applications. That approach is superseded by this Pulumi design.
-
-The approved protection matrix, product consequences, pre-production-first order, verification matrix, and rollback criteria remain valid. What changes is resource ownership and deployment:
-
-- Access applications are created by Pulumi rather than dashboard clicks;
-- the posture rule is referenced by existing Perseus resource ID rather than manually selected as an unmanaged dependency;
-- previews/unit tests provide an additional configuration safety gate;
-- the existing runbook and implementation plan must be rewritten before execution because their dashboard-configuration instructions are obsolete.
+No application/API/desktop source files change.
 
 ## References
 
@@ -489,10 +407,11 @@ Repository precedent:
 - Perseus `packages/infrastructure/src/admin-access.ts`
 - Perseus `packages/infrastructure/src/admin-access.test.ts`
 - Perseus `packages/infrastructure/src/index.ts`
-- Perseus `packages/infrastructure/src/config.ts`
 - Perseus `packages/infrastructure/Pulumi.yaml`
 - Perseus `packages/infrastructure/package.json`
-- Perseus `packages/infrastructure/.gitignore`
-- Perseus `packages/infrastructure/README.md`
+- DTXWeb `.github/scripts/ci-affected-scope.sh`
+- DTXWeb `.github/scripts/ci-affected-scope.test.sh`
+- DTXWeb `.github/workflows/unit-test.yml`
+- DTXWeb `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`
 
-Cloudflare/Pulumi behavior should be verified against current provider and Cloudflare documentation during implementation if the working Perseus resource shape no longer typechecks against the selected provider version.
+Current Pulumi local-backend and recovery behavior should be verified against Pulumi's official state/backend and destroy-troubleshooting documentation during implementation.

--- a/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md
@@ -2,193 +2,337 @@
 
 ## Summary
 
-DTXWeb will use Cloudflare Zero Trust Access as an outer gate for private web surfaces while keeping the public production site and both GraphQL API hostnames outside Access.
+DTXWeb will manage its Cloudflare Zero Trust Access applications with Pulumi, using the same Cloudflare provider and Access-resource shape already proven in Perseus, while keeping the DTXWeb slice deliberately narrower.
 
-Production protects only `/app` and its descendants. This is intentionally an operator-only surface: the Perseus-style Access policy allows the configured operator identity on a trusted device, so other Supabase users can still reach public `/login` but cannot enter production `/app` or complete desktop login against production.
+Production protects only `/app` and its descendants. This is intentionally an operator-only surface: the configured Access identity must match the intended operator and the request must satisfy the existing Perseus trusted-device posture rule. Other Supabase users may still reach public `/login`, but they cannot enter production `/app` or complete desktop login against production.
 
-Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is configured and verified first so identity, device posture, Supabase login/OAuth, and rollback are proven before the production path-scoped application is created.
+Pre-production protects the entire `pre-prod.dtx.hapadona.com` web hostname. It is deployed and verified first. Production is not applied until the pre-production Access stack passes the documented identity, posture, browser-auth, desktop, and route-boundary checks.
 
-The Zero Trust configuration is managed manually in the Cloudflare dashboard. This slice does not introduce Pulumi, Terraform, CI deployment, Worker-side Access JWT validation, service tokens, or application-code changes.
+DTXWeb gets a small `packages/infrastructure` workspace that owns only the two Access applications. Existing Worker/API deployment remains on Wrangler. This slice does not migrate Workers, D1, R2, service bindings, secrets, or runtime deployment into Pulumi.
+
+DTXWeb does not create another serial-number list or device-posture rule. Perseus remains the owner of trusted-device membership; DTXWeb consumes the existing Perseus posture-rule resource ID as Pulumi configuration.
 
 ## Goals
 
+- Manage DTXWeb Cloudflare Access declaratively with Pulumi rather than manual dashboard configuration.
+- Follow the proven Perseus Access implementation shape where it applies.
+- Reuse the existing Perseus device-posture rule ID instead of duplicating its serial list or rule.
 - Make production `/app` and production desktop login intentionally operator-only behind Cloudflare Access.
 - Keep the production public site outside Access, including `/`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/login`, and `/auth/*`.
 - Require Cloudflare Access for every route served by `pre-prod.dtx.hapadona.com`.
-- Reuse the same configured operator identity and trusted-device serial-number posture model used for Perseus.
 - Preserve Supabase authentication as an independent inner gate after Access allows a request.
 - Keep `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com` outside Access.
+- Make pre-production and production separate Pulumi stacks so rollout and rollback are environment-specific.
+- Make the stack name determine the hostname and protection scope so ordinary configuration cannot accidentally broaden production Access.
 - Roll out pre-production first, then production only after the pre-production gate and auth round-trip are verified.
-- Verify both policy clauses independently: the configured Access identity and the trusted-device posture requirement.
-- Make route-boundary checks fail loudly when the request itself fails.
-- Characterize Access-session expiry during SvelteKit client-side navigation instead of discovering that behavior after rollout.
-- Document desktop-development, non-operator lockout, E2E, and private-route invariants in a dedicated operator runbook.
+- Verify the Access identity `Include` clause independently from the device-posture `Require` clause.
+- Keep the existing operator runbook as the durable acceptance/rollback procedure, updated to use Pulumi preview/apply instead of dashboard clicks.
 
 ## Non-Goals
 
-- Add Pulumi, Terraform, or another infrastructure-as-code system.
+- Migrate DTXWeb Worker or API deployment from Wrangler to Pulumi.
+- Manage D1, R2, KV, Workers, routes, service bindings, runtime environment variables, or application secrets with Pulumi in this slice.
+- Create or manage the shared trusted-device serial-number list in DTXWeb.
+- Create or manage a second DTXWeb-specific device-posture rule.
+- Add a Pulumi `StackReference` dependency on the Perseus stack.
 - Protect the entire production `dtx.hapadona.com` hostname.
 - Protect either API hostname.
 - Make production `/app` available to every Supabase user.
 - Add a public logout route or otherwise change the current non-operator recovery behavior in this slice.
 - Replace Supabase authentication.
 - Add Worker-side validation of `CF_Authorization` or Access JWTs.
-- Add Cloudflare Access service tokens for desktop, API, CLI, E2E, or CI traffic.
+- Add Cloudflare Access service tokens, Service Auth policies, CLI applications, or Managed OAuth.
+- Copy Perseus's admin CLI/service-token resources.
 - Make pre-production an unattended E2E target in this slice.
-- Protect preview/development Worker URLs outside the named custom hostnames.
-- Change SvelteKit, GraphQL API, or desktop application code in this slice.
+- Add GitHub Actions deployment for the new Pulumi package in this slice.
+- Change SvelteKit, GraphQL API, or desktop application code.
 
 ## Existing Context
 
+### DTXWeb routing and deployment
+
 `packages/dtx-web/wrangler.jsonc` deploys the production web Worker to `dtx.hapadona.com` and pre-production to `pre-prod.dtx.hapadona.com`. The web application uses separate API hostnames: `api.dtx.hapadona.com` and `api.pre-prod.dtx.hapadona.com`.
 
-`packages/dtx-web/src/hooks.server.ts` currently treats any pathname beginning with `/app` as Supabase-authenticated. The intended private route family for this design is narrower and matches the existing redirect validator: exact `/app` or descendants under `/app/`. Production Access therefore protects `/app` and `/app/*`. No current route relies on the broader `/app...` string-prefix behavior.
+`packages/dtx-web/src/hooks.server.ts` currently treats any pathname beginning with `/app` as Supabase-authenticated. The intended private route family for this design is narrower: exact `/app` or descendants under `/app/`. Production Access therefore protects `/app` and `/app/*`.
 
-This dependency is an operating invariant: any new private production page must live at `/app` or below `/app/`, or the Access design must be revisited before shipping it. A new private sibling such as `/studio` or `/admin` would otherwise be public at the edge. A future `/appstore`-style route would also expose the current mismatch between `startsWith('/app')` and the Access destination family and should be handled as a separate routing cleanup rather than silently treated as protected.
+This dependency is an operating invariant: any new private production page must live at `/app` or below `/app/`, or the Access design must be revisited before shipping it. A new private sibling such as `/studio` or `/admin` would otherwise be public at the edge. The current `pathname.startsWith('/app')` guard is slightly broader than the intended Access family and must not be used to justify new `/app...` sibling-style routes.
+
+### Desktop authentication
 
 The desktop flow starts at web `/login` and finishes through `/app?redirect=desktop...`. Password login redirects there directly; Google OAuth does the same through the auth callback. The login page preserves the desktop callback in `sessionStorage` so the `/app` page can hand the magic link back to either the bundled `dtx://` callback or the Tauri-development loopback callback.
 
-Standalone desktop development (`bun run dev:desktop`, which runs the desktop package `dev` script) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup that value points at production, so ordinary standalone `tauri dev` authentication traverses production `/login` and production `/app`. The full local-stack command (`bun run dev`) is different: it uses `dtx-desktop#dev:local-web`, which overrides the web and API URLs to localhost. After this Access change, authentication against either deployed web environment is operator-only; non-operator contributors must use the full local stack or another separately designed ungated development environment.
+Standalone desktop development (`bun run dev:desktop`) loads `VITE_DTX_SERVER_URL` from the ignored root `.env`. In the current operator setup it points at production, so standalone `tauri dev` authentication traverses production `/login` and protected production `/app`. The full local-stack command (`bun run dev`) instead uses `dtx-desktop#dev:local-web` and localhost.
+
+After this Access change, authentication against either deployed web environment is operator-only. Non-operator contributors must use the full local stack or another separately designed ungated development environment.
+
+### Non-operator production lockout
 
 Because production `/app` sits behind a single-operator Access policy, public `/login` is an entry form, not an Access bypass. A non-operator Supabase user may authenticate successfully and then be denied when the browser returns to `/app`.
 
-That state currently has no UI recovery path. `hooks.server.ts` redirects an already-authenticated visitor from `/login` to `/app`, while the only current sign-out control lives inside the Access-protected `(app)` layout. A signed-in non-operator therefore cannot use the production UI to return to `/login` or sign out; they must clear the Drumery/Supabase cookies for the production web origin. A public logout route or a change to the authenticated `/login` redirect is an explicit deferred product decision, not part of this dashboard-only slice.
+That state currently has no UI recovery path. `hooks.server.ts` redirects an already-authenticated visitor from `/login` to `/app`, while the only current sign-out control lives inside the Access-protected `(app)` layout. A signed-in non-operator therefore must clear the Drumery/Supabase cookies for the production origin. A public logout route or a change to the authenticated `/login` redirect is an explicit deferred product decision.
 
-The repository already uses human-executed Cloudflare runbooks, for example `docs/superpowers/runbooks/2026-05-29-phase-4-preprod-cutover.md`. That file is a historical API-migration cutover checklist, so Zero Trust gets its own durable runbook rather than mixing permanent security operations into the completed Phase 4 migration document.
+### Perseus precedent
 
-The web E2E harness supports overriding `PLAYWRIGHT_BASE_URL`, but current CI runs against Playwright-managed localhost servers. Hostname-wide pre-production Access means this slice does not support unattended E2E against `pre-prod.dtx.hapadona.com`; doing so later requires a separate Access-authentication strategy and is intentionally deferred.
+Perseus already manages Cloudflare Zero Trust Access with `@pulumi/cloudflare`. Its infrastructure package creates a `ZeroTrustAccessApplication` with inline policies, uses an email `Include` selector, requires a device-posture rule, defaults the Access session to `12h`, and applies hardened cookie/application flags.
+
+Perseus also owns the trusted-device serial-number list and device-posture rule and exports `adminAccessDevicePostureRuleId` from its Pulumi program. DTXWeb will reuse that existing Cloudflare posture-rule resource ID instead of reproducing the list/rule ownership.
+
+Perseus's later CLI application, service token, `non_identity` Service Auth policy, Worker resources, R2/KV/D1 resources, and deployment workflow solve different product requirements and are not part of this design.
+
+## Architecture
+
+### DTXWeb infrastructure workspace
+
+Add a dedicated workspace:
+
+```text
+packages/infrastructure/
+├── Pulumi.yaml
+├── package.json
+├── README.md
+├── tsconfig.json
+├── vitest.config.ts
+└── src/
+    ├── access.ts
+    ├── access.test.ts
+    └── index.ts
+```
+
+The package is intentionally Access-only. It has no Worker build/deployment logic and no storage resources.
+
+The root workspace list adds `packages/infrastructure` so Bun installs and repository checks include the package naturally.
+
+Use the same dependency family as Perseus for the initial implementation:
+
+- `@pulumi/pulumi`
+- `@pulumi/cloudflare`
+- TypeScript
+- Vitest
+
+The exact dependency versions should match the currently working Perseus infrastructure package unless repository compatibility requires a newer version during implementation.
+
+### Pulumi project
+
+`Pulumi.yaml` defines one DTXWeb infrastructure project, for example:
+
+```yaml
+name: dtxweb-infrastructure
+runtime: nodejs
+description: DTXWeb Cloudflare Access infrastructure managed by Pulumi
+main: dist/index.js
+```
+
+One program serves exactly two supported stacks:
+
+- `pre-prod`
+- `production`
+
+Any other `pulumi.getStack()` value fails loudly before creating resources.
+
+This is intentional. Stack-specific hostname/path scope is code-owned rather than freely configurable.
+
+## Stack Model
+
+### `pre-prod`
+
+Creates one `ZeroTrustAccessApplication` named `DTXWeb Pre-prod` covering the entire web hostname:
+
+```text
+pre-prod.dtx.hapadona.com
+```
+
+There is no path bypass. All current and future routes on that web hostname are behind Access.
+
+`api.pre-prod.dtx.hapadona.com` is not a destination and remains outside Access.
+
+### `production`
+
+Creates one `ZeroTrustAccessApplication` named `DTXWeb Production App` with exactly these destinations:
+
+```text
+dtx.hapadona.com/app
+dtx.hapadona.com/app/*
+```
+
+The production program must not accept arbitrary destination configuration. A hostname-wide production Access application cannot be produced by changing stack config alone.
+
+`api.dtx.hapadona.com` and all production web routes outside `/app` remain outside Access.
+
+## Pulumi Configuration
+
+Both stacks require the same small set of values:
+
+- `cloudflareAccountId` — Cloudflare account ID; plain configuration.
+- `accessEmail` — the allowed operator Access identity/email; Pulumi secret.
+- `devicePostureRuleId` — the existing Perseus Cloudflare device-posture rule ID; plain configuration.
+- `accessSessionDuration` — optional; defaults to `12h`.
+
+The production and pre-production hostnames are not config values.
+
+The allowed identity is secret because the repository should not publish the operator email. The posture-rule ID is a Cloudflare resource identifier rather than a device serial or credential and does not need Pulumi-secret handling.
+
+### Reusing the Perseus posture-rule ID
+
+The operator obtains the current `adminAccessDevicePostureRuleId` from the Perseus Pulumi stack and writes that value into both DTXWeb stacks as `devicePostureRuleId`.
+
+DTXWeb does not use `pulumi.StackReference` for this dependency. A direct stack reference would couple DTXWeb to the exact Perseus Pulumi backend, organization/project name, and stack identity. Passing the stable Cloudflare resource ID as DTXWeb configuration keeps deployment of the two repositories independent while preserving Perseus as the owner of trusted-device membership.
+
+If Perseus ever replaces the posture rule and its resource ID changes, the DTXWeb stack config must be updated before the next DTXWeb `pulumi up`. This is an explicit operational dependency and belongs in the runbook.
+
+## Access Resource Construction
+
+`src/access.ts` owns pure builders plus the small resource factory.
+
+### Shared application flags
+
+Reuse the relevant hardened application flags from Perseus:
+
+```ts
+{
+  appLauncherVisible: false,
+  allowAuthenticateViaWarp: false,
+  enableBindingCookie: true,
+  httpOnlyCookieAttribute: true,
+  pathCookieAttribute: false
+}
+```
+
+Do not import or copy CLI/service-token-specific behavior.
+
+### Access policy
+
+Both stacks use one inline policy:
+
+- name: `Allow configured operator on trusted device`
+- decision: `allow`
+- precedence: `1`
+- `includes`: configured email identity
+- `requires`: configured existing device-posture rule ID
+
+The policy mirrors the proven Perseus browser-admin policy shape but references the pre-existing posture rule directly.
+
+### Application builder
+
+The builder accepts:
+
+- account ID;
+- application name;
+- primary domain;
+- fixed destination list;
+- operator email;
+- existing posture-rule ID;
+- optional session duration.
+
+It returns `cloudflare.ZeroTrustAccessApplicationArgs`.
+
+Stack-specific code supplies the destination list. No caller may supply arbitrary production paths from Pulumi config.
+
+### Resource ownership
+
+DTXWeb owns only:
+
+- `DTXWeb Pre-prod` Access application in the `pre-prod` stack;
+- `DTXWeb Production App` Access application in the `production` stack.
+
+DTXWeb explicitly does not own:
+
+- Perseus device serial list;
+- Perseus device-posture rule;
+- Access identity provider configuration;
+- service tokens;
+- Service Auth policies;
+- API hostnames;
+- Workers or storage resources.
 
 ## Protection Matrix
 
-| Surface | Cloudflare Access | Notes |
+| Surface | Cloudflare Access | Owner |
 | --- | --- | --- |
-| `dtx.hapadona.com/app` | Protected | Operator-only exact parent. |
-| `dtx.hapadona.com/app/` | Protected | Explicitly verify path semantics during rollout. |
-| `dtx.hapadona.com/app/*` | Protected | Operator-only descendants, including SvelteKit data requests. |
-| `dtx.hapadona.com/` | Public | Landing page. |
-| `dtx.hapadona.com/blog/*` | Public | Public content. |
-| `dtx.hapadona.com/preview/*` | Public | Verify with a real route such as `/preview/1`. |
-| `dtx.hapadona.com/editor` | Public | Public editor surface. |
-| `dtx.hapadona.com/tool/*` | Public | Public tools, including `/tool/dtx-to-midi`. |
-| `dtx.hapadona.com/game` | Public | Public game entry. |
-| `dtx.hapadona.com/login` | Public | Web and desktop login entry. |
-| `dtx.hapadona.com/auth/*` | Public | Supabase/OAuth callbacks. |
-| Other production web paths outside `/app` | Public | Do not broaden production Access. |
-| `pre-prod.dtx.hapadona.com/*` | Protected | Entire pre-production web hostname. |
-| `api.dtx.hapadona.com/*` | Outside Access | Existing API auth remains authoritative. |
-| `api.pre-prod.dtx.hapadona.com/*` | Outside Access | Existing API auth remains authoritative. |
+| `dtx.hapadona.com/app` | Protected | DTXWeb production Pulumi stack |
+| `dtx.hapadona.com/app/` | Protected; verify explicitly | DTXWeb production Pulumi stack |
+| `dtx.hapadona.com/app/*` | Protected | DTXWeb production Pulumi stack |
+| `dtx.hapadona.com/` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/blog/*` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/preview/*` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/editor` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/tool/*` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/game` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/login` | Public | Existing Worker deployment |
+| `dtx.hapadona.com/auth/*` | Public | Existing Worker deployment |
+| Other production web paths outside `/app` | Public | Existing Worker deployment |
+| `pre-prod.dtx.hapadona.com/*` | Protected | DTXWeb pre-prod Pulumi stack |
+| `api.dtx.hapadona.com/*` | Outside Access | Existing API deployment |
+| `api.pre-prod.dtx.hapadona.com/*` | Outside Access | Existing API deployment |
 
-Cloudflare Access application paths can protect either an entire hostname or selected paths. Production records both `/app` and `/app/*` explicitly because Cloudflare documents that a wildcard sub-path does not replace the exact parent rule. The rollout also probes `/app/` directly instead of assuming how the trailing-slash request is normalized or matched.
+## Deployment Workflow
 
-## Access Applications
+Pulumi manages only Access. Wrangler remains the runtime deployment tool.
 
-### Pre-production
+### Initial setup
 
-Create `DTXWeb Pre-prod` first as a self-hosted public-hostname application for:
+Configure both DTXWeb stacks with the Cloudflare account ID, secret Access email, reused Perseus posture-rule ID, and optional session duration.
 
-- `pre-prod.dtx.hapadona.com`
+No secret value or device serial is committed.
 
-There is no path bypass. `/`, `/login`, `/auth/*`, `/blog`, `/preview/*`, `/editor`, `/tool/*`, `/game`, `/app`, SvelteKit data requests, and future routes on that web hostname all pass through Access.
+### Pre-production first
 
-Do not include `api.pre-prod.dtx.hapadona.com`.
+1. Build/typecheck/test the infrastructure package.
+2. Run `pulumi preview -s pre-prod`.
+3. Review the preview and confirm it creates only the hostname-wide `DTXWeb Pre-prod` Access application.
+4. Run `pulumi up -s pre-prod`.
+5. Execute the complete pre-production verification section from the runbook.
+6. If any required check fails, run the environment-specific rollback before proceeding.
+
+Production must not be applied before pre-production is green.
 
 ### Production
 
-Only after the pre-production checks pass, create `DTXWeb Production App` with exactly:
+1. Run `pulumi preview -s production`.
+2. Review the preview and confirm the application has exactly `/app` and `/app/*` destinations.
+3. Run `pulumi up -s production`.
+4. Execute the complete production route, identity, posture, browser, session-expiry, and desktop verification sections from the runbook.
 
-- `dtx.hapadona.com/app`
-- `dtx.hapadona.com/app/*`
+Do not use `pulumi up` without an explicit stack in operational documentation for this feature.
 
-Do not add a hostname-wide production destination or any public path.
+## Testing Strategy
 
-## Access Policy
+### Unit tests
 
-Both applications use the same policy semantics:
+`src/access.test.ts` tests builders without contacting Cloudflare.
 
-- Action: `Allow`.
-- Include: the intended operator identity/email used for Perseus access.
-- Require: the trusted-device serial-number posture check used for Perseus.
-- Session duration: `12h`.
+At minimum, test:
 
-Prefer the existing account-level serial-number list/posture rule when DTXWeb is in the same Zero Trust account. If it is not reusable because the zone is under a different Zero Trust account, create an equivalent list/posture rule there using the same intended trusted devices. Do not weaken the posture requirement.
+- production destinations are exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`;
+- pre-production destination is hostname-wide and does not include the API hostname;
+- production cannot become hostname-wide through configuration;
+- policy contains the normalized configured email in `includes`;
+- policy references the provided posture-rule ID in `requires`;
+- default session duration is `12h`;
+- hardened application flags match the intended values;
+- unsupported stack names fail loudly;
+- invalid/empty email or posture-rule config fails before deployment if validation helpers are introduced.
 
-Verify the two policy clauses separately. A failed-posture device proves only the `Require` rule. The production rollout must also use the trusted device with a second IdP identity that is not in the `Include` list and confirm Access denies it.
+The tests should follow the Perseus pattern of separating pure builders from Pulumi resource creation so most security-sensitive behavior is deterministic and unit-testable.
 
-Do not change the account's instant-authentication setting merely to make `curl` output easier to recognize. During setup, record whether the reused Perseus login method uses the Cloudflare Access login page or instant authentication, then use the same mode for both DTXWeb applications and configure the verification helper to recognize that tenant's actual Access interception signal: a redirect when present, or HTTP `403` with both `cf-access-aud` and `cf-access-domain` headers.
+### Static verification
 
-Do not add Service Auth, Managed OAuth, or service tokens. API and other non-browser traffic stay outside these Access applications.
+Run the package TypeScript check and unit tests before any preview.
 
-## Rollout Order
+The root repository check should include the new workspace through normal workspace/turbo integration where practical; do not add unrelated CI redesign merely for this package.
 
-1. Add the dedicated DTXWeb Zero Trust operator runbook.
-2. Record the current Perseus identity provider, instant-authentication mode, intended operator identity, and serial-number posture rule without copying personal identifiers into git.
-3. Harden and dry-run the runbook's HTTP verification helpers against both a reachable URL and an intentionally invalid hostname; the invalid hostname must fail.
-4. Create the hostname-wide pre-production Access application.
-5. Run the runbook's complete pre-production verification section, including password login, Google OAuth, posture denial, and API non-interception.
-6. If any pre-production check fails, disable/remove the pre-production Access app and stop. Do not touch production.
-7. Create the production application with only `/app` and `/app/*`.
-8. Run the runbook's complete production header matrix, including `/app/`, `/app/__data.json`, the real `/preview/1` route, `/tool/*`, `/game`, and both API exclusions.
-9. Verify the Access `Include` identity rule independently on the trusted device with a non-allowed IdP identity.
-10. Run the trusted-device production browser and desktop-login checks, including standalone `tauri dev` against production.
-11. Characterize an expired Access session during a SvelteKit client-side navigation to `/app` and record the observed recovery behavior.
-12. Record final non-sensitive outcomes and deferred limitations.
+### Pulumi preview as a safety gate
 
-## Request Flows And Consequences
+`pulumi preview` is required before each environment apply.
 
-### Production browser
+Pre-production preview must show only the intended pre-production Access application.
 
-1. Browser requests `/app` or a descendant.
-2. Cloudflare Access evaluates the operator identity and device posture.
-3. A denied request never reaches DTXWeb.
-4. An allowed request reaches SvelteKit and the existing Supabase guard.
-5. Without a Supabase session, SvelteKit redirects to public `/login`.
-6. After Supabase login, the browser returns to protected `/app` and must still satisfy the Access gate.
+Production preview must show only the intended production Access application and exactly the two path destinations. A preview that shows hostname-wide production Access, an API destination, a new posture rule/list, or a service token is a hard stop.
 
-A normal Supabase user who does not match the Access policy is intentionally denied when returning to `/app`. If they now hold a Supabase session, `/login` will redirect them back into the denied `/app` surface and the current UI offers no public logout. Clearing the production Supabase cookies is the documented recovery until a separate logout UX decision is implemented.
+## Runtime Verification Requirements
 
-### Production desktop login
+The existing runbook remains the owner of live acceptance commands and browser checks. It is rewritten from dashboard instructions to Pulumi preview/apply/rollback instructions.
 
-1. Desktop opens public `/login?redirect=desktop&desktop_callback=...`.
-2. `/login` preserves the callback for the post-login handoff.
-3. Password or Google login returns the browser to `/app?redirect=desktop...`.
-4. Cloudflare Access gates that `/app` return.
-5. Only the configured operator on a trusted device can reach the `/app` handoff that generates and forwards the desktop magic link.
-
-Standalone `tauri dev` using a deployed `VITE_DTX_SERVER_URL` is therefore operator-only. In the current operator setup it targets production and is a required production acceptance check. The full local-stack `dev:local-web` path remains available without Cloudflare Access because it explicitly uses localhost.
-
-### SvelteKit client-side navigation
-
-The root server layout has a server `load`, so SvelteKit client-side navigation uses framework data requests such as `/app/__data.json`. Those requests are within `/app/*` and must be Access-protected too.
-
-Cloudflare checks every request for a valid application token. When a long-lived tab loses its Access session, a client-side data request may encounter the Access reauthentication redirect instead of normal SvelteKit data. The rollout must deliberately expire/logout the Access session and navigate client-side from a public production page into `/app`, record what the user sees, and confirm a direct reload of `/app` provides a usable reauthentication path. Any opaque fetch-error UX is a documented limitation/follow-up, not a reason to widen the Access destinations.
-
-### Pre-production
-
-Any request to `pre-prod.dtx.hapadona.com` reaches Access first. Once the browser has a valid Access session, the existing Supabase login and callback routes on that same hostname run normally behind the gate.
-
-Because no non-interactive Access credential is introduced, unattended Playwright/CI use of the pre-production hostname is unsupported by this slice even though the harness can point `PLAYWRIGHT_BASE_URL` at another host.
-
-### API traffic
-
-Requests to the two GraphQL API hostnames do not pass through these Access applications. Existing Supabase/API authorization stays unchanged and API/desktop callers require no Cloudflare Access credential.
-
-## Repository Changes
-
-Implementation creates one focused runbook:
-
-- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-
-The runbook is the single executable source of truth for dashboard configuration, header helpers, route matrices, browser/desktop checks, known limitations, and rollback. The implementation plan references named runbook sections rather than restating their command blocks.
-
-Do not edit the historical Phase 4 API migration runbook except for a future independent documentation cleanup; it is useful precedent for human-executed Cloudflare operations but not the ownership location for this permanent Access configuration.
-
-No source or deployment code changes are planned. If verification shows that SvelteKit, desktop, API, or routing code must change for this approved model to work, stop this slice and create a separate follow-up rather than widening scope.
-
-## Verification Requirements
-
-The durable runbook must make a missing HTTP response fail loudly. A DNS failure, connection failure, or timeout may not count as a successful `assert_no_access_interception` result.
-
-The runbook owns one pre-production matrix and one production matrix. The implementation plan must invoke those sections rather than duplicate their commands.
+The route-boundary helper must fail loudly if DNS, connection, TLS, or timeout fails; a request that never received an HTTP response cannot count as a successful public-route assertion.
 
 The production matrix must include:
 
@@ -196,41 +340,111 @@ The production matrix must include:
 - public: `/`, `/blog`, `/preview/1`, `/editor`, `/tool/dtx-to-midi`, `/game`, `/login`, `/auth/callback`;
 - outside Access: both API hostnames.
 
-The policy checks must independently prove:
+The policy checks independently prove:
 
 - allowed identity + trusted posture passes;
 - trusted device + non-allowed IdP identity is denied;
 - allowed identity on a device that fails posture is denied.
 
-The browser checks must cover:
+The browser checks cover:
 
-- pre-production password and Google login before production is configured;
+- pre-production password and Google login before production is applied;
 - production `/app -> /login -> /app` for the operator;
 - bundled desktop login;
-- standalone Tauri-development loopback login against production in the current operator setup;
-- expired/logged-out Access session during client-side navigation into `/app`;
+- standalone Tauri-development loopback login against deployed production in the current operator setup;
+- expired/logged-out Access session during SvelteKit client-side navigation into `/app`;
 - non-operator production login dead-end and documented cookie-clearing recovery.
 
-## Failure Handling And Rollback
+## Rollback
 
-If the verification harness cannot prove a real HTTP response, fix the harness before using it to approve any Access change.
+Rollback is stack-specific and does not touch Worker/API deployment.
 
-If pre-production identity, posture, login, callback, or route-boundary checks fail, disable/delete `DTXWeb Pre-prod` and stop before production.
+If pre-production fails required acceptance, remove/disable only the pre-production Access application through Pulumi. Production remains untouched.
 
-If any production public route is intercepted, disable `DTXWeb Production App` immediately and correct its destinations before re-enabling it. The accepted production destination set is only `/app` and `/app/*`.
+If production fails required acceptance, remove/disable only the production Access application through Pulumi. Pre-production remains available for further diagnosis.
 
-If either API hostname is intercepted, remove the API hostname from Access. Do not add service tokens as a workaround in this slice.
+The implementation plan must choose one explicit Pulumi rollback procedure and document it safely. Do not use a broad infrastructure destroy command that could affect unrelated resources if the package later grows.
 
-If the trusted production desktop flow cannot complete the `/login -> /app -> desktop` handoff, disable the production Access application and investigate separately. Do not widen the Access policy or add a bypass to make the test pass.
+Because this package owns only Access applications in this slice, rollback requires no Worker redeploy and no application-code rollback.
 
-Known/documented UX limitations such as the non-operator sign-out dead end or expired-session client-navigation behavior should be recorded as deferred follow-ups unless they prevent the trusted operator from recovering via normal browser reauthentication.
+Do not add a service token, API Access application, bypass policy, or widened destination as an emergency workaround.
 
-Rollback is dashboard-only: disable or delete the relevant Access application. No Worker rollback or code deployment is required.
+## Security And Secret Handling
+
+Never commit:
+
+- operator email;
+- device serial numbers;
+- Access cookies or JWTs;
+- Cloudflare API tokens;
+- Pulumi secret ciphertext files if the chosen backend/config workflow does not intend them for source control;
+- screenshots containing security identifiers.
+
+`accessEmail` is Pulumi secret configuration.
+
+`devicePostureRuleId` is plain configuration, but it must refer to the existing Perseus-managed rule and must never be replaced with a freshly created DTXWeb rule as part of this slice.
+
+The Cloudflare API token used for Pulumi must have only the permissions needed to manage the intended Access application resources and read/reference the relevant account-level Access resources. Permission setup belongs in the implementation/runbook, not application source.
+
+## Operational Consequences
+
+### Shared posture ownership
+
+Perseus controls trusted-device membership. Changing the Perseus serial list affects DTXWeb because both applications require the same posture rule.
+
+If the posture rule is replaced rather than updated in place, DTXWeb's `devicePostureRuleId` config becomes stale and must be changed before the next DTXWeb deployment.
+
+### Desktop development
+
+Standalone desktop auth against production or pre-production is operator-only. Full local-stack development remains the non-operator path.
+
+### Pre-production automation
+
+This slice adds no non-interactive Access credential. Unattended E2E/CI against the Access-protected pre-production hostname remains unsupported even though Playwright can target another base URL.
+
+### Non-operator logout dead end
+
+The existing production Supabase/UI behavior is unchanged. Signed-in non-operators can become trapped between public `/login` redirect behavior and Access denial at `/app`; clearing production site cookies remains the documented recovery until a separate product/code change is approved.
+
+## Repository Changes
+
+The implementation is expected to modify only infrastructure/workspace/documentation files, approximately:
+
+- `package.json` — add `packages/infrastructure` workspace and optional convenience scripts if justified by the implementation plan.
+- `bun.lock` — dependency resolution.
+- `packages/infrastructure/Pulumi.yaml` — Pulumi project metadata.
+- `packages/infrastructure/package.json` — Pulumi/Cloudflare/TypeScript/Vitest package definition.
+- `packages/infrastructure/tsconfig.json`.
+- `packages/infrastructure/vitest.config.ts`.
+- `packages/infrastructure/src/access.ts` — Access builders/resource factory.
+- `packages/infrastructure/src/access.test.ts` — unit tests.
+- `packages/infrastructure/src/index.ts` — stack selection and resource creation.
+- `packages/infrastructure/README.md` — local config/preview/apply instructions.
+- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` — Pulumi-based rollout, verification, and rollback.
+- `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md` — rewritten implementation plan after this spec is approved.
+
+No changes are planned under `packages/dtx-web`, `packages/dtx-api`, or `packages/dtx-desktop`.
+
+## Superseded Manual-Configuration Design
+
+The earlier version of this design used two manually configured dashboard applications. That approach is superseded by this Pulumi design.
+
+The approved protection matrix, product consequences, pre-production-first order, verification matrix, and rollback criteria remain valid. What changes is resource ownership and deployment:
+
+- Access applications are created by Pulumi rather than dashboard clicks;
+- the posture rule is referenced by existing Perseus resource ID rather than manually selected as an unmanaged dependency;
+- previews/unit tests provide an additional configuration safety gate;
+- the existing runbook and implementation plan must be rewritten before execution because their dashboard-configuration instructions are obsolete.
 
 ## References
 
-- Cloudflare Access application paths: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/
-- Cloudflare self-hosted public applications: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/
-- Cloudflare Access policies: https://developers.cloudflare.com/cloudflare-one/access-controls/policies/
-- Cloudflare Access authorization cookie: https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/
-- Cloudflare Access login page / instant authentication: https://developers.cloudflare.com/learning-paths/clientless-access/customize-ux/login-page/
+Repository precedent:
+
+- Perseus `packages/infrastructure/src/admin-access.ts`
+- Perseus `packages/infrastructure/src/admin-access.test.ts`
+- Perseus `packages/infrastructure/src/index.ts`
+- Perseus `packages/infrastructure/Pulumi.yaml`
+- Perseus `packages/infrastructure/package.json`
+- Perseus `packages/infrastructure/README.md`
+
+Cloudflare/Pulumi behavior should be verified against current provider and Cloudflare documentation during implementation if the working Perseus resource shape no longer typechecks against the selected provider version.


### PR DESCRIPTION
## Summary

Plans DTXWeb Cloudflare Zero Trust as a small, Access-only Pulumi package with code-owned stack scope and reuse of the existing Perseus device-posture rule.

### Approved architecture

- `packages/infrastructure` owns only DTXWeb Access applications; Wrangler keeps Worker/API/D1/R2/runtime ownership.
- Exactly two stacks: `pre-prod` and `production`.
- `pre-prod` protects the entire `pre-prod.dtx.hapadona.com` web hostname.
- `production` protects exactly `dtx.hapadona.com/app` and `dtx.hapadona.com/app/*`.
- Hostnames/destinations are code constants, not Pulumi config.
- Reuse the Perseus posture-rule Cloudflare ID as config; no DTXWeb posture/list resource and no `StackReference`.
- No Service Auth, service tokens, CLI Access app, Managed OAuth, Worker JWT validation, or runtime application-code change.
- Live `pulumi up`/destroy and browser/device acceptance are operator-only.

## Latest review changes addressed

- Adds a `dtx-web` route-tree boundary test so a future private route outside `/app` fails CI instead of silently shipping outside Access.
- Makes every operator preflight compare the current Perseus `adminAccessDevicePostureRuleId` with both DTXWeb stack config values; mismatch is a hard stop.
- Adds the required infrastructure build before preview because `Pulumi.yaml` runs `dist/index.js`.
- Adds `bun run lint` and `bunx prettier --check .` to implementation/runbook gates and requires the new CI fixture to be Prettier-formatted.
- Extends `.github/workflows/lint-and-format.yml` with `@dtx/infrastructure` TypeScript checking and makes the infrastructure `tsconfig` extend the repository base config.
- Keeps only the email validator; removes planned account/posture blank-string validators. The secret-input path is one `pulumi.output(...).apply(normalizeAccessEmail)` path and gets an explicit `Output<string>` test.
- Shrinks the planning docs substantially: design 212 lines, plan 377, runbook 342; the runbook remains the detailed operator document.
- Adds explicit Risks covering shared-posture drift, operator-machine concentration, pre-prod rollback exposure, and auth-migration sequencing.
- Confirms the queued Better Auth/D1 migration replaces the current desktop callback flow with `/app/desktop-auth` Device Authorization and explicitly plans to reconcile PR #221 docs.
- Therefore pre-production Access may be applied after implementation, but **production `pulumi up` is blocked until the Better Auth cutover/reconciliation lands**.
- Warns that destroying pre-prod Access returns the hostname to public state; this is especially sensitive when `pre-prod-prod-data` is active because that environment uses production D1/R2 resources.

## Documents

- `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md` — concise design, sequencing, and risks.
- `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md` — three agent tasks only: CI/workspace/route guard, Access implementation, docs/build/preview readiness.
- `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md` — operator-only live pre-prod procedure, production hold, and rollback.

## Implementation boundary

The agent implementation ends after tested code, CI integration, build, docs, and non-mutating previews when credentials/config already exist. A human operator may then apply and verify pre-prod. Production remains held for the Better Auth cutover.

This PR remains planning/documentation-only; no live Cloudflare configuration or DTXWeb runtime behavior is changed by merging it.