### PR TITLE
ci: scope CodeQL by changed language

### DIFF
--- a/.github/scripts/ci-affected-scope.sh
+++ b/.github/scripts/ci-affected-scope.sh
@@ -8,12 +8,12 @@ die() {
 }
 
 if [[ "$#" -ne 1 ]]; then
-	die 'usage: ci-affected-scope.sh <unit|lint>'
+	die 'usage: ci-affected-scope.sh <unit|lint|codeql>'
 fi
 
 mode="$1"
 case "$mode" in
-	unit | lint) ;;
+	unit | lint | codeql) ;;
 	*) die "unsupported mode: $mode" ;;
 esac
 
@@ -22,6 +22,61 @@ esac
 
 if ! changed_paths="$(git diff --name-only --merge-base "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD")"; then
 	die 'could not determine changed paths'
+fi
+
+if [[ "$mode" == codeql ]]; then
+	codeql_actions=false
+	codeql_javascript_typescript=false
+	codeql_python=false
+	codeql_rust=false
+	while IFS= read -r changed_path; do
+		if [[ -z "$changed_path" ]]; then
+			continue
+		fi
+
+		case "$changed_path" in
+			.github/workflows/* | .github/actions/*)
+				codeql_actions=true
+				;;
+			packages/dtx-desktop/src-tauri/*)
+				if [[ "$changed_path" == *.rs ]]; then
+					codeql_rust=true
+				else
+					die "uncertain CodeQL language mapping for native path: $changed_path"
+				fi
+				;;
+			scripts/*.py)
+				codeql_python=true
+				;;
+			scripts/requirements*.txt | scripts/*/requirements*.txt)
+				codeql_python=true
+				;;
+			*.js | *.cjs | *.mjs | *.jsx | *.ts | *.tsx | *.svelte | package.json | */package.json | bun.lock | tsconfig.base.json)
+				codeql_javascript_typescript=true
+				;;
+		esac
+	done <<<"$changed_paths"
+
+	codeql_output=()
+	if [[ "$codeql_actions" == true ]]; then
+		codeql_output+=('"actions"')
+	fi
+	if [[ "$codeql_javascript_typescript" == true ]]; then
+		codeql_output+=('"javascript-typescript"')
+	fi
+	if [[ "$codeql_python" == true ]]; then
+		codeql_output+=('"python"')
+	fi
+	if [[ "$codeql_rust" == true ]]; then
+		codeql_output+=('"rust"')
+	fi
+
+	if [[ "${#codeql_output[@]}" -eq 0 ]]; then
+		die 'CodeQL language selection was empty'
+	fi
+
+	(IFS=,; printf '[%s]\n' "${codeql_output[*]}")
+	exit 0
 fi
 
 if ! turbo_json="$(bunx turbo@2.10.9 ls --affected --output=json)"; then

--- a/.github/scripts/ci-affected-scope.test.sh
+++ b/.github/scripts/ci-affected-scope.test.sh
@@ -74,6 +74,11 @@ if [[ "$#" -ge 1 && "$1" == "diff" ]]; then
 		exit 94
 	fi
 
+	if [[ -n "${FAKE_GIT_CHANGED_PATHS:-}" ]]; then
+		printf '%s\n' "$FAKE_GIT_CHANGED_PATHS"
+		exit 0
+	fi
+
 	actual_changed_paths="$("$REAL_GIT" "$@")"
 	if [[ -n "${FAKE_GIT_EXPECTED_CHANGED_PATH:-}" && "$actual_changed_paths" != "$FAKE_GIT_EXPECTED_CHANGED_PATH" ]]; then
 		echo "merge-base changed paths were unexpected: $actual_changed_paths" >&2
@@ -108,12 +113,56 @@ create_repo() {
 	create_fake_git "$repo/bin/git"
 }
 
+create_repo_with_changes() {
+	local repo="$1"
+	local first_change_path="$2"
+	local first_change_contents="$3"
+	shift 3
+
+	create_repo "$repo" "$first_change_path" "$first_change_contents"
+
+	while [[ "$#" -gt 0 ]]; do
+		if [[ "$#" -lt 2 ]]; then
+			fail 'create_repo_with_changes requires path/content pairs'
+		fi
+		local change_path="$1"
+		local change_contents="$2"
+		shift 2
+		mkdir -p "$(dirname -- "$repo/$change_path")"
+		printf '%s\n' "$change_contents" >"$repo/$change_path"
+		"$REAL_GIT" -C "$repo" add "$change_path"
+	done
+
+	if [[ -n "$("$REAL_GIT" -C "$repo" diff --cached --name-only)" ]]; then
+		"$REAL_GIT" -C "$repo" commit -q -m 'additional changes'
+	fi
+}
+
+create_empty_repo() {
+	local repo="$1"
+
+	mkdir -p "$repo/bin"
+	"$REAL_GIT" -C "$repo" init -q
+	"$REAL_GIT" -C "$repo" config user.email ci-affected-scope@example.invalid
+	"$REAL_GIT" -C "$repo" config user.name ci-affected-scope-test
+	printf 'base\n' >"$repo/README.md"
+	"$REAL_GIT" -C "$repo" add README.md
+	"$REAL_GIT" -C "$repo" commit -q -m base
+	"$REAL_GIT" -C "$repo" branch -M main
+	"$REAL_GIT" -C "$repo" switch -q -c feature
+
+	create_fake_bunx "$repo/bin/bunx"
+	create_fake_git "$repo/bin/git"
+}
+
 run_detector() {
 	local repo="$1"
 	local mode="$2"
 	local fixture="$3"
 	local base="$4"
 	local head="$5"
+	local fake_changed_paths="${6:-}"
+	local fake_bunx_fail="${7:-false}"
 	local stderr_file="$repo/stderr.log"
 
 	(
@@ -121,10 +170,25 @@ run_detector() {
 		PATH="$repo/bin:$ORIGINAL_PATH" \
 		REAL_GIT="$REAL_GIT" \
 		FAKE_TURBO_FIXTURE="$FIXTURES_DIR/$fixture" \
+		FAKE_GIT_CHANGED_PATHS="$fake_changed_paths" \
+		FAKE_BUNX_FAIL="$fake_bunx_fail" \
 		TURBO_SCM_BASE="$base" \
 		TURBO_SCM_HEAD="$head" \
 		"$DETECTOR" "$mode" 2>"$stderr_file"
 	)
+}
+
+run_codeql_expected_changes() {
+	local test_name="$1"
+	local expected="$2"
+	shift 2
+	local repo="$TEST_ROOT/$test_name"
+
+	create_repo_with_changes "$repo" "$@"
+	local output
+	output="$(run_detector "$repo" codeql turbo-empty.json main feature)" || fail "$test_name unexpectedly failed: $(<"$repo/stderr.log")"
+	assert_equals "$expected" "$output" "$test_name"
+	echo "PASS: $test_name"
 }
 
 run_expected() {
@@ -153,6 +217,8 @@ run_expected e2e-only-lint lint turbo-e2e-web.json true packages/e2e-web/tests/c
 
 run_expected tsconfig-global-invalidation unit turbo-tsconfig.json true tsconfig.base.json tsconfig
 run_expected tsconfig-global-invalidation-lint lint turbo-tsconfig.json true tsconfig.base.json tsconfig
+
+run_expected codeql-typescript codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.ts codeql
 
 malformed_repo="$TEST_ROOT/malformed-json"
 create_repo "$malformed_repo" packages/dtx-web/src/change.ts web
@@ -222,5 +288,91 @@ if (cd "$missing_env_repo" && PATH="$missing_env_repo/bin:$ORIGINAL_PATH" REAL_G
 	fail 'missing SCM variables unexpectedly passed'
 fi
 echo 'PASS: missing SCM variables fail'
+
+run_expected codeql-workflow codeql turbo-empty.json '["actions"]' .github/workflows/change.yml workflow
+run_expected codeql-actions-directory codeql turbo-empty.json '["actions"]' .github/actions/change/action.yml action
+run_expected codeql-javascript codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.js javascript
+run_expected codeql-commonjs codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.cjs commonjs
+run_expected codeql-module-javascript codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.mjs module
+run_expected codeql-jsx codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.jsx jsx
+run_expected codeql-typescript-source codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.ts typescript
+run_expected codeql-tsx codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.tsx tsx
+run_expected codeql-svelte codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/src/change.svelte svelte
+run_expected codeql-package-json codeql turbo-empty.json '["javascript-typescript"]' packages/dtx-web/package.json package
+run_expected codeql-bun-lock codeql turbo-empty.json '["javascript-typescript"]' bun.lock lockfile
+run_expected codeql-tsconfig-base codeql turbo-empty.json '["javascript-typescript"]' tsconfig.base.json tsconfig
+run_expected codeql-python codeql turbo-empty.json '["python"]' scripts/seed.py python
+run_expected codeql-python-requirements codeql turbo-empty.json '["python"]' scripts/ci/requirements-dev.txt requirements
+run_expected codeql-rust codeql turbo-empty.json '["rust"]' packages/dtx-desktop/src-tauri/src/main.rs rust
+
+run_codeql_expected_changes \
+	codeql-mixed-three-languages \
+	'["actions","javascript-typescript","rust"]' \
+	.github/workflows/change.yml workflow \
+	packages/dtx-web/src/change.ts typescript \
+	packages/dtx-desktop/src-tauri/src/main.rs rust \
+	docs/notes.md docs
+
+run_codeql_expected_changes \
+	codeql-all-four-languages \
+	'["actions","javascript-typescript","python","rust"]' \
+	.github/workflows/change.yml workflow \
+	packages/dtx-web/src/change.ts typescript \
+	scripts/seed.py python \
+	packages/dtx-desktop/src-tauri/src/main.rs rust
+
+duplicate_paths_repo="$TEST_ROOT/codeql-duplicate-paths"
+create_repo "$duplicate_paths_repo" docs/change.md docs
+duplicate_paths=$'packages/dtx-desktop/src-tauri/src/main.rs\npackages/dtx-web/src/change.ts\n.github/workflows/change.yml\npackages/dtx-web/src/change.ts\n.github/workflows/change.yml'
+if output="$(run_detector "$duplicate_paths_repo" codeql turbo-empty.json main feature "$duplicate_paths")"; then
+	assert_equals '["actions","javascript-typescript","rust"]' "$output" 'codeql duplicate and out-of-order paths'
+else
+	fail "codeql duplicate and out-of-order paths failed: $(<"$duplicate_paths_repo/stderr.log")"
+fi
+echo 'PASS: codeql duplicate and out-of-order paths'
+
+empty_selection_repo="$TEST_ROOT/codeql-empty-selection"
+create_empty_repo "$empty_selection_repo"
+if run_detector "$empty_selection_repo" codeql turbo-empty.json main feature >/dev/null; then
+	fail 'codeql empty selection unexpectedly passed'
+fi
+echo 'PASS: codeql empty selection fails'
+
+unmapped_repo="$TEST_ROOT/codeql-unmapped"
+create_repo "$unmapped_repo" docs/change.md docs
+if run_detector "$unmapped_repo" codeql turbo-empty.json main feature >/dev/null; then
+	fail 'codeql unmapped change unexpectedly passed'
+fi
+echo 'PASS: codeql unmapped change fails'
+
+uncertain_native_repo="$TEST_ROOT/codeql-uncertain-native"
+create_repo "$uncertain_native_repo" packages/dtx-desktop/src-tauri/Cargo.toml native
+if run_detector "$uncertain_native_repo" codeql turbo-empty.json main feature >/dev/null; then
+	fail 'codeql uncertain native change unexpectedly passed'
+fi
+echo 'PASS: codeql uncertain native change fails'
+
+invalid_codeql_refs_repo="$TEST_ROOT/codeql-invalid-refs"
+create_repo "$invalid_codeql_refs_repo" packages/dtx-web/src/change.ts codeql
+if run_detector "$invalid_codeql_refs_repo" codeql turbo-empty.json missing-ref feature >/dev/null; then
+	fail 'codeql invalid refs unexpectedly passed'
+fi
+echo 'PASS: codeql invalid refs fail'
+
+codeql_turbo_bypass_repo="$TEST_ROOT/codeql-turbo-bypass"
+create_repo "$codeql_turbo_bypass_repo" packages/dtx-web/src/change.ts codeql
+if output="$(run_detector "$codeql_turbo_bypass_repo" codeql turbo-empty.json main feature '' true)"; then
+	assert_equals '["javascript-typescript"]' "$output" 'codeql bypasses Turbo'
+else
+	fail "codeql Turbo bypass failed: $(<"$codeql_turbo_bypass_repo/stderr.log")"
+fi
+echo 'PASS: codeql bypasses Turbo'
+
+missing_codeql_env_repo="$TEST_ROOT/codeql-missing-env"
+create_repo "$missing_codeql_env_repo" packages/dtx-web/src/change.ts codeql
+if (cd "$missing_codeql_env_repo" && PATH="$missing_codeql_env_repo/bin:$ORIGINAL_PATH" REAL_GIT="$REAL_GIT" FAKE_TURBO_FIXTURE="$FIXTURES_DIR/turbo-empty.json" env -u TURBO_SCM_BASE -u TURBO_SCM_HEAD "$DETECTOR" codeql >/dev/null 2>"$missing_codeql_env_repo/stderr.log"); then
+	fail 'codeql missing SCM variables unexpectedly passed'
+fi
+echo 'PASS: codeql missing SCM variables fail'
 
 echo 'All affected-scope detector tests passed.'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,42 @@ on:
     - cron: '45 14 * * 4'
 
 jobs:
+  select-languages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      languages: ${{ steps.scope.outputs.languages }}
+    steps:
+      - name: Checkout repository for pull request scope
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Select CodeQL languages
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          all_languages='["actions","javascript-typescript","python","rust"]'
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            printf 'languages=%s\n' "$all_languages" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if languages="$(.github/scripts/ci-affected-scope.sh codeql)"; then
+            printf 'languages=%s\n' "$languages" >> "$GITHUB_OUTPUT"
+          else
+            printf 'languages=%s\n' "$all_languages" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
+    needs: select-languages
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
@@ -58,23 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: javascript-typescript
-            build-mode: none
-          - language: python
-            build-mode: none
-          - language: rust
-            build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+        language: ${{ fromJSON(needs.select-languages.outputs.languages) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -90,30 +109,13 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          build-mode: none
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-
-      # If the analyze step fails for one of the languages you are analyzing with
-      # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual" for that language. Then modify this step
-      # to build your code.
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - name: Run manual build steps
-        if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- add a tested `codeql` affected-scope mode with conservative failure semantics
- select the CodeQL language matrix from PR changes, falling back to all four languages on uncertainty
- retain full-language scans for `main` pushes and scheduled runs, with `build-mode: none`

## Validation

- `actionlint .github/workflows/codeql.yml`
- `.github/scripts/ci-affected-scope.test.sh`
- `git diff --check`
- independent C1 and C2 task reviews

Hosted fixture verification is in progress.