### PR TITLE
ci: temporary HPA-613 Rust CodeQL proof

### DIFF
--- a/packages/dtx-desktop/src-tauri/src/hpa_613_codeql_fixture.rs
+++ b/packages/dtx-desktop/src-tauri/src/hpa_613_codeql_fixture.rs
@@ -1,0 +1,4 @@
+// Temporary hosted-CI fixture for HPA-613. This branch will be closed unmerged.
+pub fn hpa_613_codeql_fixture() -> bool {
+    true
+}


### PR DESCRIPTION
Temporary hosted-CI fixture for HPA-613. It adds one unreferenced Rust source file to prove a true Rust-only PR selects only Rust CodeQL with `build-mode: none`. This PR will be closed unmerged after evidence capture.