### PR TITLE
ci: temporary HPA-613 mixed CodeQL proof

### DIFF
--- a/.github/workflows/hpa-613-c2-fixture.txt
+++ b/.github/workflows/hpa-613-c2-fixture.txt
@@ -1,0 +1,1 @@
+Temporary hosted-CI fixture for HPA-613. This non-workflow file exists only to exercise the CodeQL actions mapping and will be closed unmerged.

--- a/packages/dtx-web/src/lib/hpa-613-codeql-fixture.ts
+++ b/packages/dtx-web/src/lib/hpa-613-codeql-fixture.ts
@@ -1,0 +1,2 @@
+// Temporary hosted-CI fixture for HPA-613. This branch will be closed unmerged.
+export const hpa613CodeqlFixture = true;


### PR DESCRIPTION
Temporary hosted-CI fixture for HPA-613. It touches a non-workflow file beneath `.github/workflows/` and one TypeScript source file to prove the matrix is exactly `actions` plus `javascript-typescript`. This PR will be closed unmerged after evidence capture.