### PR TITLE
ci: temporary HPA-613 CodeQL fallback proof

### DIFF
--- a/packages/dtx-desktop/src-tauri/hpa-613-codeql-uncertain-fixture.txt
+++ b/packages/dtx-desktop/src-tauri/hpa-613-codeql-uncertain-fixture.txt
@@ -1,0 +1,1 @@
+Temporary hosted-CI fixture for HPA-613. This non-Rust native path deliberately exercises the conservative CodeQL all-language fallback and will be closed unmerged.


### PR DESCRIPTION
Temporary hosted-CI fixture for HPA-613. It adds an intentionally unmapped native path so the CodeQL detector fails safely and the selector emits all four languages. This PR will be closed unmerged after evidence capture.