### PR TITLE
docs: plan Better Auth and D1 auth migration

### DIFF
--- a/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
+++ b/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
@@ -884,6 +884,7 @@ Commit native/generated changes together.
 - Modify: `packages/e2e-desktop/support/standalone-session.test.mjs`
 - Modify: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
 - Modify: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
+- Modify: `packages/e2e-desktop/scripts/google-drive-crash-recovery.test.mjs`
 
 - [ ] **Step 1: Add renderer lifecycle tests.**
 
@@ -916,7 +917,7 @@ Keep `DTX_E2E_DRUMERY_USER_ID`; it still identifies the debug-only seeded user.
 
 Update renderer/localStorage setup in `google-drive-upload.e2e.ts` and `google-drive-crash-recovery.ts` to write the new neutral session object instead of Supabase access/refresh keys.
 
-Update standalone-session tests if they assert the old auth storage/env shape.
+Update `standalone-session.test.mjs` and `google-drive-crash-recovery.test.mjs` where they assert the old auth storage/env shape.
 
 Do not add an API test-auth endpoint; reuse the native e2e/debug seed path from Task 10.
 
@@ -937,12 +938,12 @@ Simplify dev scripts/topology tests. Remove auth URI schemes only after no non-a
 ```bash
 bun run --filter=dtx-desktop test
 bun run --filter=dtx-desktop check
-bun run --filter=dtx-e2e-desktop test
+bun run --filter=dtx-e2e-desktop check
+bun test packages/e2e-desktop/support/standalone-session.test.mjs \
+  packages/e2e-desktop/scripts/google-drive-crash-recovery.test.mjs
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml --all-features
 bun run gen:native-types
 ```
-
-Use the actual E2E package unit-test script name if different; do not silently skip its support tests.
 
 ---
 
@@ -1050,6 +1051,7 @@ Run residue gate, lockfile/install check, all package typechecks, and unit tests
 - Revisit: `packages/e2e-desktop/support/standalone-session.test.mjs`
 - Revisit: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
 - Revisit: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
+- Revisit: `packages/e2e-desktop/scripts/google-drive-crash-recovery.test.mjs`
 - Create: `docs/superpowers/runbooks/2026-08-18-better-auth-d1-cutover.md`
 - After PR #221 lands, modify its Zero Trust spec/plan/runbook documents
 

--- a/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
+++ b/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
@@ -2,29 +2,35 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Remove Supabase from DTXWeb by hosting Better Auth in `dtx-api`, storing auth data in the existing Cloudflare D1 database, moving web authentication to cookies, and replacing desktop magic-link/deep-link authentication with Device Authorization plus Bearer sessions.
+**Goal:** Remove Supabase from DTXWeb by hosting Better Auth in `dtx-api`, storing auth data in the existing Cloudflare D1 database, moving web authentication to cookies, and replacing desktop magic-link/deep-link authentication with Device Authorization plus opaque Bearer sessions.
 
-**Architecture:** `dtx-api` owns one request-scoped Better Auth instance, the official Better Auth Drizzle adapter, generated auth schema, D1 migration, and neutral session resolution. `dtx-web` is a separate-origin SvelteKit client that uses a shared-parent cookie and hosts `/app/desktop-auth`. DTX Desktop requests a device code, opens the verification URL, polls natively, stores one opaque session token, and sends it as Bearer auth to the existing GraphQL and REST API. Existing application tables continue using preserved auth user IDs.
+**Architecture:** `dtx-api` owns one request-scoped Better Auth instance, the official Better Auth Drizzle adapter, generated auth schema, D1 migration, and one neutral session-resolution seam. `dtx-web` uses Better Auth cookies and hosts `/app/desktop-auth`; unsafe cookie-authenticated API requests are accepted only from the existing `CORS_ALLOWED_ORIGINS` set. DTX Desktop requests a device code, opens the browser, polls natively, stores one opaque session token, and keeps the existing `valid | invalid | not-configured` restore contract.
 
-**Tech Stack:** Better Auth 1.6.25, Better Auth Device Authorization and Bearer plugins, Cloudflare Workers, D1, Drizzle ORM/Drizzle Kit, SvelteKit 2/Svelte 5, Tauri 2/Rust, Vitest, Playwright, WireMock.
+**Tech Stack:** Better Auth 1.6.25, Device Authorization and Bearer plugins, Cloudflare Workers, D1, Drizzle ORM/Drizzle Kit, SvelteKit 2/Svelte 5, Tauri 2/Rust, Vitest, Playwright, WireMock.
 
 **Spec:** `docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md`
 
 ## Global Constraints
 
-- [ ] Use Better Auth 1.6.25 exactly; do not adopt a prerelease during this migration.
-- [ ] Follow Better Auth's Cloudflare fixture: request-scoped `drizzle(env.DB, { schema })` plus `drizzleAdapter(..., { provider: "sqlite" })`.
-- [ ] Keep Wrangler D1 migrations as the only production migration executor.
+- [ ] Implement HPA-644 in **one implementation PR**. The tasks below are reviewable commits/checkpoints, not separate PRs.
+- [ ] Use Better Auth **1.6.25 exactly**; do not adopt a prerelease in this migration.
+- [ ] Follow Better Auth's Cloudflare pattern: request-scoped `drizzle(env.DB, { schema })` plus `drizzleAdapter(..., { provider: 'sqlite' })`.
+- [ ] Keep Better Auth schema in `packages/dtx-api`; do not add it to `packages/common/src/lib/server/db/schema.ts`.
+- [ ] Keep Wrangler D1 migrations as the only production migration executor; next migration is `0008_better_auth.sql`.
 - [ ] Preserve every existing Supabase UUID used by application ownership rows.
-- [ ] Do not add dual-auth mode, OAuth Provider, JWT/JWKS, API keys, another Worker, another database, or custom device protocol.
+- [ ] Do not add dual-auth mode, OAuth Provider, JWT/JWKS, API keys, another Worker/database, custom device protocol, or bcrypt compatibility.
 - [ ] Do not preserve active Supabase sessions or old desktop access/refresh-token storage.
 - [ ] Keep Google linking explicit and signup disabled.
-- [ ] Keep the existing application-data schema and authorization scopes unchanged.
-- [ ] Write tests before each behavior change and keep each task compiling before commit.
+- [ ] Keep Google Drive OAuth independent from application Google Auth.
+- [ ] Reuse `CORS_ALLOWED_ORIGINS` as Better Auth `trustedOrigins`; do not create a parallel origin setting.
+- [ ] Preserve all `Set-Cookie` values when a Worker/SvelteKit response is reconstructed.
+- [ ] Keep `SessionValidationStatus = valid | invalid | not-configured` on desktop.
+- [ ] Production data import/deploy remains an operator-runbook action, not an implementation-plan task.
+- [ ] Write failing tests before each behavior change and keep each task compiling before commit.
 
 ---
 
-## Task 1: Pin Better Auth and create a reproducible D1 auth schema
+## Task 1: Pin Better Auth and generate the D1 auth schema
 
 **Files:**
 
@@ -40,23 +46,23 @@
 - Modify: `packages/dtx-api/wrangler.jsonc`
 - Modify: `.env.example`
 
-### Step 1: Add a failing schema contract test
+**Interfaces:**
 
-- [ ] Create `src/auth/schema.test.ts`.
-- [ ] Read `src/auth/schema.ts` and `d1-migrations/0008_better_auth.sql`.
-- [ ] Assert the generated schema and SQL include Better Auth core models, Device Authorization, and database rate limiting.
-- [ ] Assert user IDs are text primary keys and session/account/device rows reference the Better Auth user table.
-- [ ] Run:
+- Produces `createAuthOptions(config)` for Task 2.
+- Produces generated `authSchema` plus `0008_better_auth.sql` for runtime/E2E.
+- Keeps `CORS_ALLOWED_ORIGINS` as the canonical trusted-origin input.
+
+- [ ] **Step 1: Write the failing schema contract test.**
+
+Assert that generated schema/SQL contain Better Auth core tables, Device Authorization, database rate limiting, text user IDs, and the expected foreign keys.
 
 ```bash
 bun run --filter=dtx-api test -- src/auth/schema.test.ts
 ```
 
-Expected: FAIL because the schema and migration do not exist.
+Expected: FAIL because the schema/migration do not exist.
 
-### Step 2: Install pinned dependencies
-
-- [ ] Run:
+- [ ] **Step 2: Install pinned dependencies.**
 
 ```bash
 cd packages/dtx-api
@@ -67,12 +73,11 @@ bun add --dev drizzle-kit
 cd ../..
 ```
 
-- [ ] Do not add a third-party Better Auth Cloudflare adapter.
+Do not add a third-party Cloudflare adapter.
 
-### Step 3: Define shared options
+- [ ] **Step 3: Define shared Better Auth options.**
 
-- [ ] Create `options.ts` with one `createAuthOptions(config)` function.
-- [ ] Include:
+`createAuthOptions(config)` includes:
 
 ```ts
 emailAndPassword: {
@@ -93,32 +98,31 @@ account: {
     disableImplicitLinking: true,
   },
 },
+trustedOrigins: config.trustedOrigins,
 advanced: {
   crossSubDomainCookies: config.cookieDomain
     ? { enabled: true, domain: config.cookieDomain }
     : { enabled: false },
-  ipAddress: { ipAddressHeaders: ["cf-connecting-ip"] },
+  ipAddress: { ipAddressHeaders: ['cf-connecting-ip'] },
 },
 rateLimit: {
   enabled: true,
-  storage: "database",
+  storage: 'database',
 },
 plugins: [
   deviceAuthorization({
     verificationUri: `${config.webURL}/app/desktop-auth`,
-    validateClient: (clientId) => clientId === "dtx-desktop",
+    validateClient: (clientId) => clientId === 'dtx-desktop',
   }),
   bearer(),
 ],
 ```
 
-- [ ] Set `baseURL`, `secret`, and `trustedOrigins` explicitly.
-- [ ] Do not disable Better Auth CSRF or origin checks.
+Keep Better Auth CSRF/origin checks enabled.
 
-### Step 4: Generate the Drizzle schema
+- [ ] **Step 4: Generate schema with the pinned CLI.**
 
-- [ ] Create `auth.cli.ts` using the shared options and non-production placeholder values.
-- [ ] Add scripts:
+Add package scripts:
 
 ```json
 {
@@ -128,20 +132,13 @@ plugins: [
 }
 ```
 
-- [ ] Run `bun run --filter=dtx-api auth:schema:generate`.
-- [ ] Review the generated schema; do not hand-maintain Better Auth columns.
+Run generation and review output; do not hand-maintain generated columns.
 
-### Step 5: Export reviewed SQL
+- [ ] **Step 5: Export flat Wrangler-compatible SQL.**
 
-- [ ] Configure `drizzle.auth.config.ts` for SQLite using `src/auth/schema.ts`.
-- [ ] Run the export into a temporary file.
-- [ ] Copy only the generated DDL into `0008_better_auth.sql`.
-- [ ] Ensure the migration is flat SQL compatible with `wrangler d1 migrations apply`.
-- [ ] Do not add a runtime Drizzle Kit migration runner.
+Configure `drizzle.auth.config.ts`, export SQL, review it, and commit it as `0008_better_auth.sql`. Do not add a runtime Drizzle migration runner.
 
-### Step 6: Add the environment contract
-
-- [ ] Add to `Env`:
+- [ ] **Step 6: Add environment fields.**
 
 ```ts
 BETTER_AUTH_URL: string;
@@ -152,13 +149,9 @@ GOOGLE_AUTH_CLIENT_ID: string;
 GOOGLE_AUTH_CLIENT_SECRET: string;
 ```
 
-- [ ] Add non-secret URL/domain/client-ID values to each Wrangler environment.
-- [ ] Keep `BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` as Wrangler secrets.
-- [ ] Keep Supabase variables temporarily until the cutover tasks remove their consumers.
+`BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` are Wrangler secrets. Keep Supabase vars temporarily until their consumers are removed.
 
-### Step 7: Verify schema generation
-
-- [ ] Run:
+- [ ] **Step 7: Verify schema/local D1.**
 
 ```bash
 bun run --filter=dtx-api auth:schema:check
@@ -167,11 +160,7 @@ bun run --filter=dtx-api check
 bun run packages/e2e-web/setup/prepare-stack.ts
 ```
 
-Expected: generated schema is clean and all D1 migrations apply to fresh local state.
-
-### Step 8: Commit
-
-- [ ] Commit:
+- [ ] **Step 8: Commit.**
 
 ```bash
 git add packages/dtx-api/package.json bun.lock \
@@ -183,7 +172,7 @@ git commit -m "feat(auth): add Better Auth D1 schema"
 
 ---
 
-## Task 2: Mount Better Auth and enable credentialed CORS
+## Task 2: Mount Better Auth and make CORS/cookies lossless
 
 **Files:**
 
@@ -194,19 +183,36 @@ git commit -m "feat(auth): add Better Auth D1 schema"
 - Modify: `packages/dtx-api/src/lib/cors.ts`
 - Modify: `packages/dtx-api/src/lib/cors.test.ts`
 
-### Step 1: Add failing handler tests
+**Interfaces:**
 
-- [ ] Add tests proving:
-  - GET and POST under `/api/auth/*` reach Better Auth;
-  - unrelated routes still reach GraphQL/REST;
-  - unsupported methods preserve existing behavior;
-  - session lookup without credentials returns null;
-  - D1 is request-scoped.
-- [ ] Run the focused tests and confirm failure.
+- Produces `createAuth(env)` for Task 3.
+- Exports `getAllowedOrigins(env)`/`isAllowedOrigin(env, origin)` from the existing CORS seam.
+- `withCors()` preserves multiple `Set-Cookie` values for Tasks 5/6.
 
-### Step 2: Create the runtime auth factory
+- [ ] **Step 1: Add failing auth-router/CORS tests.**
 
-- [ ] Implement:
+Cover:
+
+- GET/POST `/api/auth/*` routing;
+- unrelated GraphQL/REST routing;
+- exact allowed origin and credentials;
+- denied/missing origin behavior;
+- **two distinct Set-Cookie values survive `withCors()`**.
+
+- [ ] **Step 2: Export the existing origin parser.**
+
+Keep one parser/cache in `cors.ts`:
+
+```ts
+export const getAllowedOrigins = (env: Env): ReadonlySet<string> => { /* existing parse/cache */ };
+
+export const isAllowedOrigin = (env: Env, origin: string | null): boolean =>
+  origin !== null && getAllowedOrigins(env).has(origin);
+```
+
+Use this same set when creating Better Auth `trustedOrigins`.
+
+- [ ] **Step 3: Create the request-scoped auth factory.**
 
 ```ts
 export const createAuth = (env: Env) =>
@@ -218,48 +224,32 @@ export const createAuth = (env: Env) =>
       googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
       googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
       secret: env.BETTER_AUTH_SECRET,
+      trustedOrigins: [...getAllowedOrigins(env)],
     }),
-    database: drizzleAdapter(drizzle(env.DB, { schema }), {
-      provider: "sqlite",
+    database: drizzleAdapter(drizzle(env.DB, { schema: authSchema }), {
+      provider: 'sqlite',
     }),
   });
 ```
 
-- [ ] Do not cache an auth instance across unrelated Worker environments.
+This mirrors `createDrizzleDb()` but does not move auth schema into common.
 
-### Step 3: Mount the handler before GraphQL/REST
+- [ ] **Step 4: Mount Better Auth before GraphQL/REST.**
 
-- [ ] In `src/index.ts`, handle CORS preflight first.
-- [ ] Route `/api/auth/*` GET/POST to `createAuth(env).handler(request)`.
-- [ ] Wrap the response with the existing `withCors(response, request, env)` helper.
-- [ ] Keep the current small hand-written router; do not add Hono solely for this route.
+Route GET/POST `/api/auth/*` through `createAuth(env).handler(request)` and wrap the response with `withCors()`.
 
-### Step 4: Make CORS credential-safe
+- [ ] **Step 5: Preserve multiple cookies explicitly.**
 
-- [ ] For configured origins, set:
+When `withCors()` reconstructs a response, preserve every Set-Cookie entry using the Workers multi-cookie API. Do not read a flattened `headers.get('set-cookie')` value.
 
-```text
-Access-Control-Allow-Origin: <exact origin>
-Access-Control-Allow-Credentials: true
-Vary: Origin
-```
+The focused test must assert both cookie strings remain individually retrievable.
 
-- [ ] Keep allowed methods/headers explicit.
-- [ ] Never combine credentials with `Access-Control-Allow-Origin: *`.
-- [ ] Add preflight and normal-response tests for allowed, denied, missing, and multiple configured origins.
-
-### Step 5: Verify and commit
-
-- [ ] Run:
+- [ ] **Step 6: Verify and commit.**
 
 ```bash
 bun run --filter=dtx-api test -- src/auth/auth.test.ts src/index.test.ts src/lib/cors.test.ts
 bun run --filter=dtx-api check
-```
 
-- [ ] Commit:
-
-```bash
 git add packages/dtx-api/src/auth/auth.ts packages/dtx-api/src/auth/auth.test.ts \
   packages/dtx-api/src/index.ts packages/dtx-api/src/index.test.ts \
   packages/dtx-api/src/lib/cors.ts packages/dtx-api/src/lib/cors.test.ts
@@ -268,12 +258,12 @@ git commit -m "feat(auth): mount Better Auth API"
 
 ---
 
-## Task 3: Replace Supabase token verification with one neutral session resolver
+## Task 3: Replace the Supabase verifier with one neutral session resolver
 
 **Files:**
 
-- Create: `packages/dtx-api/src/auth/session.ts`
-- Create: `packages/dtx-api/src/auth/session.test.ts`
+- Rename/rewrite: `packages/dtx-api/src/auth/verifyToken.ts` → `packages/dtx-api/src/auth/session.ts`
+- Rename/rewrite: `packages/dtx-api/src/auth/verifyToken.test.ts` → `packages/dtx-api/src/auth/session.test.ts`
 - Modify: `packages/dtx-api/src/context.ts`
 - Modify: `packages/dtx-api/src/schema/builder.ts`
 - Modify: `packages/dtx-api/src/schema/builder.test.ts`
@@ -283,47 +273,75 @@ git commit -m "feat(auth): mount Better Auth API"
 - Modify: `packages/dtx-api/src/rest/downloadSimfile.test.ts`
 - Modify: `packages/dtx-api/src/rest/downloadBulk.ts`
 - Modify: `packages/dtx-api/src/rest/downloadBulk.test.ts`
-- Delete later in this task: `packages/dtx-api/src/auth/verifyToken.ts`
-- Delete later in this task: `packages/dtx-api/src/auth/verifyToken.test.ts`
 
-### Step 1: Add resolver tests
+**Interfaces:**
 
-- [ ] Test cookie session, Bearer session, missing credentials, revoked/expired token, malformed header, and Better Auth failure.
-- [ ] Require the same normalized `{ user, session }` shape for cookie and Bearer callers.
-- [ ] Confirm invalid credentials normalize to null rather than leaking provider errors.
+- Produces `resolveAuthSession(request, env): Promise<ResolvedAuthSession | null>`.
+- Produces minimal `ApiAuthUser = { id: string }`.
+- Applies the unsafe-cookie Origin rule once for GraphQL and REST.
 
-### Step 2: Implement `resolveAuthSession`
+- [ ] **Step 1: Write resolver tests first.**
 
-- [ ] Call:
+Cover:
+
+1. valid cookie GET with no Origin;
+2. valid cookie POST with allowed Origin;
+3. cookie POST with missing Origin => null;
+4. cookie POST with disallowed Origin => null;
+5. valid Bearer POST with no Origin => valid;
+6. malformed Bearer => null;
+7. missing credentials => null;
+8. revoked/expired session => null;
+9. Better Auth exception => null.
+
+- [ ] **Step 2: Implement transport classification.**
+
+```ts
+const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+const hasBearer = (request: Request) =>
+  /^Bearer\s+\S+$/i.test(request.headers.get('authorization') ?? '');
+
+const cookieOriginAllowed = (request: Request, env: Env) =>
+  !UNSAFE_METHODS.has(request.method) ||
+  isAllowedOrigin(env, request.headers.get('origin'));
+```
+
+If there is no Bearer header and an unsafe request carries cookie authentication, reject the session before returning it unless Origin is allow-listed.
+
+- [ ] **Step 3: Normalize the Better Auth result.**
+
+```ts
+type ApiAuthUser = { id: string };
+type ResolvedAuthSession = {
+  user: ApiAuthUser;
+  session: { id: string };
+};
+```
+
+Call only:
 
 ```ts
 createAuth(env).api.getSession({ headers: request.headers })
 ```
 
-- [ ] Return neutral local types, not Better Auth internals throughout the codebase.
-- [ ] Do not decode or validate tokens independently.
+Do not decode bearer tokens or propagate Better Auth/Supabase user types through application code.
 
-### Step 3: Retarget GraphQL context and REST
+- [ ] **Step 4: Retarget context and REST.**
 
-- [ ] Replace `verifyToken()` in `context.ts` and protected REST routes.
-- [ ] Keep current Pothos scope behavior and existing unauthorized responses.
-- [ ] Cover both cookie and Bearer at the resolver boundary; route tests may mock the neutral helper.
+Replace every `verifyToken()` call with `resolveAuthSession()`. Keep current Pothos scope behavior and REST status semantics.
 
-### Step 4: Delete the Supabase verifier
+`uploadSimfileFile()` already accepts `{ id: string }`; do not widen it.
 
-- [ ] Delete `verifyToken.ts` and its tests after all imports are gone.
-- [ ] Run:
+- [ ] **Step 5: Verify no Supabase verifier use remains.**
 
 ```bash
 rg -n "verifyToken|SUPABASE_ANON_KEY" packages/dtx-api/src
+bun run --filter=dtx-api test
+bun run --filter=dtx-api check
 ```
 
-Expected: no live verifier use.
-
-### Step 5: Verify and commit
-
-- [ ] Run API tests and typecheck.
-- [ ] Commit:
+- [ ] **Step 6: Commit.**
 
 ```bash
 git add packages/dtx-api/src
@@ -345,32 +363,30 @@ git commit -m "refactor(auth): resolve Better Auth sessions"
 - Delete: `packages/dtx-web/src/lib/api/auth.ts`
 - Delete: `packages/dtx-web/src/lib/api/auth.test.ts`
 - Modify/regenerate: `packages/dtx-web/src/lib/api/generated/graphql.ts`
+- Modify: `packages/dtx-web/src/lib/api/index.ts`
 - Rewrite: `packages/dtx-web/src/routes/(app)/app/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/app-page.test.ts`
 - Delete: `packages/dtx-web/src/routes/(app)/app/app-page-redirect.test.ts`
 - Modify: `packages/dtx-api/package.json`
 
-### Step 1: Change schema expectations first
+**Interfaces:**
 
-- [ ] Update schema tests to assert `generateMagicLink` no longer exists.
-- [ ] Remove `./auth` registration from `schema/index.ts`.
-- [ ] Regenerate API schema and web GraphQL output.
+- Removes the only API consumer that needs auth-user email.
+- Leaves normal `/app` dashboard and web auth guard intact for Task 5.
 
-### Step 2: Remove server magic-link code
+- [ ] **Step 1: Change schema expectations first.**
 
-- [ ] Delete the service, mutation, tests, service-role key use, callback allowlist, and magic-link-specific KV keys.
-- [ ] Remove the inline `MAGIC_LINK_HOURLY_LIMIT` local-dev override.
-- [ ] Keep `RATE_LIMIT_API` because non-auth API paths still use it.
+Assert `generateMagicLink` no longer exists, remove `./auth` schema registration, regenerate API schema/web GraphQL output.
 
-### Step 3: Remove the web handoff
+- [ ] **Step 2: Delete magic-link service/mutation/rate-limit config.**
 
-- [ ] Remove `/app?redirect=desktop`, `desktop_callback`, magic-link generation, and callback forwarding.
-- [ ] Keep the normal dashboard page.
-- [ ] Do not add Device Authorization here; Task 8 adds the dedicated approval page.
+Remove service-role key use and `MAGIC_LINK_HOURLY_LIMIT`. Keep `RATE_LIMIT_API`.
 
-### Step 4: Verify and commit
+- [ ] **Step 3: Remove `/app?redirect=desktop` page behavior.**
 
-- [ ] Run:
+Delete magic-link generation and callback handoff from the dashboard. Do not add Device Authorization here; Task 8 owns `/app/desktop-auth`.
+
+- [ ] **Step 4: Verify and commit.**
 
 ```bash
 bun run --filter=dtx-api gen-schema
@@ -381,18 +397,19 @@ bun run --filter=dtx-api check
 bun run --filter=dtx-web check
 ```
 
-- [ ] Commit all server and generated-client removals together so the branch compiles.
+Commit all removals/generated updates together.
 
 ---
 
-## Task 5: Replace SvelteKit Supabase session plumbing
+## Task 5: Replace SvelteKit Supabase session plumbing and delete desktop web exceptions
 
 **Files:**
 
 - Create: `packages/dtx-web/src/lib/auth/client.ts`
 - Create: `packages/dtx-web/src/lib/auth/session.ts`
-- Create: `packages/dtx-web/src/lib/auth/redirect.ts`
-- Create matching tests under `packages/dtx-web/src/lib/auth/`
+- Create matching tests
+- Modify: `packages/dtx-web/src/lib/auth/google.ts`
+- Modify: `packages/dtx-web/src/lib/auth/google.test.ts`
 - Rewrite: `packages/dtx-web/src/hooks.server.ts`
 - Modify: `packages/dtx-web/src/app.d.ts`
 - Rewrite: `packages/dtx-web/src/routes/+layout.server.ts`
@@ -402,37 +419,69 @@ bun run --filter=dtx-web check
 - Modify: `packages/dtx-web/src/routes/layout.test.ts`
 - Modify: `packages/dtx-web/src/routes/layout.svelte.test.ts`
 
-### Step 1: Test session loading and guards
+**Interfaces:**
 
-- [ ] Add tests for anonymous/authenticated API session responses, forwarded cookies, propagated `Set-Cookie`, protected `/app` redirects, safe `next`, login-page redirect, and API failure.
-- [ ] Preserve the current allowlist semantics: return only to `/app` paths.
+- Reuses `safeAppRedirectPath()` and auth error strings in existing `google.ts`.
+- Produces `authClient` for Tasks 6/8.
+- Produces neutral `event.locals.user/session` and raw multi-cookie propagation.
 
-### Step 2: Add a neutral web auth client
+- [ ] **Step 1: Extend existing redirect/helper tests.**
 
-- [ ] Create the Better Auth Svelte client pointed at `PUBLIC_DTX_API_URL`.
-- [ ] Set `credentials: "include"`.
-- [ ] Register `deviceAuthorizationClient()` for Task 8.
+Keep `safeAppRedirectPath()` semantics and current sanitized Google/linking messages. Do **not** create `$lib/auth/redirect.ts`.
 
-### Step 3: Rewrite the server hook
+Delete only Supabase-specific callback URL builders/desktop redirect intent once no callers remain.
 
-- [ ] Remove `createServerClient`, `safeGetSession`, and Supabase locals.
-- [ ] Forward the incoming `Cookie` header to `/api/auth/get-session`.
-- [ ] Propagate all Better Auth `Set-Cookie` headers.
-- [ ] Populate neutral `event.locals.user` and `event.locals.session`.
-- [ ] Keep CSRF protection for SvelteKit form endpoints and the existing `/app` guard.
+- [ ] **Step 2: Add failing hook/session tests.**
 
-### Step 4: Simplify root layout data
+Cover:
 
-- [ ] Stop constructing browser/server Supabase clients.
-- [ ] Return only neutral session/user data plus existing locale data.
-- [ ] Remove `supabase:auth` invalidation and auth-state subscription.
+- anonymous/authenticated get-session;
+- incoming Cookie forwarding;
+- two returned Set-Cookie headers propagated separately;
+- protected `/app` redirect with safe `next`;
+- authenticated `/login` redirect;
+- API failure;
+- no `redirect=desktop`/`desktop_callback` branch;
+- no `DTXDesktopApp` CSRF bypass.
 
-### Step 5: Verify and commit
+- [ ] **Step 3: Create Better Auth Svelte client.**
 
-- [ ] Run focused layout/hook tests and `bun run --filter=dtx-web check`.
-- [ ] Commit:
+Point it at `PUBLIC_DTX_API_URL`, set `credentials: 'include'`, and register `deviceAuthorizationClient()`.
+
+- [ ] **Step 4: Rewrite the server hook.**
+
+The hook:
+
+1. forwards `Cookie` to `/api/auth/get-session`;
+2. reads all returned Set-Cookie values with the Workers multi-cookie API;
+3. sets neutral locals from the response body;
+4. calls `resolve(event)`;
+5. appends each raw Set-Cookie value to the outgoing SvelteKit response.
+
+Do not parse/rebuild Better Auth cookies.
+
+- [ ] **Step 5: Delete desktop-specific hook logic.**
+
+Remove:
+
+```text
+redirect=desktop
+desktop_callback
+DTXDesktopApp form-CSRF bypass
+```
+
+Keep normal same-origin SvelteKit form-CSRF protection and the `/app` guard.
+
+- [ ] **Step 6: Simplify root layout.**
+
+Stop constructing Supabase browser/server clients and remove `supabase:auth` invalidation/subscriptions. Return only neutral user/session plus existing locale data.
+
+- [ ] **Step 7: Verify and commit.**
 
 ```bash
+bun run --filter=dtx-web test -- src/lib/auth src/routes/layout.server.test.ts src/routes/layout.test.ts src/routes/layout.svelte.test.ts
+bun run --filter=dtx-web check
+
 git add packages/dtx-web/src/hooks.server.ts packages/dtx-web/src/app.d.ts \
   packages/dtx-web/src/lib/auth packages/dtx-web/src/routes/+layout*
 git commit -m "refactor(auth): load Better Auth web sessions"
@@ -444,75 +493,151 @@ git commit -m "refactor(auth): load Better Auth web sessions"
 
 **Files:**
 
+- Modify: `packages/dtx-web/src/lib/auth/google.ts`
+- Modify: `packages/dtx-web/src/lib/auth/google.test.ts`
 - Rewrite: `packages/dtx-web/src/routes/(login)/login/+page.svelte`
 - Delete/replace: `packages/dtx-web/src/routes/(login)/login/+page.server.ts`
-- Modify: `packages/dtx-web/src/routes/(login)/login/page.server.test.ts`
+- Retarget: `packages/dtx-web/src/routes/(login)/login/page.server.test.ts`
 - Delete: `packages/dtx-web/src/routes/auth/callback/+server.ts`
-- Delete: `packages/dtx-web/src/routes/auth/callback/server.test.ts`
+- Retarget/delete after migration: `packages/dtx-web/src/routes/auth/callback/server.test.ts`
 - Modify: `packages/dtx-web/src/routes/(app)/+layout.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/layout.svelte.test.ts`
 - Rewrite: `packages/dtx-web/src/routes/(app)/app/account/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts`
 
-### Step 1: Add failing login/account tests
+**Interfaces:**
 
-- [ ] Cover password success/failure, safe `next`, Google redirect, `account_not_linked`, logout, linked-method listing, explicit Google linking, and no signup UI.
+- Consumes `authClient` and retained `safeAppRedirectPath()`/sanitized messages.
+- Removes the custom SvelteKit OAuth callback route without losing its reusable test cases.
 
-### Step 2: Implement password sign-in
+- [ ] **Step 1: Move existing callback assertions before deletion.**
 
-- [ ] Use `authClient.signIn.email({ email, password })`.
-- [ ] Perform a full browser navigation to the validated `/app` destination after success.
-- [ ] Keep provider errors sanitized.
+Retarget cases from `auth/callback/server.test.ts` and `login/page.server.test.ts` into `google.test.ts`, login tests, and account tests as appropriate:
 
-### Step 3: Implement Google sign-in and explicit linking
+- safe return paths;
+- external/protocol-relative rejection;
+- provider cancel/failure sanitization;
+- existing-account-only Google copy;
+- explicit-link conflict copy.
 
-- [ ] Use `authClient.signIn.social` for login and `authClient.linkSocial` from the authenticated account page.
-- [ ] Set callback URLs to validated application routes.
-- [ ] Delete the SvelteKit OAuth callback route; Better Auth's API callback is authoritative.
-- [ ] Do not permit implicit same-email linking.
+- [ ] **Step 2: Implement password sign-in.**
 
-### Step 4: Implement logout
+Use:
 
-- [ ] Call `authClient.signOut()` and navigate to `/login`.
-- [ ] Remove Supabase identity/session assumptions from layout and account UI.
+```ts
+await authClient.signIn.email({ email, password });
+window.location.assign(safeAppRedirectPath(next));
+```
 
-### Step 5: Verify and commit
+Preserve `/app` as the missing-`next` default in the login flow.
 
-- [ ] Run web unit tests and typecheck.
-- [ ] Commit the complete web auth action migration.
+- [ ] **Step 3: Implement Google sign-in/linking.**
+
+Use `authClient.signIn.social({ provider: 'google', callbackURL })` for login and `authClient.linkSocial({ provider: 'google', callbackURL })` from the account page.
+
+Keep `account_not_linked` mapped to the existing existing-account-only message. Do not permit implicit same-email linking.
+
+- [ ] **Step 4: Delete SvelteKit OAuth callback.**
+
+Better Auth `/api/auth/callback/google` is authoritative. Delete old URL builders from `google.ts` only after caller/test migration.
+
+- [ ] **Step 5: Implement logout.**
+
+Call `authClient.signOut()` then full-navigate to `/login`. Remove Supabase identity/session assumptions from app/account UI.
+
+- [ ] **Step 6: Verify and commit.**
+
+Run focused web auth tests, full web unit suite, and typecheck. Commit the complete web auth action migration.
 
 ---
 
-## Task 7: Authenticate browser API traffic with cookies
+## Task 7: Convert **every** web API call from Bearer to cookies
 
 **Files:**
 
 - Modify: `packages/dtx-web/src/lib/api/transport.ts`
+- Modify: `packages/dtx-web/src/lib/api/transport.test.ts`
 - Modify: `packages/dtx-web/src/lib/api/client.ts`
-- Modify matching tests
-- Delete: `packages/dtx-web/src/lib/api/token.ts`
-- Delete: `packages/dtx-web/src/lib/api/token.test.ts`
+- Modify: `packages/dtx-web/src/lib/api/client.test.ts`
+- Modify: `packages/dtx-web/src/lib/api/download.ts`
+- Modify: `packages/dtx-web/src/lib/api/download.test.ts`
+- Modify: `packages/dtx-web/src/lib/api/index.test.ts`
+- Modify token-mocking tests including:
+  - `packages/dtx-web/src/lib/api/chart.test.ts`
+  - `packages/dtx-web/src/lib/api/score.test.ts`
+  - `packages/dtx-web/src/lib/api/user.test.ts`
+- Modify affected component tests consuming `bulkDownloadHeaders`
+- Delete only at the end: `packages/dtx-web/src/lib/api/token.ts`
+- Delete only at the end: `packages/dtx-web/src/lib/api/token.test.ts`
 
-### Step 1: Add transport tests
+**Interfaces:**
 
-- [ ] Browser GraphQL sets `credentials: "include"` and no Authorization header.
-- [ ] Service-binding GraphQL forwards the incoming Cookie header.
-- [ ] Anonymous requests remain anonymous.
-- [ ] Existing GraphQL error mapping remains unchanged.
+- Browser fetches use `credentials: 'include'` and no Authorization.
+- Service-binding SSR uses `{ cookieHeader, origin }`, not `accessToken`.
+- Desktop remains Bearer and is not part of this web transport task.
 
-### Step 2: Rewrite only the transport seam
+- [ ] **Step 1: Add failing browser GraphQL tests.**
 
-- [ ] Keep generated GraphQL operations and feature wrappers unchanged.
-- [ ] Remove token lookup/injection.
-- [ ] Do not introduce a proxy route solely to make auth same-origin.
+Assert GraphQL client uses credentials and no Authorization header.
 
-### Step 3: Verify and commit
+- [ ] **Step 2: Replace token-shaped `ClientCtx`.**
 
-- [ ] Run API client tests, web tests, and typecheck.
-- [ ] Commit:
+Use:
+
+```ts
+export type ClientCtx = {
+  fetch?: typeof fetch;
+  platform?: App.Platform;
+  cookieHeader?: string | null;
+  origin?: string | null;
+};
+```
+
+Delete `accessToken` from web client context.
+
+- [ ] **Step 3: Rewrite service-binding GraphQL.**
+
+Forward:
+
+```text
+content-type: application/json
+cookie: <incoming cookie>
+origin: <trusted SvelteKit event.url.origin>
+```
+
+The explicit Origin is required because GraphQL POST is an unsafe cookie-authenticated method and Task 3 enforces the same origin policy on service-binding requests.
+
+- [ ] **Step 4: Rewrite download helpers.**
+
+`downloadSimfile()` fetches with:
+
+```ts
+{ credentials: 'include' }
+```
+
+`bulkDownloadHeaders()` returns only the content-type header; the actual bulk fetch also sets `credentials: 'include'`.
+
+Update the component/helper call site that performs the bulk fetch, not just the header builder.
+
+- [ ] **Step 5: Remove every token mock/import.**
 
 ```bash
-git add packages/dtx-web/src/lib/api
+rg -n "getAccessTokenOrNull|getAccessToken|tokenFromSession|from './token'|mock.*token" packages/dtx-web/src
+```
+
+Expected before deletion: zero live call sites outside `token.ts`/its test.
+
+- [ ] **Step 6: Delete `token.ts` only after Step 5 is clean.**
+
+This ordering keeps the commit compiling.
+
+- [ ] **Step 7: Verify and commit.**
+
+```bash
+bun run --filter=dtx-web test
+bun run --filter=dtx-web check
+
+git add packages/dtx-web/src/lib/api packages/dtx-web/src/lib/components packages/dtx-web/src/routes
 git commit -m "refactor(auth): use cookie-authenticated web API"
 ```
 
@@ -527,37 +652,30 @@ git commit -m "refactor(auth): use cookie-authenticated web API"
 - Modify: `packages/dtx-web/src/lib/auth/client.ts`
 - Modify: `packages/dtx-web/src/routes/layout.test.ts`
 
-### Step 1: Add failing UI tests
+**Interfaces:**
 
-- [ ] Cover prefilled/manual code, formatting, claim success, invalid/expired code, approve, deny, double-submit prevention, and unauthenticated return-through-login.
+- Consumes authenticated Better Auth web session and `deviceAuthorizationClient()`.
+- Produces browser claim/approve/deny path for native Task 9.
 
-### Step 2: Implement the claim step
+- [ ] **Step 1: Add failing approval-page tests.**
 
-- [ ] Normalize the user code by trimming, removing dashes, and uppercasing.
-- [ ] Call Better Auth's Device Authorization verification method before showing approval controls.
-- [ ] Rely on the `/app` guard to require an authenticated browser session and preserve the page URL as `next`.
+Cover prefilled/manual code, normalization, claim success, invalid/expired code, approve, deny, double-submit prevention, and unauthenticated return-through-login.
 
-### Step 3: Implement explicit approve/deny
+- [ ] **Step 2: Implement code claim.**
 
-- [ ] Display the code and fixed `dtx-desktop` client identity.
-- [ ] Require an explicit button action.
-- [ ] Disable both actions while one is in flight.
-- [ ] Show terminal success/denial text instead of redirecting to a desktop callback.
+Normalize with trim/remove dashes/uppercase, then call Better Auth's device verification method. Rely on `/app` guard and its validated `next` return.
 
-### Step 4: Verify and commit
+- [ ] **Step 3: Implement explicit Approve/Deny.**
 
-- [ ] Run the page and layout tests plus web typecheck.
-- [ ] Commit:
+Show user code and fixed `dtx-desktop` client identity. Disable actions while one request is in flight. Show terminal success/denial text; never redirect to a desktop callback.
 
-```bash
-git add "packages/dtx-web/src/routes/(app)/app/desktop-auth" \
-  packages/dtx-web/src/lib/auth/client.ts
-git commit -m "feat(auth): add desktop device approval"
-```
+- [ ] **Step 4: Verify and commit.**
+
+Run page/layout tests plus web typecheck and commit the new route.
 
 ---
 
-## Task 9: Replace native refresh/deep-link auth with Device Authorization
+## Task 9: Replace native Supabase auth with Device Authorization
 
 **Files:**
 
@@ -572,31 +690,36 @@ git commit -m "feat(auth): add desktop device approval"
 - Modify: `packages/dtx-desktop/src-tauri/Cargo.toml`
 - Regenerate: `packages/dtx-desktop/src/renderer/src/lib/generated/native-api-contracts.ts`
 
-### Step 1: Add protocol tests with WireMock
+**Interfaces:**
 
-- [ ] Cover code request, display-safe response, pending, slow-down, approval, denial, expiry, invalid grant, malformed responses, timeout, and network failure.
-- [ ] Use paused Tokio time where practical.
-- [ ] Confirm `device_code` never crosses the Tauri command boundary.
+- `device_auth.rs` is HTTP protocol only and WireMock-testable.
+- `auth.rs` retains `AuthState`, session generation/epoch, and existing command names.
+- `validate_session` retains `SessionValidationStatus`.
 
-### Step 2: Implement a protocol-only module
+- [ ] **Step 1: Add WireMock protocol tests.**
 
-- [ ] Keep `device_auth.rs` independent of Tauri UI APIs.
-- [ ] Use Better Auth 1.6.25's exact wire field names.
-- [ ] Centralize API base URL construction.
-- [ ] Never log device codes or session tokens.
+Cover code request, display-safe response, pending, slow-down, approval, denial, expiry, invalid grant, malformed body, timeout, and network failure. Confirm `device_code` never crosses Tauri IPC.
 
-### Step 3: Replace `AuthState` with typed state
+- [ ] **Step 2: Implement protocol-only `device_auth.rs`.**
 
-- [ ] Define renderer-facing `DesktopAuthUser`, `DesktopAuthSession`, and `DeviceAuthorizationAttempt` in `api_contracts.rs` and derive `TS`.
-- [ ] Reuse the existing export target `../../src/renderer/src/lib/generated/native-api-contracts.ts`.
-- [ ] Include `userCode`, `verificationUri`, `verificationUriComplete`, and `expiresAt` in the attempt.
-- [ ] Keep one pending opaque device code in native memory.
-- [ ] Preserve authenticated user ID, session generation, and session epoch used by Google Drive reconciliation.
-- [ ] Prevent stale polls from committing after cancel/restart.
+Use Better Auth 1.6.25 wire names exactly, centralize API-base construction, and never log device/session tokens.
 
-### Step 4: Implement native commands
+- [ ] **Step 3: Define native DTOs in `api_contracts.rs`.**
 
-- [ ] Add:
+Add `DesktopAuthUser`, `DesktopAuthSession`, and `DeviceAuthorizationAttempt` with `TS` export. Attempt exposes only:
+
+```text
+userCode
+verificationUri
+verificationUriComplete
+expiresAt
+```
+
+- [ ] **Step 4: Preserve `AuthState` identity/epoch semantics.**
+
+Keep authenticated user ID, generation counter, and `AuthSessionEpoch` so Google Drive reconciliation does not regress. Replace Supabase JSON/refresh state with typed opaque session state and one pending native device code.
+
+- [ ] **Step 5: Add Device Authorization commands.**
 
 ```text
 begin_device_authorization
@@ -604,7 +727,7 @@ poll_device_authorization
 cancel_device_authorization
 ```
 
-- [ ] Preserve and retarget existing names:
+Retarget without renaming:
 
 ```text
 validate_session
@@ -613,27 +736,34 @@ logout_session
 open_external_url
 ```
 
-- [ ] `begin_device_authorization` requests/stores codes and returns display-safe data only.
-- [ ] The renderer, not the protocol module, calls `open_external_url(verificationUriComplete)`.
-- [ ] `poll_device_authorization` owns polling, handles pending/slow-down, fetches `/api/auth/get-session` after approval, and returns `DesktopAuthSession`.
-- [ ] `validate_session` calls `/api/auth/get-session` with Bearer auth and never decodes JWTs.
-- [ ] `logout_session` posts to `/api/auth/sign-out`, always clears native state, and reports whether revocation succeeded.
+- [ ] **Step 6: Preserve `SessionValidationStatus`.**
 
-### Step 5: Replace API token access
+Keep:
 
-- [ ] Rename `ensure_valid_access_token` to `current_session_token`.
-- [ ] Remove expiry parsing, refresh calls, and refresh locks.
-- [ ] Keep existing `Authorization: Bearer` request code, now with the opaque Better Auth session token.
+```rust
+Valid
+Invalid
+NotConfigured
+```
 
-### Step 6: Remove auth callback machinery
+Behavior:
 
-- [ ] Delete magic-link parsing, auth deep-link handlers/queues, loopback TCP server, callback parser, JWT parsing, Supabase refresh/logout endpoints, and auth events.
-- [ ] Remove `tauri-plugin-deep-link` only after no non-test use remains.
-- [ ] Keep `tauri-plugin-single-instance` for window focusing but remove auth URL extraction.
+- missing/blank desktop API config => `NotConfigured`;
+- `/api/auth/get-session` returns authenticated user => `Valid`;
+- 401/no session => `Invalid`;
+- network/5xx remains fail-closed and is **not** mislabeled as local configuration absence.
 
-### Step 7: Verify generated bindings and Rust
+Do not introduce Better Auth server secret into desktop config.
 
-- [ ] Run:
+- [ ] **Step 7: Replace API token access.**
+
+Rename `ensure_valid_access_token` to `current_session_token`. Remove JWT expiry parsing, refresh calls, refresh lock, and refresh events. Existing API code continues sending `Authorization: Bearer <opaque-session-token>`.
+
+- [ ] **Step 8: Remove callback machinery.**
+
+Delete auth deep-link handlers/queues, loopback TCP server, magic-link parsing, callback validation, Supabase verify/refresh/logout code, JWT decoder, and auth events. Preserve `tauri-plugin-single-instance` for normal window behavior. Remove deep-link plugin only after repository search proves no non-auth use.
+
+- [ ] **Step 9: Verify and commit.**
 
 ```bash
 cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml
@@ -643,11 +773,11 @@ cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml \
 bun run gen:native-types
 ```
 
-- [ ] Commit native changes and generated TypeScript together.
+Commit Rust and generated TypeScript together.
 
 ---
 
-## Task 10: Rewire the desktop renderer and remove callback configuration
+## Task 10: Rewire desktop renderer persistence/lifecycle
 
 **Files:**
 
@@ -666,28 +796,40 @@ bun run gen:native-types
 - Modify: root `package.json`
 - Modify: `packages/dtx-desktop/src/devTopology.test.ts`
 
-### Step 1: Add renderer lifecycle tests
+**Interfaces:**
 
-- [ ] Cover start, displayed code, browser open, poll success, one-token persistence, restore, invalid restore cleanup, logout cleanup, cancellation, retry, and browser-open failure fallback.
-- [ ] Remove assumptions about refresh tokens, JWT expiry, magic links, or session-refresh events.
+- Consumes generated Task 9 DTOs/commands.
+- Persists one `{ sessionToken, user }` value.
+- Keeps renderer restore behavior aware of `not-configured`.
 
-### Step 2: Replace Supabase-shaped persistence
+- [ ] **Step 1: Add lifecycle tests.**
 
-- [ ] Store only `{ sessionToken, user }` under one neutral key.
-- [ ] Validate stored shape and clear malformed values.
-- [ ] Do not migrate old Supabase local-storage values; delete them when encountered.
+Cover start, displayed code, browser open, poll success, persistence, restore valid, restore invalid cleanup, restore not-configured preserving storage, logout cleanup, cancel/retry, and browser-open fallback.
 
-### Step 3: Rewrite the renderer service
+- [ ] **Step 2: Replace Supabase-shaped persistence.**
 
-- [ ] Use generated native commands/types.
-- [ ] After `beginDeviceAuthorization`, call the existing `openExternalUrl(attempt.verificationUriComplete)` and then poll.
-- [ ] Show `verificationUri` and `userCode` when browser opening fails.
-- [ ] Keep one `idle | waiting | authenticated | error` state model.
-- [ ] Remove `magic-link-result` and `session-refreshed` listeners.
+Store one neutral object:
 
-### Step 4: Remove callback/deep-link configuration
+```ts
+{
+  sessionToken: string;
+  user: DesktopAuthUser;
+}
+```
 
-- [ ] Remove:
+Delete old Supabase access/refresh local-storage keys when encountered; do not migrate them.
+
+- [ ] **Step 3: Rewrite renderer auth service.**
+
+After `beginDeviceAuthorization`, open `verificationUriComplete`, show manual URI/code fallback, and poll. Remove magic-link/session-refreshed listeners.
+
+- [ ] **Step 4: Keep tri-state restore behavior.**
+
+If native returns `not-configured`, show the build/configuration error and **do not wipe the stored Better Auth session**. If `invalid`, clear it.
+
+- [ ] **Step 5: Remove callback/deep-link configuration.**
+
+Remove:
 
 ```text
 DTX_DESKTOP_AUTH_CALLBACK_PORT
@@ -695,23 +837,15 @@ VITE_DTX_DESKTOP_AUTH_CALLBACK_PORT
 PUBLIC_DTX_DESKTOP_AUTH_CALLBACK_URL
 ```
 
-- [ ] Remove auth URI scheme registration only after repository search confirms no non-auth use.
-- [ ] Simplify `dev`, `dev:local-web`, and root dev scripts.
-- [ ] Update topology tests to assert API/web URLs only.
+Simplify dev scripts/topology tests. Remove auth URI schemes only after no non-auth use remains.
 
-### Step 5: Verify and commit
+- [ ] **Step 6: Verify and commit.**
 
-- [ ] Run desktop renderer tests, Svelte typecheck, Rust tests, and `bun run gen:native-types`.
-- [ ] Commit:
-
-```bash
-git add packages/dtx-desktop package.json
-git commit -m "refactor(auth): rewire desktop session lifecycle"
-```
+Run renderer tests, typecheck, Rust tests, and native type generation; commit desktop renderer/config changes together.
 
 ---
 
-## Task 11: Add a one-shot identity import and local Better Auth E2E user
+## Task 11: Add ID-preserving identity import and Better Auth E2E seed
 
 **Files:**
 
@@ -728,42 +862,43 @@ git commit -m "refactor(auth): rewire desktop session lifecycle"
 - Modify: `packages/e2e-web/package.json`
 - Modify: `.gitignore`
 
-### Step 1: Specify import invariants in tests
+**Interfaces:**
 
-- [ ] Preserve user UUIDs exactly.
-- [ ] Map email/name/verified/timestamps and Google identity.
-- [ ] Reject duplicate email/ID and unsupported providers.
-- [ ] Import no session/access/refresh token.
-- [ ] Emit deterministic account IDs and safely escaped SQL.
-- [ ] Fail when any application owner ID lacks an imported Better Auth user.
+- Produces reviewed SQL only under ignored `tmp/auth-migration/`.
+- Seeds the fixed E2E UUID into the same D1 that `prepare-stack.ts` already migrates.
 
-### Step 2: Implement local-only import tooling
+- [ ] **Step 1: Specify import invariants in tests.**
 
-- [ ] Consume a sanitized Supabase Admin export JSON file.
-- [ ] Write only to `tmp/auth-migration/`.
-- [ ] Produce reviewed SQL for D1; do not write directly to production.
-- [ ] Do not import or depend on `@supabase/supabase-js`.
-- [ ] Hash replacement credential passwords with Better Auth's password helper.
-- [ ] Require explicit replacement password input for credential users; do not add bcrypt compatibility.
+Assert exact UUID preservation, email/name/verification/timestamps, Google identity mapping, no sessions/tokens, deterministic account IDs, SQL escaping, duplicate rejection, unsupported-provider rejection, and owner-ID reconciliation.
 
-### Step 3: Seed local E2E auth in D1
+- [ ] **Step 2: Implement local-only import tool.**
 
-- [ ] Replace Supabase E2E variables with Better Auth secret, fixed test user ID/email/password, API URL, and web URL.
-- [ ] Seed Better Auth user/account rows into the same local D1 state prepared by `prepare-stack.ts`.
-- [ ] Preserve the fixed test UUID used by application seed rows.
-- [ ] Keep CI fail-loud behavior when auth E2E inputs are incomplete.
+Consume sanitized Supabase Admin export JSON and emit D1 SQL; do not import `@supabase/supabase-js` and do not write directly to remote D1.
 
-### Step 4: Verify and commit
+- [ ] **Step 3: Handle credential users without bcrypt compatibility.**
 
-- [ ] Run import tests, local stack preparation, Playwright setup, API tests, and E2E typecheck.
-- [ ] Commit migration tooling without generated real-user SQL or secrets.
+Require explicit replacement password input and hash it with Better Auth's password helper. No replacement password means no credential account is generated.
+
+- [ ] **Step 4: Seed local Better Auth auth rows.**
+
+Replace `create-local-supabase-user.ts` with D1 seeding after `prepare-stack.ts` applies all `d1-migrations/*.sql`. Preserve the existing fixed test UUID used by application seed rows.
+
+- [ ] **Step 5: Retarget Playwright env/setup.**
+
+Remove Supabase E2E URL/anon/service-role inputs. Keep fail-loud CI behavior for incomplete Better Auth test credentials/config.
+
+- [ ] **Step 6: Verify and commit.**
+
+Run import tests, local stack preparation, Playwright setup, and E2E typecheck. Commit no real-user export/SQL/secrets.
 
 ---
 
-## Task 12: Remove all remaining Supabase runtime and configuration residue
+## Task 12: Remove all Supabase residue and obsolete typegen
 
 **Files:**
 
+- Modify: root `package.json`
+- Modify: `turbo.json`
 - Modify: `packages/dtx-api/package.json`
 - Modify: `packages/dtx-web/package.json`
 - Modify: `packages/dtx-desktop/package.json`
@@ -775,112 +910,138 @@ git commit -m "refactor(auth): rewire desktop session lifecycle"
 - Modify: `packages/dtx-web/vitest.config.ts`
 - Modify: `packages/dtx-desktop/vitest.config.ts`
 - Modify: `.env.example`
-- Modify: `turbo.json`
-- Modify affected mocks and tests
+- Modify affected mocks/tests/workflows
 - Modify: `CLAUDE.md`
 
-### Step 1: Add a residue gate
+**Interfaces:**
 
-- [ ] Search active code/config for:
+- Deletes the root/turbo Supabase `gen-types` task so Task 14 does not call it.
+- Leaves GraphQL codegen and `gen:native-types` intact.
+
+- [ ] **Step 1: Add/run a residue gate.**
 
 ```bash
 rg -n -i "@supabase|supabase|PUBLIC_SUPABASE|SUPABASE_" \
-  packages package.json turbo.json .env.example CLAUDE.md __mocks__
+  packages package.json turbo.json .env.example CLAUDE.md __mocks__ .github
 ```
 
-- [ ] Exclude only historical migration documents and the named one-shot import tool/tests.
-- [ ] The import tool may mention Supabase as an input format but must not import a Supabase package.
+Exclude only historical docs and the named one-shot import tool/tests where “Supabase” describes the input format.
 
-### Step 2: Remove packages and types
+- [ ] **Step 2: Remove packages/types/mocks.**
 
-- [ ] Remove `@supabase/ssr` and `@supabase/supabase-js` from all packages.
-- [ ] Remove the common peer dependency.
-- [ ] Delete generated Supabase database types and exports.
-- [ ] Replace Supabase mocks with neutral auth fixtures.
+Remove `@supabase/ssr`, `@supabase/supabase-js`, the common peer dependency, generated Supabase types/exports, and Supabase-specific mocks.
 
-### Step 3: Remove environment/config residue
+- [ ] **Step 3: Remove environment/workflow residue.**
 
-- [ ] Remove Supabase URL, anon key, service-role key, callback allowlist, and magic-link-limit variables from env types, Wrangler config, Vite/Vitest setup, Turbo env lists, docs, and workflows.
-- [ ] Keep unrelated D1/R2/KV/Google Drive settings.
+Delete Supabase URL/anon/service-role variables, magic-link limit, callback variables, Turbo env entries, and old E2E secret requirements.
 
-### Step 4: Verify and commit
+- [ ] **Step 4: Delete obsolete root typegen.**
 
-- [ ] Run the residue gate, install lockfile check, all package typechecks, and unit tests.
-- [ ] Commit:
+Remove:
 
-```bash
-git add .
-git commit -m "chore(auth): remove Supabase dependencies"
+```text
+package.json scripts.gen-types
+turbo.json tasks.gen-types
 ```
+
+because that task exists only to generate `packages/common/src/lib/types/supabase.types.ts`, which this task deletes.
+
+Keep:
+
+```text
+packages/dtx-api gen-schema
+dtx-web codegen
+root gen:native-types
+```
+
+- [ ] **Step 5: Verify and commit.**
+
+Run residue gate, lockfile/install check, package typechecks, and unit tests, then commit the cleanup.
 
 ---
 
-## Task 13: Cover cutover flows and reconcile Zero Trust documentation
+## Task 13: Add E2E coverage and write the production cutover runbook
 
 **Files:**
 
 - Modify/create authenticated specs under `packages/e2e-web/`
 - Modify/create desktop auth specs under `packages/e2e-desktop/`
 - Create: `docs/superpowers/runbooks/2026-08-18-better-auth-d1-cutover.md`
-- After PR #221 merges, modify:
+- After PR #221 lands, modify:
   - `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
   - `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
   - `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
 
-### Step 1: Update web E2E
+**Interfaces:**
 
-- [ ] Remove Supabase setup/secrets.
-- [ ] Cover password login, protected navigation, authenticated GraphQL/score flow, logout, and invalid-session redirect.
-- [ ] Keep Google provider behavior in integration/unit tests unless a controlled Google test identity is configured.
+- Produces automated end-to-end proof for Task 14.
+- Production runbook owns production import/deploy/rollback; Task 14 does not execute them.
 
-### Step 2: Add Device Authorization integration coverage
+- [ ] **Step 1: Update web E2E.**
 
-- [ ] Against local API/D1, request a device code, claim it with an authenticated browser session, approve it, poll for the token, validate the user, and revoke it.
-- [ ] Cover deny and expiry.
-- [ ] Do not reproduce Better Auth internals in test-only endpoints.
+Cover password login, `/app` guard, authenticated GraphQL/score flow, authenticated download, logout, and invalid-session redirect without Supabase credentials.
 
-### Step 3: Update desktop E2E
+- [ ] **Step 2: Add Device Authorization integration E2E.**
 
-- [ ] Cover renderer state and authenticated desktop behavior using a Better Auth session seeded through supported auth/D1 setup.
-- [ ] Keep one manual bundled desktop browser-handoff check in the runbook because OS browser launch is outside stable WDIO coverage.
-- [ ] Do not restore loopback/deep-link test hooks.
+Against local API/D1: request code, authenticate browser, claim, approve, poll, validate user, revoke. Cover deny and expiry. Do not add test-only auth endpoints.
 
-### Step 4: Write the cutover runbook
+- [ ] **Step 3: Update desktop E2E.**
 
-- [ ] Include exact sections for prerequisites, pinned versions, Google callbacks, Wrangler secrets, Supabase Admin export, import/reconciliation, D1 migration, deployment order, web matrix, desktop matrix, ownership queries, go/no-go, production cutover, Supabase-disable proof, and rollback.
-- [ ] Rollback redeploys previous API/web/desktop versions and leaves additive Better Auth tables in place.
+Cover renderer state and authenticated desktop behavior using supported Better Auth/D1 setup. Keep one manual real-browser-open handoff check in the runbook because OS browser launching is outside stable WDIO coverage.
 
-### Step 5: Reconcile PR #221
+- [ ] **Step 4: Write the runbook.**
 
-- [ ] Rebase onto current `main` after PR #221 lands.
-- [ ] Replace Supabase as the inner gate with Better Auth.
-- [ ] Replace `/login?redirect=desktop` and callback verification with `/app/desktop-auth` and Device Authorization.
-- [ ] Preserve production `/app` operator-only policy, pre-production web Access protection, and public API hostnames.
+Include exact sections for:
 
-### Step 6: Verify and commit
+1. backup/export prerequisites;
+2. pinned versions;
+3. Google callbacks;
+4. Wrangler secrets;
+5. Supabase Admin export;
+6. generated import SQL review;
+7. D1 migration/import order;
+8. owner-ID reconciliation queries;
+9. deployment order;
+10. web matrix;
+11. desktop matrix;
+12. Cloudflare Access matrix;
+13. go/no-go;
+14. production cutover;
+15. Supabase-disable proof;
+16. rollback.
 
-- [ ] Run both E2E suites, formatting, and `git diff --check`.
-- [ ] Commit tests and runbook together.
+Production actions are instructions for an operator, not automated steps in this implementation plan.
+
+- [ ] **Step 5: Reconcile PR #221 documentation.**
+
+Replace Supabase as the inner gate, replace `/login?redirect=desktop`/callbacks with `/app/desktop-auth`/Device Authorization, keep production `/app` operator-only, keep pre-prod Access behavior, keep API hostnames outside Access.
+
+- [ ] **Step 6: Verify and commit.**
+
+Run both E2E suites, formatting, and `git diff --check`; commit tests/runbook/docs together.
 
 ---
 
-## Task 14: Run full verification and execute the atomic cutover
+## Task 14: Full verification and pre-production proof
 
 **Files:**
 
 - Modify only files required by failed verification.
-- Update the cutover runbook with corrected non-secret assumptions/results.
+- Update the runbook with corrected **non-secret** assumptions/results.
 
-### Step 1: Run static and unit verification
+**Interfaces:**
 
-- [ ] Run:
+- Final code-PR gate.
+- Stops after pre-production proof and a production-ready runbook.
+- Does **not** execute production D1 import/deploy or remove production Supabase credentials.
+
+- [ ] **Step 1: Run static/unit/Rust verification.**
 
 ```bash
 bun run format
 bun run lint
 bun run check
 bun run test
-bun run gen-types
 git diff --check
 cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml --check
 cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml
@@ -888,9 +1049,9 @@ cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml \
   --all-targets --all-features -- -D warnings
 ```
 
-### Step 2: Run generated-artifact and residue gates
+Do **not** run the deleted root `gen-types` Supabase task.
 
-- [ ] Run:
+- [ ] **Step 2: Run generated-artifact gates.**
 
 ```bash
 bun run --filter=dtx-api auth:schema:check
@@ -900,11 +1061,19 @@ bun run gen:native-types
 git diff --exit-code
 ```
 
-- [ ] Confirm no live Supabase or desktop callback protocol remains.
+- [ ] **Step 3: Run residue gates.**
 
-### Step 3: Run E2E
+Confirm:
 
-- [ ] Run:
+```text
+no runtime Supabase imports/config
+no getAccessTokenOrNull/token.ts seam
+no desktop auth callback variables
+no auth deep-link/loopback/JWT/refresh code
+no root/turbo Supabase gen-types task
+```
+
+- [ ] **Step 4: Run E2E.**
 
 ```bash
 bun run e2e:web
@@ -913,55 +1082,54 @@ bun run e2e:desktop
 
 Expected: PASS without Supabase credentials.
 
-### Step 4: Prepare pre-production
+- [ ] **Step 5: Prepare and prove pre-production only.**
 
-- [ ] Set `BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` with Wrangler secrets.
-- [ ] Configure the exact pre-production Google callback from the runbook.
-- [ ] Apply D1 migrations.
-- [ ] Generate/review/apply sanitized identity-import SQL.
-- [ ] Fail rollout if any distinct application owner ID lacks a Better Auth user.
+Using the runbook:
 
-### Step 5: Deploy and prove pre-production
+- configure pre-prod Better Auth/Google secrets and callback;
+- apply D1 migrations;
+- generate/review/apply sanitized identity-import SQL to pre-prod;
+- reconcile every application owner ID;
+- deploy API then web;
+- build desktop candidate pointed at pre-prod;
+- execute password, Google, linking, GraphQL, upload/download, Device Authorization approve/deny/expiry, restore/logout, and Access checks;
+- confirm API auth endpoints remain outside Access and `/app/desktop-auth` remains protected;
+- confirm the candidate no longer needs Supabase at runtime.
 
-- [ ] Deploy API first, then web.
-- [ ] Build a desktop candidate pointed at pre-production.
-- [ ] Execute password, Google, explicit linking, GraphQL, upload/download, device approve/deny/expiry, restore/logout, and Access-gate checks.
-- [ ] Confirm API auth endpoints are outside Access and `/app/desktop-auth` is protected.
-- [ ] Confirm Supabase can be unreachable without breaking the candidate.
+- [ ] **Step 6: Record pre-prod evidence and production go/no-go criteria.**
 
-### Step 6: Production go/no-go
+Record only non-secret outcomes in the runbook. Production go/no-go requires all automated/pre-prod checks, exact owner reconciliation, configured callbacks/secrets, and rollback artifacts.
 
-- [ ] Proceed only when automated checks pass, identity reconciliation is exact, pre-production web/desktop flows pass, rollback artifacts exist, callbacks/secrets are configured, and PR #221 policies are verified or scheduled in the same window.
+- [ ] **Step 7: Stop before production execution.**
 
-### Step 7: Execute the production cutover
+Do not run production `0008`, production identity import, production deploy, desktop publication, or credential removal from this task. Those remain explicit operator actions in the runbook after review/approval.
 
-- [ ] Apply `0008_better_auth.sql`.
-- [ ] Apply reviewed identity-import SQL.
-- [ ] Deploy API, then web.
-- [ ] Publish/install the new desktop build.
-- [ ] Run production smoke checks.
-- [ ] Revoke/remove Supabase application credentials only after proof succeeds.
-- [ ] Do not immediately delete the Supabase project; retain rollback ability for the cutover window.
+- [ ] **Step 8: Final repository verification.**
 
-### Step 8: Final verification
+```bash
+git status --short
+git diff --check
+```
 
-- [ ] Record only non-secret results/corrections in the runbook.
-- [ ] Confirm `tmp/auth-migration/` is not tracked.
-- [ ] Re-run `git status --short` and `git diff --check`.
-- [ ] Commit verification-only fixes when needed; do not create an empty commit.
+Commit only verification-driven code/doc corrections; do not create an empty commit.
 
 ## Completion Definition
 
-The migration is complete only when:
+The implementation PR is ready when:
 
-- [ ] D1 holds Better Auth core, Device Authorization, and rate-limit tables.
-- [ ] Existing application owner UUIDs are preserved.
+- [ ] D1 schema/migration includes Better Auth core, Device Authorization, and rate-limit tables.
+- [ ] Existing application owner UUIDs are preserved by the import tooling.
 - [ ] Password and Google web sign-in use Better Auth.
-- [ ] Explicit Google linking works and implicit linking is disabled.
-- [ ] Browser GraphQL/REST use cookie sessions.
-- [ ] Desktop uses Device Authorization and Bearer sessions.
+- [ ] Explicit Google linking works; implicit linking/signup are disabled.
+- [ ] `CORS_ALLOWED_ORIGINS` is the one browser-origin trust list for CORS, Better Auth, and unsafe cookie auth.
+- [ ] Multi-value Set-Cookie survives API CORS wrapping and SvelteKit session forwarding.
+- [ ] Browser GraphQL and REST/download paths use cookies and no Supabase bearer helper remains.
+- [ ] Service-binding SSR forwards Cookie plus trusted Origin.
+- [ ] Desktop uses Device Authorization plus opaque Bearer sessions.
+- [ ] Desktop preserves `valid | invalid | not-configured` restore semantics and session epoch/Drive reconciliation.
 - [ ] Desktop contains no magic-link, auth deep-link, loopback callback, JWT decoder, or refresh-token rotation.
-- [ ] No active package, test, config, or environment contract depends on Supabase.
+- [ ] No active package/test/config/environment contract depends on Supabase.
+- [ ] Obsolete root/turbo Supabase `gen-types` is deleted.
 - [ ] Unit, integration, Rust, web E2E, and desktop E2E checks pass.
-- [ ] Pre-production and production runbook matrices pass.
-- [ ] Disabling Supabase causes no DTXWeb runtime failure.
+- [ ] Pre-production acceptance passes.
+- [ ] Production runbook is complete and ready for separate operator execution.

--- a/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
+++ b/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
@@ -1,0 +1,967 @@
+# Better Auth and D1 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Supabase from DTXWeb by hosting Better Auth in `dtx-api`, storing auth data in the existing Cloudflare D1 database, moving web authentication to cookies, and replacing desktop magic-link/deep-link authentication with Device Authorization plus Bearer sessions.
+
+**Architecture:** `dtx-api` owns one request-scoped Better Auth instance, the official Better Auth Drizzle adapter, generated auth schema, D1 migration, and neutral session resolution. `dtx-web` is a separate-origin SvelteKit client that uses a shared-parent cookie and hosts `/app/desktop-auth`. DTX Desktop requests a device code, opens the verification URL, polls natively, stores one opaque session token, and sends it as Bearer auth to the existing GraphQL and REST API. Existing application tables continue using preserved auth user IDs.
+
+**Tech Stack:** Better Auth 1.6.25, Better Auth Device Authorization and Bearer plugins, Cloudflare Workers, D1, Drizzle ORM/Drizzle Kit, SvelteKit 2/Svelte 5, Tauri 2/Rust, Vitest, Playwright, WireMock.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md`
+
+## Global Constraints
+
+- [ ] Use Better Auth 1.6.25 exactly; do not adopt a prerelease during this migration.
+- [ ] Follow Better Auth's Cloudflare fixture: request-scoped `drizzle(env.DB, { schema })` plus `drizzleAdapter(..., { provider: "sqlite" })`.
+- [ ] Keep Wrangler D1 migrations as the only production migration executor.
+- [ ] Preserve every existing Supabase UUID used by application ownership rows.
+- [ ] Do not add dual-auth mode, OAuth Provider, JWT/JWKS, API keys, another Worker, another database, or custom device protocol.
+- [ ] Do not preserve active Supabase sessions or old desktop access/refresh-token storage.
+- [ ] Keep Google linking explicit and signup disabled.
+- [ ] Keep the existing application-data schema and authorization scopes unchanged.
+- [ ] Write tests before each behavior change and keep each task compiling before commit.
+
+---
+
+## Task 1: Pin Better Auth and create a reproducible D1 auth schema
+
+**Files:**
+
+- Modify: `packages/dtx-api/package.json`
+- Modify: `bun.lock`
+- Create: `packages/dtx-api/src/auth/options.ts`
+- Create: `packages/dtx-api/src/auth/auth.cli.ts`
+- Create: `packages/dtx-api/src/auth/schema.ts`
+- Create: `packages/dtx-api/src/auth/schema.test.ts`
+- Create: `packages/dtx-api/drizzle.auth.config.ts`
+- Create: `packages/dtx-api/d1-migrations/0008_better_auth.sql`
+- Modify: `packages/dtx-api/src/env.ts`
+- Modify: `packages/dtx-api/wrangler.jsonc`
+- Modify: `.env.example`
+
+### Step 1: Add a failing schema contract test
+
+- [ ] Create `src/auth/schema.test.ts`.
+- [ ] Read `src/auth/schema.ts` and `d1-migrations/0008_better_auth.sql`.
+- [ ] Assert the generated schema and SQL include Better Auth core models, Device Authorization, and database rate limiting.
+- [ ] Assert user IDs are text primary keys and session/account/device rows reference the Better Auth user table.
+- [ ] Run:
+
+```bash
+bun run --filter=dtx-api test -- src/auth/schema.test.ts
+```
+
+Expected: FAIL because the schema and migration do not exist.
+
+### Step 2: Install pinned dependencies
+
+- [ ] Run:
+
+```bash
+cd packages/dtx-api
+bun add --exact better-auth@1.6.25
+bun add drizzle-orm@^0.45.2
+bun add --dev --exact auth@1.6.25
+bun add --dev drizzle-kit
+cd ../..
+```
+
+- [ ] Do not add a third-party Better Auth Cloudflare adapter.
+
+### Step 3: Define shared options
+
+- [ ] Create `options.ts` with one `createAuthOptions(config)` function.
+- [ ] Include:
+
+```ts
+emailAndPassword: {
+  enabled: true,
+  disableSignUp: true,
+},
+socialProviders: {
+  google: {
+    clientId: config.googleClientId,
+    clientSecret: config.googleClientSecret,
+    disableSignUp: true,
+    disableImplicitSignUp: true,
+  },
+},
+account: {
+  accountLinking: {
+    enabled: true,
+    disableImplicitLinking: true,
+  },
+},
+advanced: {
+  crossSubDomainCookies: config.cookieDomain
+    ? { enabled: true, domain: config.cookieDomain }
+    : { enabled: false },
+  ipAddress: { ipAddressHeaders: ["cf-connecting-ip"] },
+},
+rateLimit: {
+  enabled: true,
+  storage: "database",
+},
+plugins: [
+  deviceAuthorization({
+    verificationUri: `${config.webURL}/app/desktop-auth`,
+    validateClient: (clientId) => clientId === "dtx-desktop",
+  }),
+  bearer(),
+],
+```
+
+- [ ] Set `baseURL`, `secret`, and `trustedOrigins` explicitly.
+- [ ] Do not disable Better Auth CSRF or origin checks.
+
+### Step 4: Generate the Drizzle schema
+
+- [ ] Create `auth.cli.ts` using the shared options and non-production placeholder values.
+- [ ] Add scripts:
+
+```json
+{
+  "auth:schema:generate": "auth generate --config src/auth/auth.cli.ts --output src/auth/schema.ts --adapter drizzle --dialect sqlite --yes",
+  "auth:schema:export": "drizzle-kit export --config drizzle.auth.config.ts --sql=true",
+  "auth:schema:check": "bun run auth:schema:generate && git diff --exit-code -- src/auth/schema.ts"
+}
+```
+
+- [ ] Run `bun run --filter=dtx-api auth:schema:generate`.
+- [ ] Review the generated schema; do not hand-maintain Better Auth columns.
+
+### Step 5: Export reviewed SQL
+
+- [ ] Configure `drizzle.auth.config.ts` for SQLite using `src/auth/schema.ts`.
+- [ ] Run the export into a temporary file.
+- [ ] Copy only the generated DDL into `0008_better_auth.sql`.
+- [ ] Ensure the migration is flat SQL compatible with `wrangler d1 migrations apply`.
+- [ ] Do not add a runtime Drizzle Kit migration runner.
+
+### Step 6: Add the environment contract
+
+- [ ] Add to `Env`:
+
+```ts
+BETTER_AUTH_URL: string;
+BETTER_AUTH_SECRET: string;
+DTX_WEB_URL: string;
+AUTH_COOKIE_DOMAIN?: string;
+GOOGLE_AUTH_CLIENT_ID: string;
+GOOGLE_AUTH_CLIENT_SECRET: string;
+```
+
+- [ ] Add non-secret URL/domain/client-ID values to each Wrangler environment.
+- [ ] Keep `BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` as Wrangler secrets.
+- [ ] Keep Supabase variables temporarily until the cutover tasks remove their consumers.
+
+### Step 7: Verify schema generation
+
+- [ ] Run:
+
+```bash
+bun run --filter=dtx-api auth:schema:check
+bun run --filter=dtx-api test -- src/auth/schema.test.ts
+bun run --filter=dtx-api check
+bun run packages/e2e-web/setup/prepare-stack.ts
+```
+
+Expected: generated schema is clean and all D1 migrations apply to fresh local state.
+
+### Step 8: Commit
+
+- [ ] Commit:
+
+```bash
+git add packages/dtx-api/package.json bun.lock \
+  packages/dtx-api/src/auth packages/dtx-api/drizzle.auth.config.ts \
+  packages/dtx-api/d1-migrations/0008_better_auth.sql \
+  packages/dtx-api/src/env.ts packages/dtx-api/wrangler.jsonc .env.example
+git commit -m "feat(auth): add Better Auth D1 schema"
+```
+
+---
+
+## Task 2: Mount Better Auth and enable credentialed CORS
+
+**Files:**
+
+- Create: `packages/dtx-api/src/auth/auth.ts`
+- Create: `packages/dtx-api/src/auth/auth.test.ts`
+- Modify: `packages/dtx-api/src/index.ts`
+- Modify: `packages/dtx-api/src/index.test.ts`
+- Modify: `packages/dtx-api/src/lib/cors.ts`
+- Modify: `packages/dtx-api/src/lib/cors.test.ts`
+
+### Step 1: Add failing handler tests
+
+- [ ] Add tests proving:
+  - GET and POST under `/api/auth/*` reach Better Auth;
+  - unrelated routes still reach GraphQL/REST;
+  - unsupported methods preserve existing behavior;
+  - session lookup without credentials returns null;
+  - D1 is request-scoped.
+- [ ] Run the focused tests and confirm failure.
+
+### Step 2: Create the runtime auth factory
+
+- [ ] Implement:
+
+```ts
+export const createAuth = (env: Env) =>
+  betterAuth({
+    ...createAuthOptions({
+      baseURL: env.BETTER_AUTH_URL,
+      webURL: env.DTX_WEB_URL,
+      cookieDomain: env.AUTH_COOKIE_DOMAIN,
+      googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
+      googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
+      secret: env.BETTER_AUTH_SECRET,
+    }),
+    database: drizzleAdapter(drizzle(env.DB, { schema }), {
+      provider: "sqlite",
+    }),
+  });
+```
+
+- [ ] Do not cache an auth instance across unrelated Worker environments.
+
+### Step 3: Mount the handler before GraphQL/REST
+
+- [ ] In `src/index.ts`, handle CORS preflight first.
+- [ ] Route `/api/auth/*` GET/POST to `createAuth(env).handler(request)`.
+- [ ] Wrap the response with the existing `withCors(response, request, env)` helper.
+- [ ] Keep the current small hand-written router; do not add Hono solely for this route.
+
+### Step 4: Make CORS credential-safe
+
+- [ ] For configured origins, set:
+
+```text
+Access-Control-Allow-Origin: <exact origin>
+Access-Control-Allow-Credentials: true
+Vary: Origin
+```
+
+- [ ] Keep allowed methods/headers explicit.
+- [ ] Never combine credentials with `Access-Control-Allow-Origin: *`.
+- [ ] Add preflight and normal-response tests for allowed, denied, missing, and multiple configured origins.
+
+### Step 5: Verify and commit
+
+- [ ] Run:
+
+```bash
+bun run --filter=dtx-api test -- src/auth/auth.test.ts src/index.test.ts src/lib/cors.test.ts
+bun run --filter=dtx-api check
+```
+
+- [ ] Commit:
+
+```bash
+git add packages/dtx-api/src/auth/auth.ts packages/dtx-api/src/auth/auth.test.ts \
+  packages/dtx-api/src/index.ts packages/dtx-api/src/index.test.ts \
+  packages/dtx-api/src/lib/cors.ts packages/dtx-api/src/lib/cors.test.ts
+git commit -m "feat(auth): mount Better Auth API"
+```
+
+---
+
+## Task 3: Replace Supabase token verification with one neutral session resolver
+
+**Files:**
+
+- Create: `packages/dtx-api/src/auth/session.ts`
+- Create: `packages/dtx-api/src/auth/session.test.ts`
+- Modify: `packages/dtx-api/src/context.ts`
+- Modify: `packages/dtx-api/src/schema/builder.ts`
+- Modify: `packages/dtx-api/src/schema/builder.test.ts`
+- Modify: `packages/dtx-api/src/rest/upload.ts`
+- Modify: `packages/dtx-api/src/rest/upload.test.ts`
+- Modify: `packages/dtx-api/src/rest/downloadSimfile.ts`
+- Modify: `packages/dtx-api/src/rest/downloadSimfile.test.ts`
+- Modify: `packages/dtx-api/src/rest/downloadBulk.ts`
+- Modify: `packages/dtx-api/src/rest/downloadBulk.test.ts`
+- Delete later in this task: `packages/dtx-api/src/auth/verifyToken.ts`
+- Delete later in this task: `packages/dtx-api/src/auth/verifyToken.test.ts`
+
+### Step 1: Add resolver tests
+
+- [ ] Test cookie session, Bearer session, missing credentials, revoked/expired token, malformed header, and Better Auth failure.
+- [ ] Require the same normalized `{ user, session }` shape for cookie and Bearer callers.
+- [ ] Confirm invalid credentials normalize to null rather than leaking provider errors.
+
+### Step 2: Implement `resolveAuthSession`
+
+- [ ] Call:
+
+```ts
+createAuth(env).api.getSession({ headers: request.headers })
+```
+
+- [ ] Return neutral local types, not Better Auth internals throughout the codebase.
+- [ ] Do not decode or validate tokens independently.
+
+### Step 3: Retarget GraphQL context and REST
+
+- [ ] Replace `verifyToken()` in `context.ts` and protected REST routes.
+- [ ] Keep current Pothos scope behavior and existing unauthorized responses.
+- [ ] Cover both cookie and Bearer at the resolver boundary; route tests may mock the neutral helper.
+
+### Step 4: Delete the Supabase verifier
+
+- [ ] Delete `verifyToken.ts` and its tests after all imports are gone.
+- [ ] Run:
+
+```bash
+rg -n "verifyToken|SUPABASE_ANON_KEY" packages/dtx-api/src
+```
+
+Expected: no live verifier use.
+
+### Step 5: Verify and commit
+
+- [ ] Run API tests and typecheck.
+- [ ] Commit:
+
+```bash
+git add packages/dtx-api/src
+git commit -m "refactor(auth): resolve Better Auth sessions"
+```
+
+---
+
+## Task 4: Remove the custom GraphQL magic-link protocol
+
+**Files:**
+
+- Delete: `packages/dtx-api/src/services/magicLink.ts`
+- Delete: `packages/dtx-api/src/services/magicLink.test.ts`
+- Delete: `packages/dtx-api/src/schema/auth.ts`
+- Delete: `packages/dtx-api/src/schema/auth.test.ts`
+- Modify: `packages/dtx-api/src/schema/index.ts`
+- Delete: `packages/dtx-web/src/lib/api/operations/auth.graphql`
+- Delete: `packages/dtx-web/src/lib/api/auth.ts`
+- Delete: `packages/dtx-web/src/lib/api/auth.test.ts`
+- Modify/regenerate: `packages/dtx-web/src/lib/api/generated/graphql.ts`
+- Rewrite: `packages/dtx-web/src/routes/(app)/app/+page.svelte`
+- Modify: `packages/dtx-web/src/routes/(app)/app/app-page.test.ts`
+- Delete: `packages/dtx-web/src/routes/(app)/app/app-page-redirect.test.ts`
+- Modify: `packages/dtx-api/package.json`
+
+### Step 1: Change schema expectations first
+
+- [ ] Update schema tests to assert `generateMagicLink` no longer exists.
+- [ ] Remove `./auth` registration from `schema/index.ts`.
+- [ ] Regenerate API schema and web GraphQL output.
+
+### Step 2: Remove server magic-link code
+
+- [ ] Delete the service, mutation, tests, service-role key use, callback allowlist, and magic-link-specific KV keys.
+- [ ] Remove the inline `MAGIC_LINK_HOURLY_LIMIT` local-dev override.
+- [ ] Keep `RATE_LIMIT_API` because non-auth API paths still use it.
+
+### Step 3: Remove the web handoff
+
+- [ ] Remove `/app?redirect=desktop`, `desktop_callback`, magic-link generation, and callback forwarding.
+- [ ] Keep the normal dashboard page.
+- [ ] Do not add Device Authorization here; Task 8 adds the dedicated approval page.
+
+### Step 4: Verify and commit
+
+- [ ] Run:
+
+```bash
+bun run --filter=dtx-api gen-schema
+bun run --filter=dtx-web codegen
+bun run --filter=dtx-api test
+bun run --filter=dtx-web test
+bun run --filter=dtx-api check
+bun run --filter=dtx-web check
+```
+
+- [ ] Commit all server and generated-client removals together so the branch compiles.
+
+---
+
+## Task 5: Replace SvelteKit Supabase session plumbing
+
+**Files:**
+
+- Create: `packages/dtx-web/src/lib/auth/client.ts`
+- Create: `packages/dtx-web/src/lib/auth/session.ts`
+- Create: `packages/dtx-web/src/lib/auth/redirect.ts`
+- Create matching tests under `packages/dtx-web/src/lib/auth/`
+- Rewrite: `packages/dtx-web/src/hooks.server.ts`
+- Modify: `packages/dtx-web/src/app.d.ts`
+- Rewrite: `packages/dtx-web/src/routes/+layout.server.ts`
+- Rewrite: `packages/dtx-web/src/routes/+layout.ts`
+- Modify: `packages/dtx-web/src/routes/+layout.svelte`
+- Modify: `packages/dtx-web/src/routes/layout.server.test.ts`
+- Modify: `packages/dtx-web/src/routes/layout.test.ts`
+- Modify: `packages/dtx-web/src/routes/layout.svelte.test.ts`
+
+### Step 1: Test session loading and guards
+
+- [ ] Add tests for anonymous/authenticated API session responses, forwarded cookies, propagated `Set-Cookie`, protected `/app` redirects, safe `next`, login-page redirect, and API failure.
+- [ ] Preserve the current allowlist semantics: return only to `/app` paths.
+
+### Step 2: Add a neutral web auth client
+
+- [ ] Create the Better Auth Svelte client pointed at `PUBLIC_DTX_API_URL`.
+- [ ] Set `credentials: "include"`.
+- [ ] Register `deviceAuthorizationClient()` for Task 8.
+
+### Step 3: Rewrite the server hook
+
+- [ ] Remove `createServerClient`, `safeGetSession`, and Supabase locals.
+- [ ] Forward the incoming `Cookie` header to `/api/auth/get-session`.
+- [ ] Propagate all Better Auth `Set-Cookie` headers.
+- [ ] Populate neutral `event.locals.user` and `event.locals.session`.
+- [ ] Keep CSRF protection for SvelteKit form endpoints and the existing `/app` guard.
+
+### Step 4: Simplify root layout data
+
+- [ ] Stop constructing browser/server Supabase clients.
+- [ ] Return only neutral session/user data plus existing locale data.
+- [ ] Remove `supabase:auth` invalidation and auth-state subscription.
+
+### Step 5: Verify and commit
+
+- [ ] Run focused layout/hook tests and `bun run --filter=dtx-web check`.
+- [ ] Commit:
+
+```bash
+git add packages/dtx-web/src/hooks.server.ts packages/dtx-web/src/app.d.ts \
+  packages/dtx-web/src/lib/auth packages/dtx-web/src/routes/+layout*
+git commit -m "refactor(auth): load Better Auth web sessions"
+```
+
+---
+
+## Task 6: Move web sign-in, logout, and Google linking to Better Auth
+
+**Files:**
+
+- Rewrite: `packages/dtx-web/src/routes/(login)/login/+page.svelte`
+- Delete/replace: `packages/dtx-web/src/routes/(login)/login/+page.server.ts`
+- Modify: `packages/dtx-web/src/routes/(login)/login/page.server.test.ts`
+- Delete: `packages/dtx-web/src/routes/auth/callback/+server.ts`
+- Delete: `packages/dtx-web/src/routes/auth/callback/server.test.ts`
+- Modify: `packages/dtx-web/src/routes/(app)/+layout.svelte`
+- Modify: `packages/dtx-web/src/routes/(app)/layout.svelte.test.ts`
+- Rewrite: `packages/dtx-web/src/routes/(app)/app/account/+page.svelte`
+- Modify: `packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts`
+
+### Step 1: Add failing login/account tests
+
+- [ ] Cover password success/failure, safe `next`, Google redirect, `account_not_linked`, logout, linked-method listing, explicit Google linking, and no signup UI.
+
+### Step 2: Implement password sign-in
+
+- [ ] Use `authClient.signIn.email({ email, password })`.
+- [ ] Perform a full browser navigation to the validated `/app` destination after success.
+- [ ] Keep provider errors sanitized.
+
+### Step 3: Implement Google sign-in and explicit linking
+
+- [ ] Use `authClient.signIn.social` for login and `authClient.linkSocial` from the authenticated account page.
+- [ ] Set callback URLs to validated application routes.
+- [ ] Delete the SvelteKit OAuth callback route; Better Auth's API callback is authoritative.
+- [ ] Do not permit implicit same-email linking.
+
+### Step 4: Implement logout
+
+- [ ] Call `authClient.signOut()` and navigate to `/login`.
+- [ ] Remove Supabase identity/session assumptions from layout and account UI.
+
+### Step 5: Verify and commit
+
+- [ ] Run web unit tests and typecheck.
+- [ ] Commit the complete web auth action migration.
+
+---
+
+## Task 7: Authenticate browser API traffic with cookies
+
+**Files:**
+
+- Modify: `packages/dtx-web/src/lib/api/transport.ts`
+- Modify: `packages/dtx-web/src/lib/api/client.ts`
+- Modify matching tests
+- Delete: `packages/dtx-web/src/lib/api/token.ts`
+- Delete: `packages/dtx-web/src/lib/api/token.test.ts`
+
+### Step 1: Add transport tests
+
+- [ ] Browser GraphQL sets `credentials: "include"` and no Authorization header.
+- [ ] Service-binding GraphQL forwards the incoming Cookie header.
+- [ ] Anonymous requests remain anonymous.
+- [ ] Existing GraphQL error mapping remains unchanged.
+
+### Step 2: Rewrite only the transport seam
+
+- [ ] Keep generated GraphQL operations and feature wrappers unchanged.
+- [ ] Remove token lookup/injection.
+- [ ] Do not introduce a proxy route solely to make auth same-origin.
+
+### Step 3: Verify and commit
+
+- [ ] Run API client tests, web tests, and typecheck.
+- [ ] Commit:
+
+```bash
+git add packages/dtx-web/src/lib/api
+git commit -m "refactor(auth): use cookie-authenticated web API"
+```
+
+---
+
+## Task 8: Add the desktop Device Authorization approval page
+
+**Files:**
+
+- Create: `packages/dtx-web/src/routes/(app)/app/desktop-auth/+page.svelte`
+- Create: `packages/dtx-web/src/routes/(app)/app/desktop-auth/desktop-auth-page.test.ts`
+- Modify: `packages/dtx-web/src/lib/auth/client.ts`
+- Modify: `packages/dtx-web/src/routes/layout.test.ts`
+
+### Step 1: Add failing UI tests
+
+- [ ] Cover prefilled/manual code, formatting, claim success, invalid/expired code, approve, deny, double-submit prevention, and unauthenticated return-through-login.
+
+### Step 2: Implement the claim step
+
+- [ ] Normalize the user code by trimming, removing dashes, and uppercasing.
+- [ ] Call Better Auth's Device Authorization verification method before showing approval controls.
+- [ ] Rely on the `/app` guard to require an authenticated browser session and preserve the page URL as `next`.
+
+### Step 3: Implement explicit approve/deny
+
+- [ ] Display the code and fixed `dtx-desktop` client identity.
+- [ ] Require an explicit button action.
+- [ ] Disable both actions while one is in flight.
+- [ ] Show terminal success/denial text instead of redirecting to a desktop callback.
+
+### Step 4: Verify and commit
+
+- [ ] Run the page and layout tests plus web typecheck.
+- [ ] Commit:
+
+```bash
+git add "packages/dtx-web/src/routes/(app)/app/desktop-auth" \
+  packages/dtx-web/src/lib/auth/client.ts
+git commit -m "feat(auth): add desktop device approval"
+```
+
+---
+
+## Task 9: Replace native refresh/deep-link auth with Device Authorization
+
+**Files:**
+
+- Create: `packages/dtx-desktop/src-tauri/src/device_auth.rs`
+- Create: `packages/dtx-desktop/src-tauri/src/tests/device_auth_tests.rs`
+- Rewrite: `packages/dtx-desktop/src-tauri/src/auth.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/lib.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/tests/auth_tests.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/api_contracts.rs`
+- Modify: `packages/dtx-desktop/src-tauri/Cargo.toml`
+- Regenerate: `packages/dtx-desktop/src/renderer/src/lib/generated/native-api-contracts.ts`
+
+### Step 1: Add protocol tests with WireMock
+
+- [ ] Cover code request, display-safe response, pending, slow-down, approval, denial, expiry, invalid grant, malformed responses, timeout, and network failure.
+- [ ] Use paused Tokio time where practical.
+- [ ] Confirm `device_code` never crosses the Tauri command boundary.
+
+### Step 2: Implement a protocol-only module
+
+- [ ] Keep `device_auth.rs` independent of Tauri UI APIs.
+- [ ] Use Better Auth 1.6.25's exact wire field names.
+- [ ] Centralize API base URL construction.
+- [ ] Never log device codes or session tokens.
+
+### Step 3: Replace `AuthState` with typed state
+
+- [ ] Define renderer-facing `DesktopAuthUser`, `DesktopAuthSession`, and `DeviceAuthorizationAttempt` in `api_contracts.rs` and derive `TS`.
+- [ ] Reuse the existing export target `../../src/renderer/src/lib/generated/native-api-contracts.ts`.
+- [ ] Include `userCode`, `verificationUri`, `verificationUriComplete`, and `expiresAt` in the attempt.
+- [ ] Keep one pending opaque device code in native memory.
+- [ ] Preserve authenticated user ID, session generation, and session epoch used by Google Drive reconciliation.
+- [ ] Prevent stale polls from committing after cancel/restart.
+
+### Step 4: Implement native commands
+
+- [ ] Add:
+
+```text
+begin_device_authorization
+poll_device_authorization
+cancel_device_authorization
+```
+
+- [ ] Preserve and retarget existing names:
+
+```text
+validate_session
+get_current_session
+logout_session
+open_external_url
+```
+
+- [ ] `begin_device_authorization` requests/stores codes and returns display-safe data only.
+- [ ] The renderer, not the protocol module, calls `open_external_url(verificationUriComplete)`.
+- [ ] `poll_device_authorization` owns polling, handles pending/slow-down, fetches `/api/auth/get-session` after approval, and returns `DesktopAuthSession`.
+- [ ] `validate_session` calls `/api/auth/get-session` with Bearer auth and never decodes JWTs.
+- [ ] `logout_session` posts to `/api/auth/sign-out`, always clears native state, and reports whether revocation succeeded.
+
+### Step 5: Replace API token access
+
+- [ ] Rename `ensure_valid_access_token` to `current_session_token`.
+- [ ] Remove expiry parsing, refresh calls, and refresh locks.
+- [ ] Keep existing `Authorization: Bearer` request code, now with the opaque Better Auth session token.
+
+### Step 6: Remove auth callback machinery
+
+- [ ] Delete magic-link parsing, auth deep-link handlers/queues, loopback TCP server, callback parser, JWT parsing, Supabase refresh/logout endpoints, and auth events.
+- [ ] Remove `tauri-plugin-deep-link` only after no non-test use remains.
+- [ ] Keep `tauri-plugin-single-instance` for window focusing but remove auth URL extraction.
+
+### Step 7: Verify generated bindings and Rust
+
+- [ ] Run:
+
+```bash
+cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml
+cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml
+cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml \
+  --all-targets --all-features -- -D warnings
+bun run gen:native-types
+```
+
+- [ ] Commit native changes and generated TypeScript together.
+
+---
+
+## Task 10: Rewire the desktop renderer and remove callback configuration
+
+**Files:**
+
+- Rewrite: `packages/dtx-desktop/src/renderer/src/services/authService.ts`
+- Rename/rewrite: `packages/dtx-desktop/src/renderer/src/services/supabaseService.ts` → `sessionStorage.ts`
+- Rename/rewrite matching test
+- Modify: `packages/dtx-desktop/src/renderer/src/services/desktopHost.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/desktopHost.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/App.svelte`
+- Modify: `packages/dtx-desktop/src/renderer/src/App.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/services/authService.test.ts`
+- Modify: `packages/dtx-desktop/src/renderer/src/env.d.ts`
+- Modify: `packages/dtx-desktop/package.json`
+- Modify: `packages/dtx-desktop/src-tauri/tauri.conf.json`
+- Modify: `packages/dtx-desktop/src-tauri/tauri.dev.conf.json`
+- Modify: root `package.json`
+- Modify: `packages/dtx-desktop/src/devTopology.test.ts`
+
+### Step 1: Add renderer lifecycle tests
+
+- [ ] Cover start, displayed code, browser open, poll success, one-token persistence, restore, invalid restore cleanup, logout cleanup, cancellation, retry, and browser-open failure fallback.
+- [ ] Remove assumptions about refresh tokens, JWT expiry, magic links, or session-refresh events.
+
+### Step 2: Replace Supabase-shaped persistence
+
+- [ ] Store only `{ sessionToken, user }` under one neutral key.
+- [ ] Validate stored shape and clear malformed values.
+- [ ] Do not migrate old Supabase local-storage values; delete them when encountered.
+
+### Step 3: Rewrite the renderer service
+
+- [ ] Use generated native commands/types.
+- [ ] After `beginDeviceAuthorization`, call the existing `openExternalUrl(attempt.verificationUriComplete)` and then poll.
+- [ ] Show `verificationUri` and `userCode` when browser opening fails.
+- [ ] Keep one `idle | waiting | authenticated | error` state model.
+- [ ] Remove `magic-link-result` and `session-refreshed` listeners.
+
+### Step 4: Remove callback/deep-link configuration
+
+- [ ] Remove:
+
+```text
+DTX_DESKTOP_AUTH_CALLBACK_PORT
+VITE_DTX_DESKTOP_AUTH_CALLBACK_PORT
+PUBLIC_DTX_DESKTOP_AUTH_CALLBACK_URL
+```
+
+- [ ] Remove auth URI scheme registration only after repository search confirms no non-auth use.
+- [ ] Simplify `dev`, `dev:local-web`, and root dev scripts.
+- [ ] Update topology tests to assert API/web URLs only.
+
+### Step 5: Verify and commit
+
+- [ ] Run desktop renderer tests, Svelte typecheck, Rust tests, and `bun run gen:native-types`.
+- [ ] Commit:
+
+```bash
+git add packages/dtx-desktop package.json
+git commit -m "refactor(auth): rewire desktop session lifecycle"
+```
+
+---
+
+## Task 11: Add a one-shot identity import and local Better Auth E2E user
+
+**Files:**
+
+- Create: `packages/dtx-api/src/scripts/migrate-supabase-auth.ts`
+- Create: `packages/dtx-api/src/scripts/migrate-supabase-auth.test.ts`
+- Create sanitized fixtures under `packages/dtx-api/src/scripts/fixtures/`
+- Modify: `packages/dtx-api/package.json`
+- Delete: `packages/e2e-web/setup/create-local-supabase-user.ts`
+- Create: `packages/e2e-web/setup/seed-better-auth-user.ts`
+- Modify: `packages/e2e-web/setup/prepare-stack.ts`
+- Modify: `packages/e2e-web/playwright.config.ts`
+- Modify: `packages/e2e-web/test-config.ts`
+- Modify: `packages/e2e-web/global.setup.ts`
+- Modify: `packages/e2e-web/package.json`
+- Modify: `.gitignore`
+
+### Step 1: Specify import invariants in tests
+
+- [ ] Preserve user UUIDs exactly.
+- [ ] Map email/name/verified/timestamps and Google identity.
+- [ ] Reject duplicate email/ID and unsupported providers.
+- [ ] Import no session/access/refresh token.
+- [ ] Emit deterministic account IDs and safely escaped SQL.
+- [ ] Fail when any application owner ID lacks an imported Better Auth user.
+
+### Step 2: Implement local-only import tooling
+
+- [ ] Consume a sanitized Supabase Admin export JSON file.
+- [ ] Write only to `tmp/auth-migration/`.
+- [ ] Produce reviewed SQL for D1; do not write directly to production.
+- [ ] Do not import or depend on `@supabase/supabase-js`.
+- [ ] Hash replacement credential passwords with Better Auth's password helper.
+- [ ] Require explicit replacement password input for credential users; do not add bcrypt compatibility.
+
+### Step 3: Seed local E2E auth in D1
+
+- [ ] Replace Supabase E2E variables with Better Auth secret, fixed test user ID/email/password, API URL, and web URL.
+- [ ] Seed Better Auth user/account rows into the same local D1 state prepared by `prepare-stack.ts`.
+- [ ] Preserve the fixed test UUID used by application seed rows.
+- [ ] Keep CI fail-loud behavior when auth E2E inputs are incomplete.
+
+### Step 4: Verify and commit
+
+- [ ] Run import tests, local stack preparation, Playwright setup, API tests, and E2E typecheck.
+- [ ] Commit migration tooling without generated real-user SQL or secrets.
+
+---
+
+## Task 12: Remove all remaining Supabase runtime and configuration residue
+
+**Files:**
+
+- Modify: `packages/dtx-api/package.json`
+- Modify: `packages/dtx-web/package.json`
+- Modify: `packages/dtx-desktop/package.json`
+- Modify: `packages/common/package.json`
+- Modify: `bun.lock`
+- Delete: `packages/common/src/lib/types/supabase.types.ts`
+- Modify: `packages/common/src/lib/index.ts`
+- Modify: `packages/dtx-web/.env.types-only`
+- Modify: `packages/dtx-web/vitest.config.ts`
+- Modify: `packages/dtx-desktop/vitest.config.ts`
+- Modify: `.env.example`
+- Modify: `turbo.json`
+- Modify affected mocks and tests
+- Modify: `CLAUDE.md`
+
+### Step 1: Add a residue gate
+
+- [ ] Search active code/config for:
+
+```bash
+rg -n -i "@supabase|supabase|PUBLIC_SUPABASE|SUPABASE_" \
+  packages package.json turbo.json .env.example CLAUDE.md __mocks__
+```
+
+- [ ] Exclude only historical migration documents and the named one-shot import tool/tests.
+- [ ] The import tool may mention Supabase as an input format but must not import a Supabase package.
+
+### Step 2: Remove packages and types
+
+- [ ] Remove `@supabase/ssr` and `@supabase/supabase-js` from all packages.
+- [ ] Remove the common peer dependency.
+- [ ] Delete generated Supabase database types and exports.
+- [ ] Replace Supabase mocks with neutral auth fixtures.
+
+### Step 3: Remove environment/config residue
+
+- [ ] Remove Supabase URL, anon key, service-role key, callback allowlist, and magic-link-limit variables from env types, Wrangler config, Vite/Vitest setup, Turbo env lists, docs, and workflows.
+- [ ] Keep unrelated D1/R2/KV/Google Drive settings.
+
+### Step 4: Verify and commit
+
+- [ ] Run the residue gate, install lockfile check, all package typechecks, and unit tests.
+- [ ] Commit:
+
+```bash
+git add .
+git commit -m "chore(auth): remove Supabase dependencies"
+```
+
+---
+
+## Task 13: Cover cutover flows and reconcile Zero Trust documentation
+
+**Files:**
+
+- Modify/create authenticated specs under `packages/e2e-web/`
+- Modify/create desktop auth specs under `packages/e2e-desktop/`
+- Create: `docs/superpowers/runbooks/2026-08-18-better-auth-d1-cutover.md`
+- After PR #221 merges, modify:
+  - `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
+  - `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
+  - `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
+
+### Step 1: Update web E2E
+
+- [ ] Remove Supabase setup/secrets.
+- [ ] Cover password login, protected navigation, authenticated GraphQL/score flow, logout, and invalid-session redirect.
+- [ ] Keep Google provider behavior in integration/unit tests unless a controlled Google test identity is configured.
+
+### Step 2: Add Device Authorization integration coverage
+
+- [ ] Against local API/D1, request a device code, claim it with an authenticated browser session, approve it, poll for the token, validate the user, and revoke it.
+- [ ] Cover deny and expiry.
+- [ ] Do not reproduce Better Auth internals in test-only endpoints.
+
+### Step 3: Update desktop E2E
+
+- [ ] Cover renderer state and authenticated desktop behavior using a Better Auth session seeded through supported auth/D1 setup.
+- [ ] Keep one manual bundled desktop browser-handoff check in the runbook because OS browser launch is outside stable WDIO coverage.
+- [ ] Do not restore loopback/deep-link test hooks.
+
+### Step 4: Write the cutover runbook
+
+- [ ] Include exact sections for prerequisites, pinned versions, Google callbacks, Wrangler secrets, Supabase Admin export, import/reconciliation, D1 migration, deployment order, web matrix, desktop matrix, ownership queries, go/no-go, production cutover, Supabase-disable proof, and rollback.
+- [ ] Rollback redeploys previous API/web/desktop versions and leaves additive Better Auth tables in place.
+
+### Step 5: Reconcile PR #221
+
+- [ ] Rebase onto current `main` after PR #221 lands.
+- [ ] Replace Supabase as the inner gate with Better Auth.
+- [ ] Replace `/login?redirect=desktop` and callback verification with `/app/desktop-auth` and Device Authorization.
+- [ ] Preserve production `/app` operator-only policy, pre-production web Access protection, and public API hostnames.
+
+### Step 6: Verify and commit
+
+- [ ] Run both E2E suites, formatting, and `git diff --check`.
+- [ ] Commit tests and runbook together.
+
+---
+
+## Task 14: Run full verification and execute the atomic cutover
+
+**Files:**
+
+- Modify only files required by failed verification.
+- Update the cutover runbook with corrected non-secret assumptions/results.
+
+### Step 1: Run static and unit verification
+
+- [ ] Run:
+
+```bash
+bun run format
+bun run lint
+bun run check
+bun run test
+bun run gen-types
+git diff --check
+cargo fmt --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml --check
+cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml
+cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml \
+  --all-targets --all-features -- -D warnings
+```
+
+### Step 2: Run generated-artifact and residue gates
+
+- [ ] Run:
+
+```bash
+bun run --filter=dtx-api auth:schema:check
+bun run --filter=dtx-api gen-schema
+bun run --filter=dtx-web codegen
+bun run gen:native-types
+git diff --exit-code
+```
+
+- [ ] Confirm no live Supabase or desktop callback protocol remains.
+
+### Step 3: Run E2E
+
+- [ ] Run:
+
+```bash
+bun run e2e:web
+bun run e2e:desktop
+```
+
+Expected: PASS without Supabase credentials.
+
+### Step 4: Prepare pre-production
+
+- [ ] Set `BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` with Wrangler secrets.
+- [ ] Configure the exact pre-production Google callback from the runbook.
+- [ ] Apply D1 migrations.
+- [ ] Generate/review/apply sanitized identity-import SQL.
+- [ ] Fail rollout if any distinct application owner ID lacks a Better Auth user.
+
+### Step 5: Deploy and prove pre-production
+
+- [ ] Deploy API first, then web.
+- [ ] Build a desktop candidate pointed at pre-production.
+- [ ] Execute password, Google, explicit linking, GraphQL, upload/download, device approve/deny/expiry, restore/logout, and Access-gate checks.
+- [ ] Confirm API auth endpoints are outside Access and `/app/desktop-auth` is protected.
+- [ ] Confirm Supabase can be unreachable without breaking the candidate.
+
+### Step 6: Production go/no-go
+
+- [ ] Proceed only when automated checks pass, identity reconciliation is exact, pre-production web/desktop flows pass, rollback artifacts exist, callbacks/secrets are configured, and PR #221 policies are verified or scheduled in the same window.
+
+### Step 7: Execute the production cutover
+
+- [ ] Apply `0008_better_auth.sql`.
+- [ ] Apply reviewed identity-import SQL.
+- [ ] Deploy API, then web.
+- [ ] Publish/install the new desktop build.
+- [ ] Run production smoke checks.
+- [ ] Revoke/remove Supabase application credentials only after proof succeeds.
+- [ ] Do not immediately delete the Supabase project; retain rollback ability for the cutover window.
+
+### Step 8: Final verification
+
+- [ ] Record only non-secret results/corrections in the runbook.
+- [ ] Confirm `tmp/auth-migration/` is not tracked.
+- [ ] Re-run `git status --short` and `git diff --check`.
+- [ ] Commit verification-only fixes when needed; do not create an empty commit.
+
+## Completion Definition
+
+The migration is complete only when:
+
+- [ ] D1 holds Better Auth core, Device Authorization, and rate-limit tables.
+- [ ] Existing application owner UUIDs are preserved.
+- [ ] Password and Google web sign-in use Better Auth.
+- [ ] Explicit Google linking works and implicit linking is disabled.
+- [ ] Browser GraphQL/REST use cookie sessions.
+- [ ] Desktop uses Device Authorization and Bearer sessions.
+- [ ] Desktop contains no magic-link, auth deep-link, loopback callback, JWT decoder, or refresh-token rotation.
+- [ ] No active package, test, config, or environment contract depends on Supabase.
+- [ ] Unit, integration, Rust, web E2E, and desktop E2E checks pass.
+- [ ] Pre-production and production runbook matrices pass.
+- [ ] Disabling Supabase causes no DTXWeb runtime failure.

--- a/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
+++ b/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
@@ -4,33 +4,52 @@
 
 **Goal:** Remove Supabase from DTXWeb by hosting Better Auth in `dtx-api`, storing auth data in the existing Cloudflare D1 database, moving web authentication to cookies, and replacing desktop magic-link/deep-link authentication with Device Authorization plus opaque Bearer sessions.
 
-**Architecture:** `dtx-api` owns one request-scoped Better Auth instance, the official Better Auth Drizzle adapter, generated auth schema, D1 migration, and one neutral session-resolution seam. `dtx-web` uses Better Auth cookies and hosts `/app/desktop-auth`; unsafe cookie-authenticated API requests are accepted only from the existing `CORS_ALLOWED_ORIGINS` set. DTX Desktop requests a device code, opens the browser, polls natively, stores one opaque session token, and keeps the existing `valid | invalid | not-configured` restore contract.
+**Architecture:** Delivery is split at the additive/destructive seam. Foundation PR A adds and proves Better Auth schema, routing, credentialed CORS, the neutral resolver, environment-specific cookies, rate-limit policy, and a production API service binding while leaving Supabase as the live application authorization source. Cutover PR B then switches GraphQL/REST, web, desktop, E2E, and identity import together; it merges/deploys only after full-system tests and pre-production proof.
 
-**Tech Stack:** Better Auth 1.6.25, Device Authorization and Bearer plugins, Cloudflare Workers, D1, Drizzle ORM/Drizzle Kit, SvelteKit 2/Svelte 5, Tauri 2/Rust, Vitest, Playwright, WireMock.
+**Tech Stack:** Better Auth 1.6.x pinned exactly at implementation start, Better Auth Device Authorization and Bearer plugins, Cloudflare Workers/D1/Service Bindings, Drizzle ORM/Drizzle Kit, SvelteKit 2/Svelte 5, Tauri 2/Rust, Vitest, Playwright, WDIO, WireMock.
 
 **Spec:** `docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md`
 
 ## Global Constraints
 
-- [ ] Implement HPA-644 in **one implementation PR**. The tasks below are reviewable commits/checkpoints, not separate PRs.
-- [ ] Use Better Auth **1.6.25 exactly**; do not adopt a prerelease in this migration.
-- [ ] Follow Better Auth's Cloudflare pattern: request-scoped `drizzle(env.DB, { schema })` plus `drizzleAdapter(..., { provider: 'sqlite' })`.
+- [ ] Track both implementation PRs under HPA-644.
+- [ ] At Task 1 start, select the then-current stable `1.6.x` patch and pin `better-auth` and npm package `auth` to that same exact version.
+- [ ] Do not jump to Better Auth 1.7.x during this migration without revalidating schema, account, Device Authorization, Bearer, and callback contracts.
+- [ ] `auth` is intentionally the Better Auth CLI package; do not replace it with `@better-auth/cli` by assumption.
+- [ ] Use request-scoped `drizzle(env.DB, { schema })` plus the official Drizzle adapter with `provider: 'sqlite'`.
 - [ ] Keep Better Auth schema in `packages/dtx-api`; do not add it to `packages/common/src/lib/server/db/schema.ts`.
 - [ ] Keep Wrangler D1 migrations as the only production migration executor; next migration is `0008_better_auth.sql`.
 - [ ] Preserve every existing Supabase UUID used by application ownership rows.
-- [ ] Do not add dual-auth mode, OAuth Provider, JWT/JWKS, API keys, another Worker/database, custom device protocol, or bcrypt compatibility.
+- [ ] Do not add dual-auth application authorization, OAuth Provider, JWT/JWKS, API keys, another Worker/database, custom device protocol, FKs to auth users, or bcrypt compatibility.
 - [ ] Do not preserve active Supabase sessions or old desktop access/refresh-token storage.
 - [ ] Keep Google linking explicit and signup disabled.
 - [ ] Keep Google Drive OAuth independent from application Google Auth.
-- [ ] Reuse `CORS_ALLOWED_ORIGINS` as Better Auth `trustedOrigins`; do not create a parallel origin setting.
-- [ ] Preserve all `Set-Cookie` values when a Worker/SvelteKit response is reconstructed.
+- [ ] Use `DTX_WEB_URL` as the only application-auth trusted web origin.
+- [ ] Keep `CORS_ALLOWED_ORIGINS` for CORS only.
+- [ ] Use distinct `AUTH_COOKIE_PREFIX` values for production, pre-production, and local development.
+- [ ] Preserve multiple Set-Cookie values; never flatten through `headers.get('set-cookie')`.
 - [ ] Keep `SessionValidationStatus = valid | invalid | not-configured` on desktop.
-- [ ] Production data import/deploy remains an operator-runbook action, not an implementation-plan task.
-- [ ] Write failing tests before each behavior change and keep each task compiling before commit.
+- [ ] Preserve the existing feature-gated debug-only desktop E2E auth seam, reshaped for Better Auth.
+- [ ] Production identity import/deploy remains an operator-runbook action, not an implementation-plan task.
+- [ ] Write failing tests before behavior changes and keep each task compiling before commit.
+
+## Delivery Boundary
+
+### Foundation PR A
+
+Tasks 1-3 are additive and independently deployable. They may create Better Auth tables/endpoints, but `verifyToken()` remains the only authorization source for existing GraphQL/REST application data.
+
+After Task 3, deploy PR A to pre-production and prove the migration, handler, cookie configuration, neutral resolver tests, and service binding before merging.
+
+### Cutover PR B
+
+Tasks 4-15 perform the application cutover. The branch may be temporarily cross-component-inconsistent between commits; do not deploy it mid-task. Merge/deploy only after Task 15 passes.
 
 ---
 
-## Task 1: Pin Better Auth and generate the D1 auth schema
+# Foundation PR A
+
+## Task 1: Select/pin Better Auth 1.6.x and generate the D1 auth schema
 
 **Files:**
 
@@ -49,80 +68,100 @@
 **Interfaces:**
 
 - Produces `createAuthOptions(config)` for Task 2.
-- Produces generated `authSchema` plus `0008_better_auth.sql` for runtime/E2E.
-- Keeps `CORS_ALLOWED_ORIGINS` as the canonical trusted-origin input.
+- Produces generated `authSchema` and `0008_better_auth.sql`.
+- Adds `DTX_WEB_URL`, `AUTH_COOKIE_DOMAIN`, and `AUTH_COOKIE_PREFIX` to runtime configuration.
 
-- [ ] **Step 1: Write the failing schema contract test.**
+- [ ] **Step 1: Verify the implementation-time 1.6.x patch.**
 
-Assert that generated schema/SQL contain Better Auth core tables, Device Authorization, database rate limiting, text user IDs, and the expected foreign keys.
+Check Better Auth release/tag state and inspect changes since the planning version. Confirm the selected 1.6.x patch still exposes the required Device Authorization, Bearer, Drizzle adapter, cookiePrefix, trustedOrigins, rateLimit customRules, and CLI schema-generation APIs.
+
+Record the exact version in the PR description/runbook.
+
+- [ ] **Step 2: Add a failing schema contract test.**
+
+Assert generated schema/SQL include Better Auth core tables, Device Authorization tables, database rate-limit table, text user IDs, and expected foreign keys.
 
 ```bash
 bun run --filter=dtx-api test -- src/auth/schema.test.ts
 ```
 
-Expected: FAIL because the schema/migration do not exist.
+Expected: FAIL because schema/migration do not exist.
 
-- [ ] **Step 2: Install pinned dependencies.**
+- [ ] **Step 3: Install matching exact packages.**
+
+If the selected patch is `1.6.X`:
 
 ```bash
 cd packages/dtx-api
-bun add --exact better-auth@1.6.25
+bun add --exact better-auth@1.6.X
 bun add drizzle-orm@^0.45.2
-bun add --dev --exact auth@1.6.25
+bun add --dev --exact auth@1.6.X
 bun add --dev drizzle-kit
 cd ../..
 ```
 
-Do not add a third-party Cloudflare adapter.
+The package named `auth` is the Better Auth CLI.
 
-- [ ] **Step 3: Define shared Better Auth options.**
+- [ ] **Step 4: Define shared options.**
 
-`createAuthOptions(config)` includes:
+`createAuthOptions(config)` must include:
 
 ```ts
-emailAndPassword: {
-  enabled: true,
-  disableSignUp: true,
-},
-socialProviders: {
-  google: {
-    clientId: config.googleClientId,
-    clientSecret: config.googleClientSecret,
-    disableSignUp: true,
-    disableImplicitSignUp: true,
-  },
-},
-account: {
-  accountLinking: {
+const trustedWebOrigin = new URL(config.webURL).origin;
+
+return {
+  baseURL: config.baseURL,
+  secret: config.secret,
+  trustedOrigins: [trustedWebOrigin],
+  emailAndPassword: {
     enabled: true,
-    disableImplicitLinking: true,
+    disableSignUp: true,
   },
-},
-trustedOrigins: config.trustedOrigins,
-advanced: {
-  crossSubDomainCookies: config.cookieDomain
-    ? { enabled: true, domain: config.cookieDomain }
-    : { enabled: false },
-  ipAddress: { ipAddressHeaders: ['cf-connecting-ip'] },
-},
-rateLimit: {
-  enabled: true,
-  storage: 'database',
-},
-plugins: [
-  deviceAuthorization({
-    verificationUri: `${config.webURL}/app/desktop-auth`,
-    validateClient: (clientId) => clientId === 'dtx-desktop',
-  }),
-  bearer(),
-],
+  socialProviders: {
+    google: {
+      clientId: config.googleClientId,
+      clientSecret: config.googleClientSecret,
+      disableSignUp: true,
+      disableImplicitSignUp: true,
+    },
+  },
+  account: {
+    accountLinking: {
+      enabled: true,
+      disableImplicitLinking: true,
+    },
+  },
+  advanced: {
+    cookiePrefix: config.cookiePrefix,
+    crossSubDomainCookies: config.cookieDomain
+      ? { enabled: true, domain: config.cookieDomain }
+      : { enabled: false },
+    ipAddress: { ipAddressHeaders: ['cf-connecting-ip'] },
+  },
+  rateLimit: {
+    enabled: true,
+    storage: 'database',
+    customRules: {
+      '/get-session': false,
+    },
+  },
+  plugins: [
+    deviceAuthorization({
+      verificationUri: `${config.webURL}/app/desktop-auth`,
+      validateClient: (clientId) => clientId === 'dtx-desktop',
+    }),
+    bearer(),
+  ],
+};
 ```
 
 Keep Better Auth CSRF/origin checks enabled.
 
-- [ ] **Step 4: Generate schema with the pinned CLI.**
+Do not use `CORS_ALLOWED_ORIGINS` in Better Auth options.
 
-Add package scripts:
+- [ ] **Step 5: Generate schema with the pinned CLI.**
+
+Add scripts using the selected exact CLI:
 
 ```json
 {
@@ -132,26 +171,45 @@ Add package scripts:
 }
 ```
 
-Run generation and review output; do not hand-maintain generated columns.
+Run generation and review output; do not hand-maintain Better Auth columns.
 
-- [ ] **Step 5: Export flat Wrangler-compatible SQL.**
+- [ ] **Step 6: Export flat Wrangler-compatible SQL.**
 
-Configure `drizzle.auth.config.ts`, export SQL, review it, and commit it as `0008_better_auth.sql`. Do not add a runtime Drizzle migration runner.
+Configure `drizzle.auth.config.ts`, export SQL, review it, and commit as `0008_better_auth.sql`. Do not add a runtime Drizzle migration runner.
 
-- [ ] **Step 6: Add environment fields.**
+- [ ] **Step 7: Add environment values.**
+
+Add to `Env`:
 
 ```ts
 BETTER_AUTH_URL: string;
 BETTER_AUTH_SECRET: string;
 DTX_WEB_URL: string;
 AUTH_COOKIE_DOMAIN?: string;
+AUTH_COOKIE_PREFIX: string;
 GOOGLE_AUTH_CLIENT_ID: string;
 GOOGLE_AUTH_CLIENT_SECRET: string;
 ```
 
-`BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` are Wrangler secrets. Keep Supabase vars temporarily until their consumers are removed.
+Wrangler values:
 
-- [ ] **Step 7: Verify schema/local D1.**
+```text
+prod:     DTX_WEB_URL=https://dtx.hapadona.com
+          AUTH_COOKIE_DOMAIN=dtx.hapadona.com
+          AUTH_COOKIE_PREFIX=dtx
+
+pre-prod: DTX_WEB_URL=https://pre-prod.dtx.hapadona.com
+          AUTH_COOKIE_DOMAIN=pre-prod.dtx.hapadona.com
+          AUTH_COOKIE_PREFIX=dtx-preprod
+
+local:    DTX_WEB_URL=http://localhost:5173
+          AUTH_COOKIE_DOMAIN omitted
+          AUTH_COOKIE_PREFIX=dtx-local
+```
+
+`BETTER_AUTH_SECRET` and `GOOGLE_AUTH_CLIENT_SECRET` remain Wrangler secrets. Keep Supabase vars temporarily because application authorization still uses them in PR A.
+
+- [ ] **Step 8: Verify schema/local D1.**
 
 ```bash
 bun run --filter=dtx-api auth:schema:check
@@ -160,7 +218,7 @@ bun run --filter=dtx-api check
 bun run packages/e2e-web/setup/prepare-stack.ts
 ```
 
-- [ ] **Step 8: Commit.**
+- [ ] **Step 9: Commit.**
 
 ```bash
 git add packages/dtx-api/package.json bun.lock \
@@ -172,7 +230,7 @@ git commit -m "feat(auth): add Better Auth D1 schema"
 
 ---
 
-## Task 2: Mount Better Auth and make CORS/cookies lossless
+## Task 2: Mount Better Auth and make CORS credential-capable
 
 **Files:**
 
@@ -185,34 +243,54 @@ git commit -m "feat(auth): add Better Auth D1 schema"
 
 **Interfaces:**
 
-- Produces `createAuth(env)` for Task 3.
-- Exports `getAllowedOrigins(env)`/`isAllowedOrigin(env, origin)` from the existing CORS seam.
-- `withCors()` preserves multiple `Set-Cookie` values for Tasks 5/6.
+- Produces request-scoped `createAuth(env)` for Task 3.
+- Exports the existing `getAllowedOrigins(env)` only for CORS.
+- Keeps existing application GraphQL/REST auth on `verifyToken()`.
 
 - [ ] **Step 1: Add failing auth-router/CORS tests.**
 
 Cover:
 
-- GET/POST `/api/auth/*` routing;
-- unrelated GraphQL/REST routing;
-- exact allowed origin and credentials;
-- denied/missing origin behavior;
-- **two distinct Set-Cookie values survive `withCors()`**.
+1. GET/POST `/api/auth/*` route to Better Auth;
+2. unrelated GraphQL/REST still route normally;
+3. allowed preflight echoes exact Origin + credentials true;
+4. allowed normal response echoes exact Origin + credentials true;
+5. denied/missing Origin receives no credentialed CORS grant;
+6. two distinct Set-Cookie values survive `withCors()`.
 
-- [ ] **Step 2: Export the existing origin parser.**
+- [ ] **Step 2: Make both existing CORS call sites credentialed.**
 
-Keep one parser/cache in `cors.ts`:
+In `handlePreflight()` for an allowed origin:
 
 ```ts
-export const getAllowedOrigins = (env: Env): ReadonlySet<string> => { /* existing parse/cache */ };
-
-export const isAllowedOrigin = (env: Env, origin: string | null): boolean =>
-  origin !== null && getAllowedOrigins(env).has(origin);
+headers['Access-Control-Allow-Origin'] = origin;
+headers['Access-Control-Allow-Credentials'] = 'true';
+headers.Vary = 'Origin';
 ```
 
-Use this same set when creating Better Auth `trustedOrigins`.
+In `withCors()` for an allowed origin:
 
-- [ ] **Step 3: Create the request-scoped auth factory.**
+```ts
+headers.set('Access-Control-Allow-Origin', origin);
+headers.set('Access-Control-Allow-Credentials', 'true');
+appendVary(headers, 'Origin');
+```
+
+Leave `CORS_ALLOWED_ORIGINS` parsing/caching otherwise unchanged.
+
+- [ ] **Step 3: Keep `withCors()` structure unless the multi-cookie test fails.**
+
+Current code starts from:
+
+```ts
+const headers = new Headers(response.headers);
+```
+
+If Step 1 proves two Set-Cookie values survive, keep this copy path. Do not replace it with `headers.get('set-cookie')`.
+
+If the supported Workers test runtime proves cardinality is lost, implement the smallest multi-cookie-preserving copy and keep the regression test.
+
+- [ ] **Step 4: Create request-scoped Better Auth.**
 
 ```ts
 export const createAuth = (env: Env) =>
@@ -221,10 +299,10 @@ export const createAuth = (env: Env) =>
       baseURL: env.BETTER_AUTH_URL,
       webURL: env.DTX_WEB_URL,
       cookieDomain: env.AUTH_COOKIE_DOMAIN,
+      cookiePrefix: env.AUTH_COOKIE_PREFIX,
       googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
       googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
       secret: env.BETTER_AUTH_SECRET,
-      trustedOrigins: [...getAllowedOrigins(env)],
     }),
     database: drizzleAdapter(drizzle(env.DB, { schema: authSchema }), {
       provider: 'sqlite',
@@ -232,17 +310,11 @@ export const createAuth = (env: Env) =>
   });
 ```
 
-This mirrors `createDrizzleDb()` but does not move auth schema into common.
+- [ ] **Step 5: Mount handler before GraphQL/REST.**
 
-- [ ] **Step 4: Mount Better Auth before GraphQL/REST.**
+Handle CORS preflight first, then GET/POST `/api/auth/*`, then existing GraphQL/REST. Wrap auth responses with `withCors()`.
 
-Route GET/POST `/api/auth/*` through `createAuth(env).handler(request)` and wrap the response with `withCors()`.
-
-- [ ] **Step 5: Preserve multiple cookies explicitly.**
-
-When `withCors()` reconstructs a response, preserve every Set-Cookie entry using the Workers multi-cookie API. Do not read a flattened `headers.get('set-cookie')` value.
-
-The focused test must assert both cookie strings remain individually retrievable.
+Do not add Hono.
 
 - [ ] **Step 6: Verify and commit.**
 
@@ -258,12 +330,119 @@ git commit -m "feat(auth): mount Better Auth API"
 
 ---
 
-## Task 3: Replace the Supabase verifier with one neutral session resolver
+## Task 3: Add an unwired neutral session resolver and production API service binding
 
 **Files:**
 
-- Rename/rewrite: `packages/dtx-api/src/auth/verifyToken.ts` → `packages/dtx-api/src/auth/session.ts`
-- Rename/rewrite: `packages/dtx-api/src/auth/verifyToken.test.ts` → `packages/dtx-api/src/auth/session.test.ts`
+- Create: `packages/dtx-api/src/auth/session.ts`
+- Create: `packages/dtx-api/src/auth/session.test.ts`
+- Modify: `packages/dtx-web/wrangler.jsonc`
+- Modify generated/declared Cloudflare binding types if required by `cf-typegen`
+
+**Interfaces:**
+
+- Produces `resolveAuthSession(request, env)` for Cutover Task 4.
+- Produces minimal `ApiAuthUser = { id: string }`.
+- Does **not** modify `packages/dtx-api/src/context.ts` or REST routes yet.
+- Adds root `API -> dtx-api` service binding for production SSR.
+
+- [ ] **Step 1: Add failing resolver tests.**
+
+Cover:
+
+1. valid cookie GET without Origin;
+2. valid cookie POST with exact `new URL(DTX_WEB_URL).origin`;
+3. cookie POST with missing Origin => null;
+4. cookie POST with different Origin => null;
+5. valid Bearer POST without Origin => valid;
+6. malformed Bearer => null;
+7. missing credentials => null;
+8. revoked/expired session => null;
+9. Better Auth exception => null.
+
+- [ ] **Step 2: Implement canonical trusted-origin classification.**
+
+```ts
+const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+const trustedWebOrigin = new URL(env.DTX_WEB_URL).origin;
+const hasBearer = request.headers.get('authorization')?.startsWith('Bearer ') === true;
+const hasCookie = request.headers.has('cookie');
+
+if (
+  !hasBearer &&
+  hasCookie &&
+  UNSAFE_METHODS.has(request.method) &&
+  request.headers.get('origin') !== trustedWebOrigin
+) {
+  return null;
+}
+```
+
+Then call `createAuth(env).api.getSession({ headers: request.headers })` and normalize to local types.
+
+Do not import or consult `CORS_ALLOWED_ORIGINS` here.
+
+- [ ] **Step 3: Keep the live Supabase verifier wired.**
+
+Do not edit `context.ts`, upload/download routes, or delete `verifyToken.ts` in PR A.
+
+Add a source-level assertion/test if helpful so a future edit cannot accidentally wire Better Auth before the cutover PR.
+
+- [ ] **Step 4: Add the production service binding.**
+
+In the root production stanza of `packages/dtx-web/wrangler.jsonc` add:
+
+```json
+"services": [{ "binding": "API", "service": "dtx-api" }]
+```
+
+Keep existing pre-prod bindings:
+
+```text
+pre-prod           -> dtx-api-pre-prod
+pre-prod-prod-data -> dtx-api-pre-prod-prod-data
+```
+
+- [ ] **Step 5: Verify and commit.**
+
+```bash
+bun run --filter=dtx-api test -- src/auth/session.test.ts
+bun run --filter=dtx-api check
+bun run --filter=dtx-web check
+bun run --filter=dtx-web cf-typegen
+
+git add packages/dtx-api/src/auth/session.ts packages/dtx-api/src/auth/session.test.ts \
+  packages/dtx-web/wrangler.jsonc packages/dtx-web/worker-configuration.d.ts
+git commit -m "feat(auth): add Better Auth session foundation"
+```
+
+If `cf-typegen` writes a different tracked type file, stage that exact generated file instead of inventing `worker-configuration.d.ts`.
+
+---
+
+## Foundation PR A gate
+
+- [ ] Rebase on current `main`.
+- [ ] Run Tasks 1-3 verification again.
+- [ ] Confirm the diff contains no GraphQL/REST authorization switch and no Supabase deletion.
+- [ ] Deploy D1 migration/API/web config to pre-production.
+- [ ] Verify `0008_better_auth.sql` applies cleanly.
+- [ ] Verify `/api/auth/get-session` anonymous behavior and Device Authorization code issuance/validation behavior expected for the pinned patch.
+- [ ] Verify credentialed CORS from the exact pre-production web origin.
+- [ ] Verify localhost may remain in `CORS_ALLOWED_ORIGINS` without appearing in Better Auth `trustedOrigins`.
+- [ ] Verify the production service-binding config resolves `dtx-api` in Wrangler validation.
+- [ ] Record non-secret smoke evidence in PR A/HPA-644.
+- [ ] Merge PR A before starting PR B from updated `main`.
+
+---
+
+# Cutover PR B
+
+## Task 4: Switch GraphQL and REST authorization to Better Auth
+
+**Files:**
+
 - Modify: `packages/dtx-api/src/context.ts`
 - Modify: `packages/dtx-api/src/schema/builder.ts`
 - Modify: `packages/dtx-api/src/schema/builder.test.ts`
@@ -273,84 +452,59 @@ git commit -m "feat(auth): mount Better Auth API"
 - Modify: `packages/dtx-api/src/rest/downloadSimfile.test.ts`
 - Modify: `packages/dtx-api/src/rest/downloadBulk.ts`
 - Modify: `packages/dtx-api/src/rest/downloadBulk.test.ts`
+- Delete after all callers move: `packages/dtx-api/src/auth/verifyToken.ts`
+- Delete after all callers move: `packages/dtx-api/src/auth/verifyToken.test.ts`
 
 **Interfaces:**
 
-- Produces `resolveAuthSession(request, env): Promise<ResolvedAuthSession | null>`.
-- Produces minimal `ApiAuthUser = { id: string }`.
-- Applies the unsafe-cookie Origin rule once for GraphQL and REST.
+- Consumes Foundation `resolveAuthSession()`.
+- Makes `ApiAuthUser = { id: string }` the application authorization boundary.
 
-- [ ] **Step 1: Write resolver tests first.**
+- [ ] **Step 1: Retarget API route/context tests first.**
 
-Cover:
+For GraphQL and protected REST prove:
 
-1. valid cookie GET with no Origin;
-2. valid cookie POST with allowed Origin;
-3. cookie POST with missing Origin => null;
-4. cookie POST with disallowed Origin => null;
-5. valid Bearer POST with no Origin => valid;
-6. malformed Bearer => null;
-7. missing credentials => null;
-8. revoked/expired session => null;
-9. Better Auth exception => null.
+- valid Better Auth cookie session;
+- valid desktop Bearer session;
+- unsafe cookie missing/wrong Origin is unauthorized;
+- Bearer needs no Origin;
+- anonymous/invalid remains existing unauthorized behavior.
 
-- [ ] **Step 2: Implement transport classification.**
+- [ ] **Step 2: Replace `verifyToken()` callers.**
 
-```ts
-const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+Use `resolveAuthSession(request, env)` in `context.ts` and protected REST routes. Preserve existing Pothos auth scopes/status/error semantics.
 
-const hasBearer = (request: Request) =>
-  /^Bearer\s+\S+$/i.test(request.headers.get('authorization') ?? '');
+- [ ] **Step 3: Narrow API user shape.**
 
-const cookieOriginAllowed = (request: Request, env: Env) =>
-  !UNSAFE_METHODS.has(request.method) ||
-  isAllowedOrigin(env, request.headers.get('origin'));
-```
-
-If there is no Bearer header and an unsafe request carries cookie authentication, reject the session before returning it unless Origin is allow-listed.
-
-- [ ] **Step 3: Normalize the Better Auth result.**
+Use:
 
 ```ts
 type ApiAuthUser = { id: string };
-type ResolvedAuthSession = {
-  user: ApiAuthUser;
-  session: { id: string };
-};
 ```
 
-Call only:
+Do not export Better Auth or Supabase provider-specific user/session types into schema/services.
 
-```ts
-createAuth(env).api.getSession({ headers: request.headers })
-```
-
-Do not decode bearer tokens or propagate Better Auth/Supabase user types through application code.
-
-- [ ] **Step 4: Retarget context and REST.**
-
-Replace every `verifyToken()` call with `resolveAuthSession()`. Keep current Pothos scope behavior and REST status semantics.
-
-`uploadSimfileFile()` already accepts `{ id: string }`; do not widen it.
-
-- [ ] **Step 5: Verify no Supabase verifier use remains.**
+- [ ] **Step 4: Delete old verifier after search is clean.**
 
 ```bash
 rg -n "verifyToken|SUPABASE_ANON_KEY" packages/dtx-api/src
-bun run --filter=dtx-api test
-bun run --filter=dtx-api check
 ```
 
-- [ ] **Step 6: Commit.**
+Delete `verifyToken.ts` only when no application caller remains.
+
+- [ ] **Step 5: Verify and commit.**
 
 ```bash
+bun run --filter=dtx-api test
+bun run --filter=dtx-api check
+
 git add packages/dtx-api/src
-git commit -m "refactor(auth): resolve Better Auth sessions"
+git commit -m "refactor(auth): use Better Auth application sessions"
 ```
 
 ---
 
-## Task 4: Remove the custom GraphQL magic-link protocol
+## Task 5: Remove the custom magic-link/desktop web handoff
 
 **Files:**
 
@@ -363,28 +517,24 @@ git commit -m "refactor(auth): resolve Better Auth sessions"
 - Delete: `packages/dtx-web/src/lib/api/auth.ts`
 - Delete: `packages/dtx-web/src/lib/api/auth.test.ts`
 - Modify/regenerate: `packages/dtx-web/src/lib/api/generated/graphql.ts`
-- Modify: `packages/dtx-web/src/lib/api/index.ts`
 - Rewrite: `packages/dtx-web/src/routes/(app)/app/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/app-page.test.ts`
 - Delete: `packages/dtx-web/src/routes/(app)/app/app-page-redirect.test.ts`
 - Modify: `packages/dtx-api/package.json`
 
-**Interfaces:**
-
-- Removes the only API consumer that needs auth-user email.
-- Leaves normal `/app` dashboard and web auth guard intact for Task 5.
-
 - [ ] **Step 1: Change schema expectations first.**
 
-Assert `generateMagicLink` no longer exists, remove `./auth` schema registration, regenerate API schema/web GraphQL output.
+Assert `generateMagicLink` disappears, remove schema registration, regenerate GraphQL schema/client output.
 
-- [ ] **Step 2: Delete magic-link service/mutation/rate-limit config.**
+- [ ] **Step 2: Remove server magic-link code.**
 
-Remove service-role key use and `MAGIC_LINK_HOURLY_LIMIT`. Keep `RATE_LIMIT_API`.
+Delete service, mutation, tests, magic-link service-role usage, callback allowlist, magic-link KV keys, and local `MAGIC_LINK_HOURLY_LIMIT` override.
 
-- [ ] **Step 3: Remove `/app?redirect=desktop` page behavior.**
+Keep `RATE_LIMIT_API` because downloads still use it.
 
-Delete magic-link generation and callback handoff from the dashboard. Do not add Device Authorization here; Task 8 owns `/app/desktop-auth`.
+- [ ] **Step 3: Remove `/app?redirect=desktop` UI handoff.**
+
+Remove magic-link generation and callback URL forwarding from the dashboard. Do not add Device Authorization here; Task 9 adds `/app/desktop-auth`.
 
 - [ ] **Step 4: Verify and commit.**
 
@@ -397,99 +547,73 @@ bun run --filter=dtx-api check
 bun run --filter=dtx-web check
 ```
 
-Commit all removals/generated updates together.
+Commit server/schema/generated-web removals together.
 
 ---
 
-## Task 5: Replace SvelteKit Supabase session plumbing and delete desktop web exceptions
+## Task 6: Replace SvelteKit Supabase session plumbing
 
 **Files:**
 
 - Create: `packages/dtx-web/src/lib/auth/client.ts`
 - Create: `packages/dtx-web/src/lib/auth/session.ts`
 - Create matching tests
-- Modify: `packages/dtx-web/src/lib/auth/google.ts`
-- Modify: `packages/dtx-web/src/lib/auth/google.test.ts`
 - Rewrite: `packages/dtx-web/src/hooks.server.ts`
 - Modify: `packages/dtx-web/src/app.d.ts`
 - Rewrite: `packages/dtx-web/src/routes/+layout.server.ts`
 - Rewrite: `packages/dtx-web/src/routes/+layout.ts`
 - Modify: `packages/dtx-web/src/routes/+layout.svelte`
-- Modify: `packages/dtx-web/src/routes/layout.server.test.ts`
-- Modify: `packages/dtx-web/src/routes/layout.test.ts`
-- Modify: `packages/dtx-web/src/routes/layout.svelte.test.ts`
+- Modify related layout/hook tests
 
 **Interfaces:**
 
-- Reuses `safeAppRedirectPath()` and auth error strings in existing `google.ts`.
-- Produces `authClient` for Tasks 6/8.
-- Produces neutral `event.locals.user/session` and raw multi-cookie propagation.
+- Reuses `safeAppRedirectPath()` from `$lib/auth/google.ts`; no second redirect helper.
+- Uses production/pre-prod `event.platform.env.API` service binding when available.
+- Falls back to `PUBLIC_DTX_API_URL` for local Vite/non-Workers execution.
 
-- [ ] **Step 1: Extend existing redirect/helper tests.**
+- [ ] **Step 1: Add failing session/guard tests.**
 
-Keep `safeAppRedirectPath()` semantics and current sanitized Google/linking messages. Do **not** create `$lib/auth/redirect.ts`.
+Cover anonymous/authenticated session lookup, service binding preference, public fallback, forwarded cookies, two Set-Cookie propagation, protected `/app` redirect, safe `next`, authenticated `/login` redirect, and API failure.
 
-Delete only Supabase-specific callback URL builders/desktop redirect intent once no callers remain.
-
-- [ ] **Step 2: Add failing hook/session tests.**
-
-Cover:
-
-- anonymous/authenticated get-session;
-- incoming Cookie forwarding;
-- two returned Set-Cookie headers propagated separately;
-- protected `/app` redirect with safe `next`;
-- authenticated `/login` redirect;
-- API failure;
-- no `redirect=desktop`/`desktop_callback` branch;
-- no `DTXDesktopApp` CSRF bypass.
-
-- [ ] **Step 3: Create Better Auth Svelte client.**
+- [ ] **Step 2: Add Better Auth Svelte client.**
 
 Point it at `PUBLIC_DTX_API_URL`, set `credentials: 'include'`, and register `deviceAuthorizationClient()`.
 
-- [ ] **Step 4: Rewrite the server hook.**
+- [ ] **Step 3: Implement server session lookup without a public production round-trip.**
 
-The hook:
+If `event.platform?.env.API` exists, call its `fetch()` handler with `/api/auth/get-session`. Otherwise fetch `PUBLIC_DTX_API_URL`.
 
-1. forwards `Cookie` to `/api/auth/get-session`;
-2. reads all returned Set-Cookie values with the Workers multi-cookie API;
-3. sets neutral locals from the response body;
-4. calls `resolve(event)`;
-5. appends each raw Set-Cookie value to the outgoing SvelteKit response.
+Forward the incoming Cookie header.
 
-Do not parse/rebuild Better Auth cookies.
+For service-binding unsafe GraphQL later, the external trusted origin is `event.url.origin`; session GET itself remains read-only and does not require Origin.
 
-- [ ] **Step 5: Delete desktop-specific hook logic.**
+- [ ] **Step 4: Preserve every Set-Cookie value.**
 
-Remove:
+Use the runtime multi-cookie API and append each raw Set-Cookie value to the SvelteKit response. Never use a single `headers.get('set-cookie')` value.
+
+- [ ] **Step 5: Delete old desktop web exceptions.**
+
+Remove from `hooks.server.ts`:
 
 ```text
 redirect=desktop
 desktop_callback
-DTXDesktopApp form-CSRF bypass
+DTXDesktopApp user-agent/x-requested-with CSRF bypass
 ```
 
-Keep normal same-origin SvelteKit form-CSRF protection and the `/app` guard.
+Keep normal SvelteKit form-CSRF behavior and `/app` guard.
 
-- [ ] **Step 6: Simplify root layout.**
+- [ ] **Step 6: Simplify layout data.**
 
-Stop constructing Supabase browser/server clients and remove `supabase:auth` invalidation/subscriptions. Return only neutral user/session plus existing locale data.
+Remove Supabase clients/subscriptions/invalidation. Return neutral user/session plus existing locale data.
 
 - [ ] **Step 7: Verify and commit.**
 
-```bash
-bun run --filter=dtx-web test -- src/lib/auth src/routes/layout.server.test.ts src/routes/layout.test.ts src/routes/layout.svelte.test.ts
-bun run --filter=dtx-web check
-
-git add packages/dtx-web/src/hooks.server.ts packages/dtx-web/src/app.d.ts \
-  packages/dtx-web/src/lib/auth packages/dtx-web/src/routes/+layout*
-git commit -m "refactor(auth): load Better Auth web sessions"
-```
+Run focused hook/layout tests, full web tests, and `bun run --filter=dtx-web check`.
 
 ---
 
-## Task 6: Move web sign-in, logout, and Google linking to Better Auth
+## Task 7: Move web sign-in, logout, and Google linking to Better Auth
 
 **Files:**
 
@@ -505,53 +629,34 @@ git commit -m "refactor(auth): load Better Auth web sessions"
 - Rewrite: `packages/dtx-web/src/routes/(app)/app/account/+page.svelte`
 - Modify: `packages/dtx-web/src/routes/(app)/app/account/account-page.test.ts`
 
-**Interfaces:**
+- [ ] **Step 1: Move existing redirect/error assertions before route deletion.**
 
-- Consumes `authClient` and retained `safeAppRedirectPath()`/sanitized messages.
-- Removes the custom SvelteKit OAuth callback route without losing its reusable test cases.
-
-- [ ] **Step 1: Move existing callback assertions before deletion.**
-
-Retarget cases from `auth/callback/server.test.ts` and `login/page.server.test.ts` into `google.test.ts`, login tests, and account tests as appropriate:
-
-- safe return paths;
-- external/protocol-relative rejection;
-- provider cancel/failure sanitization;
-- existing-account-only Google copy;
-- explicit-link conflict copy.
+Retarget existing callback/login tests for safe `/app` paths, external/protocol-relative rejection, provider cancellation/failure sanitization, existing-account-only copy, and explicit-link conflict copy.
 
 - [ ] **Step 2: Implement password sign-in.**
-
-Use:
 
 ```ts
 await authClient.signIn.email({ email, password });
 window.location.assign(safeAppRedirectPath(next));
 ```
 
-Preserve `/app` as the missing-`next` default in the login flow.
+Preserve `/app` as the missing-next default.
 
 - [ ] **Step 3: Implement Google sign-in/linking.**
 
-Use `authClient.signIn.social({ provider: 'google', callbackURL })` for login and `authClient.linkSocial({ provider: 'google', callbackURL })` from the account page.
+Use `signIn.social({ provider: 'google', callbackURL })` for login and `linkSocial({ provider: 'google', callbackURL })` on the account page. Keep implicit linking/signup disabled.
 
-Keep `account_not_linked` mapped to the existing existing-account-only message. Do not permit implicit same-email linking.
+- [ ] **Step 4: Delete old SvelteKit OAuth callback.**
 
-- [ ] **Step 4: Delete SvelteKit OAuth callback.**
+Better Auth `/api/auth/callback/google` is authoritative. Delete only old Supabase callback URL builders after callers/tests move.
 
-Better Auth `/api/auth/callback/google` is authoritative. Delete old URL builders from `google.ts` only after caller/test migration.
+- [ ] **Step 5: Implement logout and verify.**
 
-- [ ] **Step 5: Implement logout.**
-
-Call `authClient.signOut()` then full-navigate to `/login`. Remove Supabase identity/session assumptions from app/account UI.
-
-- [ ] **Step 6: Verify and commit.**
-
-Run focused web auth tests, full web unit suite, and typecheck. Commit the complete web auth action migration.
+Call `authClient.signOut()` then full-navigate to `/login`. Run web auth tests/typecheck and commit.
 
 ---
 
-## Task 7: Convert **every** web API call from Bearer to cookies
+## Task 8: Convert every web API call from Bearer to cookies
 
 **Files:**
 
@@ -562,27 +667,16 @@ Run focused web auth tests, full web unit suite, and typecheck. Commit the compl
 - Modify: `packages/dtx-web/src/lib/api/download.ts`
 - Modify: `packages/dtx-web/src/lib/api/download.test.ts`
 - Modify: `packages/dtx-web/src/lib/api/index.test.ts`
-- Modify token-mocking tests including:
-  - `packages/dtx-web/src/lib/api/chart.test.ts`
-  - `packages/dtx-web/src/lib/api/score.test.ts`
-  - `packages/dtx-web/src/lib/api/user.test.ts`
-- Modify affected component tests consuming `bulkDownloadHeaders`
-- Delete only at the end: `packages/dtx-web/src/lib/api/token.ts`
-- Delete only at the end: `packages/dtx-web/src/lib/api/token.test.ts`
+- Modify token-mocking tests including `chart.test.ts`, `score.test.ts`, `user.test.ts`
+- Modify affected bulk-download component/helper tests
+- Delete only at end: `packages/dtx-web/src/lib/api/token.ts`
+- Delete only at end: `packages/dtx-web/src/lib/api/token.test.ts`
 
-**Interfaces:**
+- [ ] **Step 1: Add browser GraphQL tests.**
 
-- Browser fetches use `credentials: 'include'` and no Authorization.
-- Service-binding SSR uses `{ cookieHeader, origin }`, not `accessToken`.
-- Desktop remains Bearer and is not part of this web transport task.
-
-- [ ] **Step 1: Add failing browser GraphQL tests.**
-
-Assert GraphQL client uses credentials and no Authorization header.
+Assert browser GraphQL uses `credentials: 'include'` and no Authorization header.
 
 - [ ] **Step 2: Replace token-shaped `ClientCtx`.**
-
-Use:
 
 ```ts
 export type ClientCtx = {
@@ -593,8 +687,6 @@ export type ClientCtx = {
 };
 ```
 
-Delete `accessToken` from web client context.
-
 - [ ] **Step 3: Rewrite service-binding GraphQL.**
 
 Forward:
@@ -602,48 +694,33 @@ Forward:
 ```text
 content-type: application/json
 cookie: <incoming cookie>
-origin: <trusted SvelteKit event.url.origin>
+origin: <canonical DTX web origin>
 ```
 
-The explicit Origin is required because GraphQL POST is an unsafe cookie-authenticated method and Task 3 enforces the same origin policy on service-binding requests.
+The Origin must be the external trusted web origin, not an internal service-binding URL.
 
 - [ ] **Step 4: Rewrite download helpers.**
 
-`downloadSimfile()` fetches with:
+`downloadSimfile()` fetches with `credentials: 'include'`. `bulkDownloadHeaders()` stops adding Bearer; the actual bulk fetch also sets `credentials: 'include'`.
 
-```ts
-{ credentials: 'include' }
-```
-
-`bulkDownloadHeaders()` returns only the content-type header; the actual bulk fetch also sets `credentials: 'include'`.
-
-Update the component/helper call site that performs the bulk fetch, not just the header builder.
-
-- [ ] **Step 5: Remove every token mock/import.**
+- [ ] **Step 5: Remove all token mocks/imports before deleting helper.**
 
 ```bash
 rg -n "getAccessTokenOrNull|getAccessToken|tokenFromSession|from './token'|mock.*token" packages/dtx-web/src
 ```
 
-Expected before deletion: zero live call sites outside `token.ts`/its test.
+Delete `token.ts` only after the search is clean.
 
-- [ ] **Step 6: Delete `token.ts` only after Step 5 is clean.**
-
-This ordering keeps the commit compiling.
-
-- [ ] **Step 7: Verify and commit.**
+- [ ] **Step 6: Verify and commit.**
 
 ```bash
 bun run --filter=dtx-web test
 bun run --filter=dtx-web check
-
-git add packages/dtx-web/src/lib/api packages/dtx-web/src/lib/components packages/dtx-web/src/routes
-git commit -m "refactor(auth): use cookie-authenticated web API"
 ```
 
 ---
 
-## Task 8: Add the desktop Device Authorization approval page
+## Task 9: Add the desktop Device Authorization approval page
 
 **Files:**
 
@@ -652,40 +729,37 @@ git commit -m "refactor(auth): use cookie-authenticated web API"
 - Modify: `packages/dtx-web/src/lib/auth/client.ts`
 - Modify: `packages/dtx-web/src/routes/layout.test.ts`
 
-**Interfaces:**
-
-- Consumes authenticated Better Auth web session and `deviceAuthorizationClient()`.
-- Produces browser claim/approve/deny path for native Task 9.
-
 - [ ] **Step 1: Add failing approval-page tests.**
 
 Cover prefilled/manual code, normalization, claim success, invalid/expired code, approve, deny, double-submit prevention, and unauthenticated return-through-login.
 
-- [ ] **Step 2: Implement code claim.**
+- [ ] **Step 2: Implement claim.**
 
-Normalize with trim/remove dashes/uppercase, then call Better Auth's device verification method. Rely on `/app` guard and its validated `next` return.
+Normalize code by trim/remove dashes/uppercase, call the pinned Better Auth Device Authorization verification method, and rely on `/app` guard for auth/next.
 
-- [ ] **Step 3: Implement explicit Approve/Deny.**
+- [ ] **Step 3: Implement explicit approve/deny.**
 
-Show user code and fixed `dtx-desktop` client identity. Disable actions while one request is in flight. Show terminal success/denial text; never redirect to a desktop callback.
+Show user code and fixed `dtx-desktop` client identity. Disable both buttons while processing. Show terminal success/denial text; never redirect to a desktop callback.
 
 - [ ] **Step 4: Verify and commit.**
 
-Run page/layout tests plus web typecheck and commit the new route.
+Run page/layout tests plus web typecheck.
 
 ---
 
-## Task 9: Replace native Supabase auth with Device Authorization
+## Task 10: Replace native Supabase auth with Device Authorization and retarget native E2E auth
 
 **Files:**
 
 - Create: `packages/dtx-desktop/src-tauri/src/device_auth.rs`
 - Create: `packages/dtx-desktop/src-tauri/src/tests/device_auth_tests.rs`
 - Rewrite: `packages/dtx-desktop/src-tauri/src/auth.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/e2e.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/api.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/lib.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/tests/auth_tests.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/tests/api_tests.rs`
+- Modify: `packages/dtx-desktop/src-tauri/src/tests/e2e_tests.rs`
 - Modify: `packages/dtx-desktop/src-tauri/src/api_contracts.rs`
 - Modify: `packages/dtx-desktop/src-tauri/Cargo.toml`
 - Regenerate: `packages/dtx-desktop/src/renderer/src/lib/generated/native-api-contracts.ts`
@@ -693,20 +767,22 @@ Run page/layout tests plus web typecheck and commit the new route.
 **Interfaces:**
 
 - `device_auth.rs` is HTTP protocol only and WireMock-testable.
-- `auth.rs` retains `AuthState`, session generation/epoch, and existing command names.
-- `validate_session` retains `SessionValidationStatus`.
+- `auth.rs` retains `AuthState`, session generation/epoch, existing command names, and e2e/debug seed path.
+- `SessionData` becomes Better Auth-shaped `{ sessionToken, user }`.
 
 - [ ] **Step 1: Add WireMock protocol tests.**
 
 Cover code request, display-safe response, pending, slow-down, approval, denial, expiry, invalid grant, malformed body, timeout, and network failure. Confirm `device_code` never crosses Tauri IPC.
 
-- [ ] **Step 2: Implement protocol-only `device_auth.rs`.**
+- [ ] **Step 2: Implement protocol-only module.**
 
-Use Better Auth 1.6.25 wire names exactly, centralize API-base construction, and never log device/session tokens.
+Use exact wire fields of the Task-1 pinned Better Auth patch. Centralize API base URL construction and never log device/session tokens.
 
-- [ ] **Step 3: Define native DTOs in `api_contracts.rs`.**
+- [ ] **Step 3: Define native DTOs.**
 
-Add `DesktopAuthUser`, `DesktopAuthSession`, and `DeviceAuthorizationAttempt` with `TS` export. Attempt exposes only:
+Add `DesktopAuthUser`, `DesktopAuthSession`, `DeviceAuthorizationAttempt` in `api_contracts.rs` with existing `ts-rs` export target.
+
+Attempt exposes only:
 
 ```text
 userCode
@@ -715,11 +791,36 @@ verificationUriComplete
 expiresAt
 ```
 
-- [ ] **Step 4: Preserve `AuthState` identity/epoch semantics.**
+- [ ] **Step 4: Preserve `AuthState`/Drive epoch semantics.**
 
-Keep authenticated user ID, generation counter, and `AuthSessionEpoch` so Google Drive reconciliation does not regress. Replace Supabase JSON/refresh state with typed opaque session state and one pending native device code.
+Keep authenticated user ID, generation counter, and `AuthSessionEpoch`. Replace Supabase JSON/refresh state with typed opaque session state and one pending native device code.
 
-- [ ] **Step 5: Add Device Authorization commands.**
+- [ ] **Step 5: Retarget `SessionData` and native E2E validation.**
+
+Replace:
+
+```text
+access_token
+refresh_token
+user
+```
+
+with:
+
+```text
+sessionToken
+user
+```
+
+Update `e2e_session_matches_user()` to require the expected user ID and a non-empty session token only.
+
+Update `AuthState::for_e2e_user()` and `src/tests/e2e_tests.rs` so no fake Supabase refresh token remains.
+
+Keep this path gated by `feature = "e2e"` + `debug_assertions`; it must remain impossible in release binaries.
+
+- [ ] **Step 6: Add/retarget commands.**
+
+Add:
 
 ```text
 begin_device_authorization
@@ -736,32 +837,15 @@ logout_session
 open_external_url
 ```
 
-- [ ] **Step 6: Preserve `SessionValidationStatus`.**
-
-Keep:
-
-```rust
-Valid
-Invalid
-NotConfigured
-```
-
-Behavior:
-
-- missing/blank desktop API config => `NotConfigured`;
-- `/api/auth/get-session` returns authenticated user => `Valid`;
-- 401/no session => `Invalid`;
-- network/5xx remains fail-closed and is **not** mislabeled as local configuration absence.
-
-Do not introduce Better Auth server secret into desktop config.
+`validate_session` retains `Valid | Invalid | NotConfigured`.
 
 - [ ] **Step 7: Replace API token access.**
 
-Rename `ensure_valid_access_token` to `current_session_token`. Remove JWT expiry parsing, refresh calls, refresh lock, and refresh events. Existing API code continues sending `Authorization: Bearer <opaque-session-token>`.
+Rename `ensure_valid_access_token` to `current_session_token`. Remove JWT expiry parsing, refresh calls, refresh lock, and refresh events. Existing API calls continue `Authorization: Bearer <opaque-session-token>`.
 
-- [ ] **Step 8: Remove callback machinery.**
+- [ ] **Step 8: Remove production callback machinery.**
 
-Delete auth deep-link handlers/queues, loopback TCP server, magic-link parsing, callback validation, Supabase verify/refresh/logout code, JWT decoder, and auth events. Preserve `tauri-plugin-single-instance` for normal window behavior. Remove deep-link plugin only after repository search proves no non-auth use.
+Delete auth deep-link handlers/queues, loopback server, magic-link parsing, callback validation, Supabase verify/refresh/logout code, JWT decoder, auth events. Keep single-instance behavior; remove deep-link plugin only if no non-auth use remains.
 
 - [ ] **Step 9: Verify and commit.**
 
@@ -773,11 +857,11 @@ cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml \
 bun run gen:native-types
 ```
 
-Commit Rust and generated TypeScript together.
+Commit native/generated changes together.
 
 ---
 
-## Task 10: Rewire desktop renderer persistence/lifecycle
+## Task 11: Rewire desktop renderer and every existing desktop E2E session seed
 
 **Files:**
 
@@ -795,18 +879,17 @@ Commit Rust and generated TypeScript together.
 - Modify: `packages/dtx-desktop/src-tauri/tauri.dev.conf.json`
 - Modify: root `package.json`
 - Modify: `packages/dtx-desktop/src/devTopology.test.ts`
+- Modify: `packages/e2e-desktop/wdio.conf.ts`
+- Modify: `packages/e2e-desktop/support/standalone-session.ts`
+- Modify: `packages/e2e-desktop/support/standalone-session.test.mjs`
+- Modify: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
+- Modify: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
 
-**Interfaces:**
+- [ ] **Step 1: Add renderer lifecycle tests.**
 
-- Consumes generated Task 9 DTOs/commands.
-- Persists one `{ sessionToken, user }` value.
-- Keeps renderer restore behavior aware of `not-configured`.
+Cover start, displayed code, browser open, poll success, persistence, restore valid, restore invalid cleanup, restore not-configured preserving storage, logout cleanup, cancellation/retry, and browser-open fallback.
 
-- [ ] **Step 1: Add lifecycle tests.**
-
-Cover start, displayed code, browser open, poll success, persistence, restore valid, restore invalid cleanup, restore not-configured preserving storage, logout cleanup, cancel/retry, and browser-open fallback.
-
-- [ ] **Step 2: Replace Supabase-shaped persistence.**
+- [ ] **Step 2: Replace renderer persistence.**
 
 Store one neutral object:
 
@@ -817,17 +900,27 @@ Store one neutral object:
 }
 ```
 
-Delete old Supabase access/refresh local-storage keys when encountered; do not migrate them.
+Delete old `auth_access_token`, `auth_refresh_token`, and `auth_user_data` values when encountered; do not migrate them.
 
 - [ ] **Step 3: Rewrite renderer auth service.**
 
-After `beginDeviceAuthorization`, open `verificationUriComplete`, show manual URI/code fallback, and poll. Remove magic-link/session-refreshed listeners.
+After `beginDeviceAuthorization`, call existing `openExternalUrl(verificationUriComplete)`, show manual URI/code fallback, and poll. Remove magic-link/session-refreshed listeners.
 
 - [ ] **Step 4: Keep tri-state restore behavior.**
 
-If native returns `not-configured`, show the build/configuration error and **do not wipe the stored Better Auth session**. If `invalid`, clear it.
+`not-configured` preserves stored Better Auth session and surfaces build/config error. `invalid` clears it.
 
-- [ ] **Step 5: Remove callback/deep-link configuration.**
+- [ ] **Step 5: Retarget WDIO/standalone E2E injection.**
+
+Keep `DTX_E2E_DRUMERY_USER_ID`; it still identifies the debug-only seeded user.
+
+Update renderer/localStorage setup in `google-drive-upload.e2e.ts` and `google-drive-crash-recovery.ts` to write the new neutral session object instead of Supabase access/refresh keys.
+
+Update standalone-session tests if they assert the old auth storage/env shape.
+
+Do not add an API test-auth endpoint; reuse the native e2e/debug seed path from Task 10.
+
+- [ ] **Step 6: Remove callback/deep-link configuration.**
 
 Remove:
 
@@ -839,13 +932,21 @@ PUBLIC_DTX_DESKTOP_AUTH_CALLBACK_URL
 
 Simplify dev scripts/topology tests. Remove auth URI schemes only after no non-auth use remains.
 
-- [ ] **Step 6: Verify and commit.**
+- [ ] **Step 7: Verify and commit.**
 
-Run renderer tests, typecheck, Rust tests, and native type generation; commit desktop renderer/config changes together.
+```bash
+bun run --filter=dtx-desktop test
+bun run --filter=dtx-desktop check
+bun run --filter=dtx-e2e-desktop test
+cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml --all-features
+bun run gen:native-types
+```
+
+Use the actual E2E package unit-test script name if different; do not silently skip its support tests.
 
 ---
 
-## Task 11: Add ID-preserving identity import and Better Auth E2E seed
+## Task 12: Add ID-preserving identity import and Better Auth web E2E seed
 
 **Files:**
 
@@ -862,38 +963,29 @@ Run renderer tests, typecheck, Rust tests, and native type generation; commit de
 - Modify: `packages/e2e-web/package.json`
 - Modify: `.gitignore`
 
-**Interfaces:**
+- [ ] **Step 1: Specify import invariants.**
 
-- Produces reviewed SQL only under ignored `tmp/auth-migration/`.
-- Seeds the fixed E2E UUID into the same D1 that `prepare-stack.ts` already migrates.
-
-- [ ] **Step 1: Specify import invariants in tests.**
-
-Assert exact UUID preservation, email/name/verification/timestamps, Google identity mapping, no sessions/tokens, deterministic account IDs, SQL escaping, duplicate rejection, unsupported-provider rejection, and owner-ID reconciliation.
+Test exact UUID preservation, email/name/verification/timestamps, Google identity, no sessions/tokens, deterministic account IDs, SQL escaping, duplicate rejection, unsupported-provider rejection, and owner-ID reconciliation.
 
 - [ ] **Step 2: Implement local-only import tool.**
 
-Consume sanitized Supabase Admin export JSON and emit D1 SQL; do not import `@supabase/supabase-js` and do not write directly to remote D1.
+Consume sanitized Supabase Admin export JSON and emit reviewed D1 SQL under ignored `tmp/auth-migration/`. Do not import `@supabase/supabase-js`; do not write remote D1 directly.
 
 - [ ] **Step 3: Handle credential users without bcrypt compatibility.**
 
-Require explicit replacement password input and hash it with Better Auth's password helper. No replacement password means no credential account is generated.
+Require explicit replacement password input and hash it with the pinned Better Auth password helper. No replacement password means no credential account.
 
-- [ ] **Step 4: Seed local Better Auth auth rows.**
+- [ ] **Step 4: Seed local Better Auth web user.**
 
-Replace `create-local-supabase-user.ts` with D1 seeding after `prepare-stack.ts` applies all `d1-migrations/*.sql`. Preserve the existing fixed test UUID used by application seed rows.
+After `prepare-stack.ts` applies every migration, seed Better Auth user/account rows into the same D1 using the fixed test UUID already used by application seed rows.
 
-- [ ] **Step 5: Retarget Playwright env/setup.**
+- [ ] **Step 5: Retarget Playwright env/setup and verify.**
 
-Remove Supabase E2E URL/anon/service-role inputs. Keep fail-loud CI behavior for incomplete Better Auth test credentials/config.
-
-- [ ] **Step 6: Verify and commit.**
-
-Run import tests, local stack preparation, Playwright setup, and E2E typecheck. Commit no real-user export/SQL/secrets.
+Remove Supabase E2E URL/anon/service-role inputs. Keep fail-loud CI behavior for incomplete Better Auth test config. Run import tests, local stack prep, Playwright setup, and E2E typecheck.
 
 ---
 
-## Task 12: Remove all Supabase residue and obsolete typegen
+## Task 13: Remove Supabase residue and obsolete typegen
 
 **Files:**
 
@@ -913,27 +1005,22 @@ Run import tests, local stack preparation, Playwright setup, and E2E typecheck. 
 - Modify affected mocks/tests/workflows
 - Modify: `CLAUDE.md`
 
-**Interfaces:**
-
-- Deletes the root/turbo Supabase `gen-types` task so Task 14 does not call it.
-- Leaves GraphQL codegen and `gen:native-types` intact.
-
-- [ ] **Step 1: Add/run a residue gate.**
+- [ ] **Step 1: Run residue gate before edits.**
 
 ```bash
 rg -n -i "@supabase|supabase|PUBLIC_SUPABASE|SUPABASE_" \
   packages package.json turbo.json .env.example CLAUDE.md __mocks__ .github
 ```
 
-Exclude only historical docs and the named one-shot import tool/tests where “Supabase” describes the input format.
+Historical migration docs and the one-shot import tool may describe Supabase as an input format; runtime/config/tests may not depend on it.
 
 - [ ] **Step 2: Remove packages/types/mocks.**
 
-Remove `@supabase/ssr`, `@supabase/supabase-js`, the common peer dependency, generated Supabase types/exports, and Supabase-specific mocks.
+Remove `@supabase/ssr`, `@supabase/supabase-js`, common peer dependency, generated Supabase types/exports, and provider mocks.
 
 - [ ] **Step 3: Remove environment/workflow residue.**
 
-Delete Supabase URL/anon/service-role variables, magic-link limit, callback variables, Turbo env entries, and old E2E secret requirements.
+Delete Supabase URL/anon/service-role variables, magic-link limit, callback vars, Turbo env entries, and old E2E secret requirements.
 
 - [ ] **Step 4: Delete obsolete root typegen.**
 
@@ -944,96 +1031,73 @@ package.json scripts.gen-types
 turbo.json tasks.gen-types
 ```
 
-because that task exists only to generate `packages/common/src/lib/types/supabase.types.ts`, which this task deletes.
-
-Keep:
-
-```text
-packages/dtx-api gen-schema
-dtx-web codegen
-root gen:native-types
-```
+Keep API GraphQL schema generation, dtx-web codegen, and root `gen:native-types`.
 
 - [ ] **Step 5: Verify and commit.**
 
-Run residue gate, lockfile/install check, package typechecks, and unit tests, then commit the cleanup.
+Run residue gate, lockfile/install check, all package typechecks, and unit tests.
 
 ---
 
-## Task 13: Add E2E coverage and write the production cutover runbook
+## Task 14: Add E2E coverage and write/reconcile the production runbook
 
 **Files:**
 
 - Modify/create authenticated specs under `packages/e2e-web/`
 - Modify/create desktop auth specs under `packages/e2e-desktop/`
+- Revisit: `packages/e2e-desktop/wdio.conf.ts`
+- Revisit: `packages/e2e-desktop/support/standalone-session.ts`
+- Revisit: `packages/e2e-desktop/support/standalone-session.test.mjs`
+- Revisit: `packages/e2e-desktop/specs/google-drive-upload.e2e.ts`
+- Revisit: `packages/e2e-desktop/scripts/google-drive-crash-recovery.ts`
 - Create: `docs/superpowers/runbooks/2026-08-18-better-auth-d1-cutover.md`
-- After PR #221 lands, modify:
-  - `docs/superpowers/specs/2026-08-17-cloudflare-zero-trust-web-access-design.md`
-  - `docs/superpowers/plans/2026-08-17-cloudflare-zero-trust-web-access.md`
-  - `docs/superpowers/runbooks/2026-08-17-cloudflare-zero-trust-web-access.md`
-
-**Interfaces:**
-
-- Produces automated end-to-end proof for Task 14.
-- Production runbook owns production import/deploy/rollback; Task 14 does not execute them.
+- After PR #221 lands, modify its Zero Trust spec/plan/runbook documents
 
 - [ ] **Step 1: Update web E2E.**
 
 Cover password login, `/app` guard, authenticated GraphQL/score flow, authenticated download, logout, and invalid-session redirect without Supabase credentials.
 
-- [ ] **Step 2: Add Device Authorization integration E2E.**
+- [ ] **Step 2: Cover real Device Authorization at API/web integration level.**
 
-Against local API/D1: request code, authenticate browser, claim, approve, poll, validate user, revoke. Cover deny and expiry. Do not add test-only auth endpoints.
+Against local API/D1: request code, authenticate browser, claim, approve, poll, validate user, and revoke. Cover deny and expiry.
 
-- [ ] **Step 3: Update desktop E2E.**
+Do not add a production or API-wide test-auth endpoint. It is acceptable to retain the existing native `e2e + debug_assertions` seed seam for WDIO desktop tests; that path is already compile-time excluded from release builds.
 
-Cover renderer state and authenticated desktop behavior using supported Better Auth/D1 setup. Keep one manual real-browser-open handoff check in the runbook because OS browser launching is outside stable WDIO coverage.
+- [ ] **Step 3: Re-run desktop E2E session-shape audit.**
 
-- [ ] **Step 4: Write the runbook.**
+```bash
+rg -n "auth_access_token|auth_refresh_token|auth_user_data|e2e-supabase|refresh_token|DTX_E2E_DRUMERY_USER_ID" \
+  packages/e2e-desktop packages/dtx-desktop/src-tauri/src
+```
 
-Include exact sections for:
+Expected after intended debug-only identifiers are accounted for: no Supabase-shaped renderer session seed or fake refresh token remains.
 
-1. backup/export prerequisites;
-2. pinned versions;
-3. Google callbacks;
-4. Wrangler secrets;
-5. Supabase Admin export;
-6. generated import SQL review;
-7. D1 migration/import order;
-8. owner-ID reconciliation queries;
-9. deployment order;
-10. web matrix;
-11. desktop matrix;
-12. Cloudflare Access matrix;
-13. go/no-go;
-14. production cutover;
-15. Supabase-disable proof;
-16. rollback.
+- [ ] **Step 4: Update desktop E2E.**
 
-Production actions are instructions for an operator, not automated steps in this implementation plan.
+Cover renderer auth state and authenticated desktop behavior using the debug-only native seed plus Better Auth-shaped `{ sessionToken, user }` storage. Keep one manual real-browser-open Device Authorization handoff check in the runbook because OS browser launch is outside stable WDIO coverage.
 
-- [ ] **Step 5: Reconcile PR #221 documentation.**
+- [ ] **Step 5: Write production runbook.**
 
-Replace Supabase as the inner gate, replace `/login?redirect=desktop`/callbacks with `/app/desktop-auth`/Device Authorization, keep production `/app` operator-only, keep pre-prod Access behavior, keep API hostnames outside Access.
+Include exact sections for backup/export, pinned version, cookie prefixes/domains, trusted web origins, service binding, Google callbacks, Wrangler secrets, Supabase Admin export, generated import SQL review, D1 order, owner reconciliation, deployment order, web matrix, desktop matrix, Access matrix, go/no-go, production cutover, Supabase-disable proof, and rollback.
 
-- [ ] **Step 6: Verify and commit.**
+Production actions remain operator instructions.
 
-Run both E2E suites, formatting, and `git diff --check`; commit tests/runbook/docs together.
+- [ ] **Step 6: Reconcile PR #221 documentation.**
+
+Replace Supabase inner gate with Better Auth and `/login?redirect=desktop` callbacks with `/app/desktop-auth` Device Authorization. Preserve production `/app` operator policy, pre-prod Access behavior, and public API hostnames.
+
+- [ ] **Step 7: Verify and commit.**
+
+Run web E2E, desktop E2E, formatting, and `git diff --check`.
 
 ---
 
-## Task 14: Full verification and pre-production proof
+## Task 15: Full verification and pre-production cutover proof
 
 **Files:**
 
 - Modify only files required by failed verification.
-- Update the runbook with corrected **non-secret** assumptions/results.
-
-**Interfaces:**
-
-- Final code-PR gate.
-- Stops after pre-production proof and a production-ready runbook.
-- Does **not** execute production D1 import/deploy or remove production Supabase credentials.
+- Update runbook with corrected non-secret assumptions/results.
 
 - [ ] **Step 1: Run static/unit/Rust verification.**
 
@@ -1049,7 +1113,7 @@ cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml \
   --all-targets --all-features -- -D warnings
 ```
 
-Do **not** run the deleted root `gen-types` Supabase task.
+Do not run deleted root `gen-types`.
 
 - [ ] **Step 2: Run generated-artifact gates.**
 
@@ -1061,16 +1125,21 @@ bun run gen:native-types
 git diff --exit-code
 ```
 
-- [ ] **Step 3: Run residue gates.**
+- [ ] **Step 3: Run auth/trust residue gates.**
 
 Confirm:
 
 ```text
-no runtime Supabase imports/config
-no getAccessTokenOrNull/token.ts seam
-no desktop auth callback variables
-no auth deep-link/loopback/JWT/refresh code
-no root/turbo Supabase gen-types task
+no runtime Supabase import/config
+no getAccessTokenOrNull/token.ts
+no desktop auth callback vars
+no production auth deep-link/loopback/JWT/refresh code
+no root/turbo Supabase gen-types
+auth trustedOrigins comes from DTX_WEB_URL, not CORS_ALLOWED_ORIGINS
+prod/pre-prod cookie prefixes differ
+credentialed CORS true on preflight and normal responses
+production dtx-web has API service binding
+/get-session is exempt from DB-backed rate limiting
 ```
 
 - [ ] **Step 4: Run E2E.**
@@ -1082,54 +1151,88 @@ bun run e2e:desktop
 
 Expected: PASS without Supabase credentials.
 
-- [ ] **Step 5: Prepare and prove pre-production only.**
+- [ ] **Step 5: Prove pre-production.**
 
 Using the runbook:
 
-- configure pre-prod Better Auth/Google secrets and callback;
-- apply D1 migrations;
-- generate/review/apply sanitized identity-import SQL to pre-prod;
+- configure pre-prod Better Auth/Google secrets/callback;
+- confirm `DTX_WEB_URL=https://pre-prod.dtx.hapadona.com`;
+- confirm `AUTH_COOKIE_PREFIX=dtx-preprod`;
+- apply D1 migration;
+- generate/review/apply sanitized identity-import SQL to pre-prod only;
 - reconcile every application owner ID;
 - deploy API then web;
+- verify SvelteKit SSR uses service binding;
 - build desktop candidate pointed at pre-prod;
 - execute password, Google, linking, GraphQL, upload/download, Device Authorization approve/deny/expiry, restore/logout, and Access checks;
-- confirm API auth endpoints remain outside Access and `/app/desktop-auth` remains protected;
-- confirm the candidate no longer needs Supabase at runtime.
+- verify localhost CORS origins do not become Better Auth trusted origins;
+- verify production `dtx.*` cookie is not interpreted as pre-production session;
+- verify candidate no longer needs Supabase runtime access.
 
-- [ ] **Step 6: Record pre-prod evidence and production go/no-go criteria.**
+- [ ] **Step 6: Record evidence and stop before production.**
 
-Record only non-secret outcomes in the runbook. Production go/no-go requires all automated/pre-prod checks, exact owner reconciliation, configured callbacks/secrets, and rollback artifacts.
+Record only non-secret outcomes. Production go/no-go requires all checks, exact owner reconciliation, callbacks/secrets, rollback artifacts, and reviewed runbook.
 
-- [ ] **Step 7: Stop before production execution.**
+Do not run production `0008`, production identity import, production deploy, desktop publication, or credential removal from this task.
 
-Do not run production `0008`, production identity import, production deploy, desktop publication, or credential removal from this task. Those remain explicit operator actions in the runbook after review/approval.
-
-- [ ] **Step 8: Final repository verification.**
+- [ ] **Step 7: Final repository verification.**
 
 ```bash
 git status --short
 git diff --check
 ```
 
-Commit only verification-driven code/doc corrections; do not create an empty commit.
+Commit only verification-driven corrections.
+
+## Risks
+
+### Foundation/cutover drift
+
+PR A intentionally adds unused Better Auth infrastructure while Supabase remains live. PR B must start from merged PR A and must not reintroduce a dual-auth application authorization path.
+
+### Cookie collision
+
+Production domain cookie scope includes nested pre-production hosts. Distinct `AUTH_COOKIE_PREFIX` values are required before browser Better Auth sessions are used.
+
+### Origin confusion
+
+`CORS_ALLOWED_ORIGINS` contains deployed pre-production localhost entries. It is never an auth trust list. `DTX_WEB_URL` is the only trusted application web origin.
+
+### SSR hot path
+
+Production session lookup must use the service binding, and `/get-session` must be exempt from DB rate limiting.
+
+### Desktop E2E seam
+
+Existing debug E2E currently assumes access + refresh tokens. Task 10/11 must migrate the seed and renderer storage before Task 15 runs `e2e:desktop`.
+
+### Identity mismatch
+
+No application ownership FK is added; exact import reconciliation is therefore a hard pre-production/production gate.
 
 ## Completion Definition
 
-The implementation PR is ready when:
+HPA-644 is ready for production operator execution when:
 
-- [ ] D1 schema/migration includes Better Auth core, Device Authorization, and rate-limit tables.
-- [ ] Existing application owner UUIDs are preserved by the import tooling.
+- [ ] Foundation PR A merged/deployed and additive pre-production proof passed.
+- [ ] Cutover PR B static/type/unit/Rust/web-E2E/desktop-E2E gates pass.
+- [ ] Better Auth/CLI are pinned to the same reviewed 1.6.x patch.
+- [ ] D1 holds Better Auth core, Device Authorization, and rate-limit tables.
+- [ ] Existing application owner UUIDs are preserved by import tooling.
 - [ ] Password and Google web sign-in use Better Auth.
-- [ ] Explicit Google linking works; implicit linking/signup are disabled.
-- [ ] `CORS_ALLOWED_ORIGINS` is the one browser-origin trust list for CORS, Better Auth, and unsafe cookie auth.
-- [ ] Multi-value Set-Cookie survives API CORS wrapping and SvelteKit session forwarding.
-- [ ] Browser GraphQL and REST/download paths use cookies and no Supabase bearer helper remains.
-- [ ] Service-binding SSR forwards Cookie plus trusted Origin.
-- [ ] Desktop uses Device Authorization plus opaque Bearer sessions.
-- [ ] Desktop preserves `valid | invalid | not-configured` restore semantics and session epoch/Drive reconciliation.
-- [ ] Desktop contains no magic-link, auth deep-link, loopback callback, JWT decoder, or refresh-token rotation.
-- [ ] No active package/test/config/environment contract depends on Supabase.
-- [ ] Obsolete root/turbo Supabase `gen-types` is deleted.
-- [ ] Unit, integration, Rust, web E2E, and desktop E2E checks pass.
-- [ ] Pre-production acceptance passes.
-- [ ] Production runbook is complete and ready for separate operator execution.
+- [ ] Explicit linking works; implicit linking/signup remain disabled.
+- [ ] `DTX_WEB_URL` is the auth trust origin; `CORS_ALLOWED_ORIGINS` is CORS-only.
+- [ ] Production/pre-prod/local cookies have distinct prefixes.
+- [ ] Credentialed CORS is enabled on preflight and normal responses.
+- [ ] Multi-value Set-Cookie survives CORS and SvelteKit forwarding.
+- [ ] Production SSR uses the `API -> dtx-api` service binding.
+- [ ] `/get-session` does not use database-backed rate limiting.
+- [ ] Browser GraphQL/REST/downloads use cookie sessions and unsafe-method canonical-Origin validation.
+- [ ] Desktop uses Device Authorization + opaque Bearer sessions.
+- [ ] Desktop retains valid/invalid/not-configured and Drive session-epoch semantics.
+- [ ] Desktop E2E uses Better Auth-shaped `{ sessionToken, user }` and no fake refresh token.
+- [ ] No production auth magic-link/deep-link/loopback/JWT/refresh-token machinery remains.
+- [ ] No active package/config/test depends on Supabase.
+- [ ] Obsolete root/turbo Supabase `gen-types` is removed.
+- [ ] Full pre-production acceptance passes.
+- [ ] Production runbook is ready for separate operator execution.

--- a/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
@@ -6,101 +6,118 @@
 
 ## Summary
 
-DTXWeb already stores application data in Cloudflare D1. Supabase remains as the authentication provider and as Supabase-shaped session plumbing across the web app, API, desktop app, tests, environment configuration, and generated types.
+DTXWeb already stores application data in Cloudflare D1. Supabase remains as the authentication provider and as Supabase-shaped session plumbing across the web app, API, desktop app, E2E setup, dependencies, generated types, and environment configuration.
 
-This design completes the migration by hosting Better Auth in `dtx-api`, storing Better Auth data in the existing D1 database, moving browser requests to Better Auth cookie sessions, and replacing the desktop magic-link/deep-link protocol with Better Auth Device Authorization plus Bearer sessions.
+Complete the migration by hosting Better Auth 1.6.25 in `dtx-api`, storing Better Auth tables in the existing D1 database, using cookies for web authentication, and replacing the desktop magic-link/deep-link protocol with Better Auth Device Authorization plus opaque Bearer sessions.
 
-The cutover is intentionally direct. There is no dual-auth feature flag, long-lived Supabase verifier, custom device protocol, OAuth Provider/JWT layer, or second auth Worker.
+The cutover stays intentionally small:
+
+- one auth runtime in `dtx-api`;
+- one D1 database;
+- the official Better Auth Drizzle adapter;
+- no dual-auth compatibility mode;
+- no OAuth Provider/JWT/JWKS layer;
+- no second Worker;
+- no custom device protocol;
+- no permanent bcrypt compatibility.
+
+The migration invalidates active Supabase sessions. Existing application ownership identifiers are preserved exactly.
 
 ## Current State
 
-### Application data
+### Application data is already D1-backed
 
-The application data path is already D1-backed:
+`dtx-api` owns the `DB` binding and versioned Wrangler D1 migrations. Shared application queries use the existing D1 schema for simfiles, DTX files, user profiles, chart scores, and scores.
 
-- `dtx-api` owns the `DB` binding and versioned D1 migrations.
-- Shared server queries use the existing D1 schema for simfiles, DTX files, user profiles, chart scores, and scores.
-- Runtime code no longer uses Supabase tables or Supabase Storage.
+Runtime application data no longer depends on Supabase tables or Supabase Storage.
 
-Application ownership is keyed by the current Supabase user UUID stored as text. At minimum, `simfiles.user_id`, `user_profiles.user_id`, and `chart_scores.user_id` depend on that value.
+Application ownership is keyed by Supabase UUIDs stored as text, including `simfiles.user_id`, `user_profiles.user_id`, and `chart_scores.user_id`. Those columns do not need to become foreign keys to Better Auth.
 
 ### Remaining Supabase responsibilities
 
 Supabase still owns or shapes:
 
-- Web SSR/browser session creation and validation.
-- Password sign-in, Google OAuth, explicit provider linking, and logout.
-- API bearer-token validation.
-- Desktop magic-link generation and exchange.
-- Desktop deep-link and loopback callback handling.
-- Desktop JWT expiry parsing and refresh-token rotation.
-- E2E user provisioning.
-- Environment variables, dependencies, generated Supabase types, and mocks.
+- SvelteKit SSR/browser session creation and validation;
+- password sign-in, Google sign-in, explicit provider linking, and logout;
+- API Bearer-token validation;
+- desktop magic-link generation and exchange;
+- desktop deep-link and loopback callback handling;
+- desktop JWT expiry parsing and refresh-token rotation;
+- E2E user provisioning;
+- environment variables, dependencies, generated Supabase types, and mocks.
 
-The desktop path has the largest migration payoff. Better Auth Device Authorization replaces the custom GraphQL magic-link mutation, callback validation, URI schemes, loopback server, JWT decoding, refresh lock, and session-refresh events.
+The desktop path has the largest simplification opportunity. Device Authorization removes the custom magic-link mutation, callback allowlists, auth URI schemes, loopback HTTP server, JWT decoder, refresh lock, and session-refresh events.
 
 ## Goals
 
 1. Make D1 the only database used by DTXWeb runtime services.
 2. Replace Supabase Auth with Better Auth 1.6.25.
-3. Preserve every migrated user's existing UUID as the Better Auth user ID.
+3. Preserve every migrated Supabase UUID as the matching Better Auth `user.id`.
 4. Keep password and Google sign-in for existing users.
-5. Keep Google account linking explicit.
-6. Use Better Auth Device Authorization for desktop sign-in.
-7. Use Better Auth's Bearer plugin for desktop GraphQL and REST requests.
-8. Remove runtime Supabase dependencies, variables, callbacks, refresh logic, generated types, and test bootstrap code.
-9. Keep the architecture small and first-party-client focused.
+5. Keep Google linking explicit and signup disabled.
+6. Authenticate browser API traffic with Better Auth cookies.
+7. Authenticate desktop API traffic with Device Authorization plus opaque Bearer sessions.
+8. Remove all runtime Supabase dependencies, variables, callbacks, refresh logic, generated types, and E2E bootstrap code.
+9. Keep production cutover operations in an operator runbook, not in the implementation task list.
 
 ## Non-goals
 
-This migration does not add:
+Do not add:
 
-- Public registration.
-- Password-reset or email-verification delivery.
-- Passkeys, two-factor authentication, organizations, roles, or an admin dashboard.
-- Better Auth Infrastructure.
-- An OAuth 2.1/OIDC provider, JWT/JWKS issuance, scopes, or API keys.
-- A second auth Worker or second D1 database.
-- KV/Redis session storage.
-- Desktop keychain migration.
-- Backward compatibility for active Supabase sessions.
-- A permanent bcrypt compatibility layer.
+- public registration;
+- password-reset or email-verification delivery;
+- passkeys, 2FA, organizations, roles, or an admin dashboard;
+- Better Auth Infrastructure;
+- OAuth Provider, OIDC Provider, JWT/JWKS, API keys, scopes, or resource audiences;
+- another Worker or database;
+- KV/Redis session storage;
+- desktop keychain migration;
+- backward compatibility for active Supabase sessions;
+- permanent bcrypt verification.
 
-Active Supabase sessions are invalidated at cutover. Users sign in again through Better Auth.
+Google Drive OAuth remains separate from application authentication.
 
 ## Decisions
 
 ### 1. Host Better Auth in `dtx-api`
 
-`dtx-api` already owns D1 and the public API hostname. It mounts Better Auth under `/api/auth/*` before the existing GraphQL and REST router.
+`dtx-api` already owns D1 and the public API hostname. Mount Better Auth under `/api/auth/*` before the existing GraphQL and REST routes in the current hand-written router.
 
-This avoids giving the web Worker a D1 binding, running two auth instances, sharing auth internals between Workers, or making desktop polling depend on a Cloudflare Access-protected hostname.
+`dtx-web` does not receive a D1 binding. Production web also has no API service binding today, so browser production traffic continues to call `PUBLIC_DTX_API_URL` directly.
 
-`dtx-web` remains the browser UI and desktop approval surface.
+This avoids two auth instances, another Worker, or a new internal auth service.
 
-### 2. Use Better Auth's official Drizzle adapter over D1
+### 2. Use the official Drizzle-on-D1 adapter
 
-Better Auth 1.6.25's Cloudflare fixture uses a request-scoped Drizzle client and the official adapter:
+Follow Better Auth 1.6.25's Cloudflare pattern:
 
 ```ts
-database: drizzleAdapter(drizzle(env.DB, { schema }), {
-  provider: "sqlite",
-})
+const db = drizzle(env.DB, { schema: authSchema });
+
+database: drizzleAdapter(db, {
+  provider: 'sqlite',
+});
 ```
 
-The generated auth schema lives at `packages/dtx-api/src/auth/schema.ts`. The existing application-data schema remains unchanged.
+This mirrors the existing `createDrizzleDb()` shape in `@dtx/common/server`, but the Better Auth schema remains owned by `dtx-api` because it is auth-runtime data, not application-domain data.
 
-The pinned Better Auth CLI generates the Drizzle schema. `drizzle-kit export` emits reviewed SQL into the repository's existing Wrangler D1 migration flow. Wrangler remains the only production migration executor.
+The pinned Better Auth CLI generates `packages/dtx-api/src/auth/schema.ts`. `drizzle-kit export` produces reviewed flat SQL for `packages/dtx-api/d1-migrations/0008_better_auth.sql`. Wrangler remains the only production migration executor.
 
-### 3. Keep auth rate limiting inside Better Auth
+### 3. Keep one origin allowlist
 
-Better Auth uses its database-backed rate limiter. Behind Cloudflare it reads `cf-connecting-ip` rather than trusting a client-controlled forwarded chain.
+`CORS_ALLOWED_ORIGINS` is the single configured list of browser origins trusted to call `dtx-api`.
 
-The existing `RATE_LIMIT_API` KV binding remains for downloads and other API features. Only magic-link-specific rate-limit code and variables are removed.
+Export the parser/read helper from `packages/dtx-api/src/lib/cors.ts` and reuse the same set for:
+
+- CORS response headers;
+- Better Auth `trustedOrigins`;
+- cookie-authenticated unsafe API request validation.
+
+Do not introduce a second `TRUSTED_ORIGINS` setting.
+
+`DTX_WEB_URL` remains because Device Authorization needs one canonical web URL for `verificationUri`.
 
 ### 4. Use cross-subdomain cookies for web sessions
-
-Better Auth runs on the API hostname while SvelteKit runs on the web hostname.
 
 | Environment | API base URL | Web origin | Cookie domain |
 | --- | --- | --- | --- |
@@ -108,9 +125,37 @@ Better Auth runs on the API hostname while SvelteKit runs on the web hostname.
 | Pre-production | `https://api.pre-prod.dtx.hapadona.com` | `https://pre-prod.dtx.hapadona.com` | `pre-prod.dtx.hapadona.com` |
 | Local | `http://localhost:8787` | `http://localhost:5173` | omitted |
 
-CORS echoes only configured origins, sets `Access-Control-Allow-Credentials: true`, and includes `Vary: Origin`. Browser auth and GraphQL requests use `credentials: "include"`.
+CORS echoes only allow-listed origins, sets `Access-Control-Allow-Credentials: true`, and includes `Vary: Origin`. Browser auth, GraphQL, and authenticated REST requests use `credentials: 'include'`.
 
-### 5. Disable signup and implicit linking
+Because the production cookie domain is a parent of pre-production hostnames, cookie authentication must not rely on CORS alone as its CSRF boundary.
+
+### 5. Enforce Origin on unsafe cookie-authenticated API requests
+
+`resolveAuthSession()` distinguishes authentication transport:
+
+- If a valid `Authorization: Bearer` header is present, validate it with Better Auth and do not require `Origin`. This is the desktop/native path.
+- If authentication comes from cookies and the method is `POST`, `PUT`, `PATCH`, or `DELETE`, require `Origin` to be present and contained in `CORS_ALLOWED_ORIGINS` before accepting the session.
+- Cookie-authenticated `GET`/`HEAD` stays usable without `Origin` so normal authenticated reads and navigation/download paths are not broken.
+
+An unsafe request with a cookie but an absent/disallowed Origin is treated as unauthenticated at the shared session boundary. Protected GraphQL/REST code then returns its existing forbidden/unauthorized result.
+
+SvelteKit service-binding GraphQL calls explicitly forward both the incoming cookie and the trusted web origin so they satisfy the same rule. Production, which has no service binding, uses normal browser `Origin` headers.
+
+Better Auth's own `/api/auth/*` handler keeps Better Auth's built-in origin/CSRF checks enabled.
+
+### 6. Preserve multiple `Set-Cookie` headers
+
+Cloudflare Workers exposes multiple `Set-Cookie` values separately. Any wrapper that reconstructs a `Response` must preserve their cardinality.
+
+`withCors()` gets a regression test with two `Set-Cookie` values. When copying a response, preserve the array returned by the Workers `Headers` cookie API rather than flattening cookies through `headers.get('set-cookie')`.
+
+The SvelteKit session hook also reads all returned Set-Cookie values and appends each raw header to the eventual web response. It does not parse and reserialize Better Auth cookies.
+
+This keeps login/session rotation correct without adding a cookie-parsing dependency.
+
+### 7. Disable signup and implicit linking
+
+Use:
 
 ```ts
 emailAndPassword: {
@@ -119,8 +164,8 @@ emailAndPassword: {
 },
 socialProviders: {
   google: {
-    clientId: env.GOOGLE_AUTH_CLIENT_ID,
-    clientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
+    clientId: config.googleClientId,
+    clientSecret: config.googleClientSecret,
     disableSignUp: true,
     disableImplicitSignUp: true,
   },
@@ -133,47 +178,71 @@ account: {
 },
 ```
 
-Imported Google accounts can sign in. An authenticated user can link Google explicitly with `linkSocial()`.
+Imported Google identities may sign in. An authenticated user links Google explicitly with `linkSocial()`.
 
-The Google Auth client is separate from the existing Google Drive OAuth client used by the desktop app.
+### 8. Reuse the existing web redirect/error allowlist
 
-### 6. Use Device Authorization and Bearer, not OAuth Provider/JWT
+Do not create a second redirect helper.
 
-DTX Desktop is a first-party client of the same application. It does not need third-party client registration, scopes, resource audiences, refresh tokens, JWT verification, or JWKS.
+Keep `packages/dtx-web/src/lib/auth/google.ts` as the application-auth redirect/error seam:
+
+- retain `safeAppRedirectPath()`;
+- retain sanitized Google/auth error messages;
+- retain explicit-linking messages;
+- delete only the Supabase-specific `/auth/callback` URL builders and desktop redirect intent after callers are migrated.
+
+Existing login and callback tests are retargeted so the current allowlist/error cases remain covered instead of being replaced by thinner tests.
+
+### 9. Use Device Authorization and Bearer for desktop
+
+DTX Desktop is a first-party client of the same application. It does not need OAuth Provider, scopes, JWT access tokens, JWKS, or refresh-token rotation.
+
+Configure:
 
 ```ts
 plugins: [
   deviceAuthorization({
-    verificationUri: `${env.DTX_WEB_URL}/app/desktop-auth`,
-    validateClient: (clientId) => clientId === "dtx-desktop",
+    verificationUri: `${config.webURL}/app/desktop-auth`,
+    validateClient: (clientId) => clientId === 'dtx-desktop',
   }),
   bearer(),
 ]
 ```
 
-`/device/token` returns a Better Auth session token in `access_token`. Desktop sends that opaque token as `Authorization: Bearer <token>`. `auth.api.getSession({ headers })` validates both browser cookies and desktop bearer sessions.
+`/device/token` returns a Better Auth session token in `access_token`. Desktop sends it as `Authorization: Bearer <token>`. The same Better Auth `getSession` path validates browser cookies and desktop bearer sessions.
 
-## Target Architecture
+### 10. Preserve desktop session-validation semantics
+
+Keep the existing renderer/native contract:
 
 ```text
-                                 Cloudflare D1
-                    application tables + Better Auth tables
-                                        ▲
-                                        │
-                         api.dtx.hapadona.com
-                 ┌──────────────────────┴──────────────────────┐
-                 │                                             │
-          /api/auth/*                                  /graphql + REST
-        Better Auth handler                         resolve Better Auth session
-                 │                                             │
-       ┌─────────┴─────────┐                                   │
-       │                   │                                   │
-Web browser cookie    Desktop device flow ── Bearer session ───┘
-       │
-dtx.hapadona.com
-login, account, and
-/app/desktop-auth UI
+valid | invalid | not-configured
 ```
+
+`validate_session` is retargeted, not redesigned:
+
+- missing/blank desktop API configuration => `not-configured`;
+- authenticated `/api/auth/get-session` returns the user => `valid`;
+- 401/no session => `invalid`;
+- transport/server failure remains fail-closed according to the current restore behavior and must not be mislabeled as local configuration absence.
+
+The desktop never receives `BETTER_AUTH_SECRET`; that secret remains server-only.
+
+### 11. Keep API auth user types minimal
+
+After the magic-link mutation is removed, GraphQL/REST authorization only needs the user identifier.
+
+Use a neutral API type such as:
+
+```ts
+type ApiAuthUser = {
+  id: string;
+};
+```
+
+Add `email` only at a boundary that actually renders or needs it. Do not re-export or emulate Supabase `User`/`Session` shapes.
+
+The web session model may expose Better Auth user fields needed by the UI; that is separate from `dtx-api`'s authorization type.
 
 ## Better Auth Server
 
@@ -184,226 +253,195 @@ packages/dtx-api/src/auth/options.ts
 packages/dtx-api/src/auth/auth.ts
 packages/dtx-api/src/auth/auth.cli.ts
 packages/dtx-api/src/auth/schema.ts
-packages/dtx-api/src/auth/session.ts
+packages/dtx-api/src/auth/session.ts   # rename/rewrite of the current verifier seam
 packages/dtx-api/src/auth/*.test.ts
 packages/dtx-api/drizzle.auth.config.ts
 packages/dtx-api/d1-migrations/0008_better_auth.sql
 ```
 
-`createAuthOptions(config)` contains shared provider, cookie, rate-limit, and plugin settings. Runtime supplies D1 and real secrets. CLI schema generation supplies non-production placeholders and the pinned Drizzle SQLite adapter metadata.
-
-### Runtime instance
-
-```ts
-export const createAuth = (env: Env) =>
-  betterAuth({
-    ...createAuthOptions({
-      baseURL: env.BETTER_AUTH_URL,
-      webURL: env.DTX_WEB_URL,
-      cookieDomain: env.AUTH_COOKIE_DOMAIN,
-      googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
-      googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
-      secret: env.BETTER_AUTH_SECRET,
-    }),
-    database: drizzleAdapter(drizzle(env.DB, { schema }), {
-      provider: "sqlite",
-    }),
-  });
-```
-
-The instance is request-scoped because the Cloudflare D1 binding is request-scoped.
+`createAuthOptions()` contains provider, cookie, rate-limit, origin, and plugin settings. Runtime supplies D1 and real secrets. CLI schema generation supplies non-production placeholders.
 
 ### Router order
 
-`packages/dtx-api/src/index.ts` handles requests in this order:
+`packages/dtx-api/src/index.ts` handles:
 
-1. CORS preflight.
-2. Better Auth `/api/auth/*` GET/POST handler.
-3. Existing GraphQL and REST routes.
-4. Existing not-found response.
+1. CORS preflight;
+2. Better Auth `/api/auth/*` GET/POST;
+3. GraphQL and REST;
+4. not-found.
 
-The Worker does not add Hono or another router solely for auth mounting.
+Do not add Hono solely to mount auth.
 
 ### Neutral session resolver
 
-`packages/dtx-api/src/auth/session.ts` exposes one boundary:
+Rename/rewrite the current verifier seam into `packages/dtx-api/src/auth/session.ts`:
 
 ```ts
-resolveAuthSession(request, env): Promise<{
-  user: AuthUser | null;
-  session: AuthSession | null;
-}>
+type ResolvedAuthSession = {
+  user: ApiAuthUser;
+  session: { id: string };
+};
+
+resolveAuthSession(request, env): Promise<ResolvedAuthSession | null>
 ```
 
-It calls `createAuth(env).api.getSession({ headers: request.headers })` and normalizes missing or invalid sessions to null.
+The implementation:
 
-GraphQL context and protected REST routes use the same helper. The current `verifyToken()` function is removed.
+1. classifies Bearer versus cookie transport;
+2. applies the unsafe-cookie Origin rule;
+3. calls `createAuth(env).api.getSession({ headers: request.headers })`;
+4. normalizes provider-specific data to the local type;
+5. returns null for missing/invalid credentials.
 
-### Remove custom magic links
+GraphQL context and protected REST routes use this one helper.
 
-Delete:
+### Auth rate limiting
 
-- GraphQL `generateMagicLink` mutation and service.
-- Generated web GraphQL operation and wrapper.
-- Web `/app?redirect=desktop` handoff.
-- Magic-link rate-limit configuration.
+Use Better Auth's database-backed rate limiter with `cf-connecting-ip`.
 
-Device Authorization endpoints become the only desktop authentication protocol.
+Keep `RATE_LIMIT_API` for downloads and other existing API rate limits. Delete only magic-link-specific keys/configuration.
 
 ## Web Authentication
 
-### Server hook
+### SvelteKit hook
 
-The SvelteKit hook no longer constructs a Supabase client. It calls the API session endpoint with the incoming cookie header, stores neutral user/session data in `event.locals`, and keeps the existing `/app` route guard and safe `next` handling.
+The hook no longer constructs a Supabase client.
 
-When Better Auth rotates a cookie, the hook forwards all returned `Set-Cookie` headers to the browser.
+It:
 
-### Browser client
+1. forwards the incoming `Cookie` header to `/api/auth/get-session`;
+2. captures all returned Set-Cookie headers;
+3. stores neutral user/session data in `event.locals`;
+4. appends each raw Set-Cookie header to the SvelteKit response;
+5. guards `/app` and preserves a validated `next` destination.
 
-Create one Better Auth Svelte client pointed at `PUBLIC_DTX_API_URL` with `credentials: "include"` and the Device Authorization client plugin.
+Delete the old desktop-specific branches:
 
-The root layout stops exposing a Supabase client. Page data contains only neutral session/user data.
+- `redirect=desktop`;
+- `desktop_callback` forwarding;
+- the `DTXDesktopApp` form-CSRF bypass.
+
+Device Authorization no longer posts forms from the desktop app into the web Worker.
 
 ### Login and Google OAuth
 
-The login page uses:
+Use the Better Auth browser client for password and Google sign-in. Preserve `safeAppRedirectPath()` and sanitized errors from `$lib/auth/google.ts`.
 
-```ts
-authClient.signIn.email({ email, password })
-authClient.signIn.social({ provider: "google", callbackURL })
-```
+Google callbacks terminate at `dtx-api`'s Better Auth handler. Delete the SvelteKit `/auth/callback` route after its reusable allowlist/error assertions have been moved to the retained helper/login/account tests.
 
-After password sign-in, the page performs a full navigation to the validated `next` route. Google callbacks terminate at the API hostname; the custom SvelteKit `/auth/callback` route is removed.
+### Every web API call uses cookies
 
-### GraphQL transport
+The cookie cutover is complete only when all browser/SSR API seams are converted before `token.ts` is deleted.
 
-The generated GraphQL layer remains unchanged.
+Update together:
 
-- Browser requests use `credentials: "include"` and no bearer header.
-- SvelteKit service-binding requests forward the incoming `Cookie` header.
-- Desktop requests keep `Authorization: Bearer`, now carrying a Better Auth session token.
+- `packages/dtx-web/src/lib/api/transport.ts`;
+- `packages/dtx-web/src/lib/api/client.ts`;
+- `packages/dtx-web/src/lib/api/download.ts`;
+- API wrapper tests that mock `./token`;
+- components/tests that consume `bulkDownloadHeaders`.
 
-`packages/dtx-web/src/lib/api/token.ts` is removed.
+Browser GraphQL and download fetches use `credentials: 'include'` and no Authorization header.
 
-### Logout and account linking
+Service-binding SSR GraphQL forwards `Cookie` and the trusted web `Origin`. No token-shaped `ClientCtx.accessToken` remains.
 
-Logout calls `authClient.signOut()` and navigates to `/login`.
-
-The account page uses Better Auth account APIs and explicit `linkSocial({ provider: "google" })`. Supabase identity objects disappear from the UI contract.
+Only after those imports/tests are gone is `packages/dtx-web/src/lib/api/token.ts` deleted.
 
 ## Desktop Authentication
 
 ### Browser approval flow
 
-1. Rust posts to `/api/auth/device/code` with `client_id=dtx-desktop`.
+1. Native code posts to `/api/auth/device/code` with `client_id=dtx-desktop`.
 2. Better Auth returns device/user codes, verification URLs, interval, and expiry.
-3. Rust stores only the opaque `device_code` in native memory and returns display-safe attempt data.
-4. The renderer calls the existing `open_external_url` command with `verification_uri_complete` and shows `user_code`.
-5. The browser reaches `/app/desktop-auth?user_code=...`.
-6. The web auth guard requires a Better Auth browser session.
-7. The page calls the Device Authorization verification endpoint to claim the code for that session.
-8. The page shows the code/client and requires explicit Approve or Deny.
-9. Rust polls `/api/auth/device/token` at the server interval.
+3. Native code keeps `device_code` only in memory and returns display-safe attempt data.
+4. Renderer calls existing `open_external_url(verificationUriComplete)`.
+5. Browser reaches `/app/desktop-auth?user_code=...`.
+6. The `/app` guard requires a Better Auth web session.
+7. The page verifies/claims the user code for that session.
+8. The page requires explicit Approve or Deny.
+9. Native code polls `/api/auth/device/token` at the required interval.
 10. On approval, Better Auth returns the opaque session token.
-11. Rust calls `/api/auth/get-session` with Bearer auth to obtain the user.
-12. Native and renderer state persist one session token plus user data.
+11. Native code calls `/api/auth/get-session` with Bearer auth to obtain the user.
+12. Native/renderer state stores one session token plus user data.
 
-The API hostname stays outside Cloudflare Access so issuance and polling work. The approval route remains under `/app`, preserving PR #221's operator-only production gate.
+The API hostname stays outside Cloudflare Access. `/app/desktop-auth` stays under the protected application surface.
 
 ### Native command boundary
+
+Add:
 
 ```text
 begin_device_authorization
 poll_device_authorization
 cancel_device_authorization
+```
+
+Retarget without renaming:
+
+```text
 validate_session
 get_current_session
 logout_session
 open_external_url
 ```
 
-The migration preserves the existing `validate_session`, `get_current_session`, `logout_session`, and `open_external_url` names. Only their Supabase-shaped payloads change.
+Keep Device Authorization HTTP protocol code in `device_auth.rs`, independent of Tauri UI APIs, and cover it with WireMock.
 
-`begin_device_authorization` returns `userCode`, `verificationUri`, `verificationUriComplete`, and `expiresAt`. It never exposes `device_code`.
+### Native DTOs and state
 
-`poll_device_authorization` handles:
+Define renderer-facing DTOs in `packages/dtx-desktop/src-tauri/src/api_contracts.rs` and generate TypeScript through the existing `ts-rs` export target.
 
-- `authorization_pending`: continue.
-- `slow_down`: add five seconds.
-- `access_denied`: stop with denial.
-- `expired_token`: stop and require restart.
-- `invalid_grant`: clear the attempt.
-- Network failure: return a retryable error.
+Preserve the current authenticated user ID, session generation, and session epoch used by Google Drive reconciliation.
 
-Only one pending attempt exists. A generation counter or cancellation token prevents an older poll from committing after cancel/restart.
+Remove:
 
-### Native state and persistence
-
-Replace arbitrary Supabase JSON with typed `DesktopAuthUser`, `DesktopAuthSession`, and `DeviceAuthorizationAttempt` contracts generated from `src-tauri/src/api_contracts.rs` into `src/renderer/src/lib/generated/native-api-contracts.ts`.
-
-Renderer persistence stores only:
-
-```ts
-interface StoredDesktopAuthSession {
-  sessionToken: string;
-  user: DesktopAuthUser;
-}
-```
-
-Keep the existing local-storage mechanism for this migration. Moving the token to the OS keychain is a separate hardening task.
-
-Preserve the current authenticated user ID, session generation, and session epoch used by Google Drive state reconciliation.
-
-### Remove callback machinery
-
-Delete:
-
-- Magic-link parsing/exchange.
-- Auth deep-link handlers and queues.
-- Loopback TCP callback server.
-- Callback URL/port validation.
-- JWT payload parsing.
-- Supabase refresh/logout REST calls.
-- Refresh single-flight mutex.
+- magic-link parsing/exchange;
+- auth deep-link handlers/queues;
+- loopback TCP callback server;
+- callback URL/port validation;
+- JWT parsing;
+- Supabase refresh/logout requests;
+- refresh single-flight mutex;
 - `magic-link-result` and `session-refreshed` events.
 
-Remove `tauri-plugin-deep-link` after no non-test use remains. Keep `tauri-plugin-single-instance` for window focusing, without auth URL extraction.
+Remove the auth deep-link plugin/config only after repository search proves it has no non-auth use. Keep single-instance window focusing.
 
 ## Identity Migration
 
 ### Preserve IDs
 
-Every Better Auth `user.id` must equal the existing Supabase UUID. Application ownership rows are not rewritten.
+Every imported Better Auth `user.id` equals the existing Supabase UUID. Application ownership rows are not rewritten.
 
-The migration imports:
+Import:
 
-- User ID.
-- Email and name.
-- Email verification state.
-- Created/updated timestamps.
-- Google provider/account identity.
-- Credential account only when a replacement password is supplied.
+- user ID;
+- email/name;
+- verification state;
+- timestamps;
+- Google account identity;
+- credential account only when an explicit replacement password is supplied.
 
-Do not import Supabase sessions, access tokens, or refresh tokens.
+Do not import Supabase sessions/access/refresh tokens.
 
 ### Password policy
 
-Supabase password hashes are bcrypt while Better Auth defaults to scrypt. There are no external users and backward compatibility is not required, so do not add permanent bcrypt verification.
+Do not add bcrypt compatibility. Replacement credential passwords are hashed with Better Auth's own password helper during the one-shot import.
 
-For each credential user, provide a replacement password during the one-shot import and hash it with Better Auth's own password helper. Users without a replacement password use an imported Google account or are reset manually before cutover.
+### Import tooling
 
-### One-shot import tool
+Create a local-only script that consumes a sanitized Supabase Admin export and emits reviewed D1 SQL under `tmp/auth-migration/`.
 
-Create a local-only script that consumes a sanitized Supabase Admin export and emits reviewed D1 SQL. It must:
+It must:
 
-- Validate UUIDs and unique emails.
-- Reject unsupported providers instead of guessing.
-- Generate deterministic account IDs.
-- Escape SQL values safely.
-- Exclude sessions.
-- Reconcile every distinct application owner ID against imported users.
-- Write only under `tmp/auth-migration/`, which remains ignored.
-- Never send Supabase secrets to a Worker.
+- validate UUIDs and unique emails;
+- reject unsupported providers;
+- generate deterministic account IDs;
+- escape SQL values safely;
+- exclude sessions;
+- reconcile every distinct application owner ID;
+- never send Supabase secrets to a Worker.
+
+Local/E2E setup seeds the Better Auth test user into the same D1 prepared by `prepare-stack.ts`, which already applies every D1 migration in lexical order.
 
 ## Environment Contract
 
@@ -418,7 +456,13 @@ GOOGLE_AUTH_CLIENT_ID
 GOOGLE_AUTH_CLIENT_SECRET
 ```
 
-Secrets are Wrangler secrets. URL/domain/client-ID values are environment vars.
+Continue using:
+
+```text
+CORS_ALLOWED_ORIGINS
+```
+
+as the single browser-origin trust list.
 
 Keep desktop:
 
@@ -428,149 +472,106 @@ VITE_DTX_API_URL
 GOOGLE_DRIVE_OAUTH_CLIENT_ID
 ```
 
-Remove Supabase and desktop auth-callback variables after cutover.
+Remove all Supabase and desktop auth-callback variables after the cutover implementation is complete.
 
-## Error Handling
+## Cutover Strategy
 
-### Web
+### Code PR
 
-- Invalid credentials remain on login with a sanitized message.
-- `account_not_linked` instructs the user to sign in with the existing method and link Google explicitly.
-- Invalid/expired device codes show a restart message.
-- Approval/denial controls disable while in flight.
+The implementation PR ends when:
 
-### Desktop
+- static/type/unit/Rust checks pass;
+- generated auth/GraphQL/native artifacts are clean;
+- Supabase residue gates pass;
+- web and desktop E2E pass without Supabase credentials;
+- pre-production migration/deployment/acceptance has been proven;
+- the production runbook is complete.
 
-- Pending and slow-down are internal polling states.
-- Denial and expiry are distinct user-facing outcomes.
-- Invalid stored sessions clear local/native state.
-- Logout clears local state even when server revocation fails.
-- Browser-opening failure shows the plain verification URL and code.
+Do not execute production D1 identity import, production deployment, desktop publication, or credential removal as an implementation-plan task.
 
-### API
+### Operator runbook
 
-- Better Auth owns auth endpoint errors.
-- GraphQL and REST preserve current unauthorized semantics.
-- Public download behavior remains controlled by the existing flag.
-- Credentialed CORS never uses `*`.
+The runbook owns production actions:
 
-## Security Boundary
+1. backup/export;
+2. configure Better Auth/Google secrets and callbacks;
+3. apply `0008_better_auth.sql`;
+4. apply reviewed identity-import SQL;
+5. reconcile owner IDs;
+6. deploy API then web;
+7. publish/install the desktop build;
+8. run web/desktop/Access smoke matrices;
+9. prove Supabase can be disabled;
+10. retain rollback artifacts for the cutover window.
 
-Better Auth owns password hashing, OAuth state/callback validation, signed cookies, session storage/expiry, CSRF/origin checks, device-code generation/claiming/approval/polling/expiry, Bearer validation/revocation, and auth rate limiting.
-
-DTXWeb owns exact origins/cookie domains, secret storage, Access placement, approval UI, ownership-ID preservation, and local desktop cleanup.
-
-## Deployment and Cutover
-
-The implementation ships as one code PR but is proved in stages.
-
-### Pre-production
-
-1. Apply `0008_better_auth.sql`.
-2. Configure Better Auth and Google secrets.
-3. Import pre-production identities.
-4. Deploy API and web.
-5. Build desktop against pre-production.
-6. Prove password, Google, linking, logout, GraphQL, REST, device approval/denial/expiry/restore/logout.
-7. Confirm API auth endpoints remain outside Access and `/app/desktop-auth` remains protected.
-
-### Production
-
-1. Export and back up Supabase Auth data.
-2. Apply the D1 auth migration.
-3. Generate, review, and apply identity-import SQL.
-4. Deploy API and web in the same cutover window.
-5. Release the Better Auth desktop build.
-6. Require users to sign in again.
-7. Run ownership and end-to-end checks.
-8. Remove/revoke Supabase credentials only after acceptance.
-
-A short coordinated cutover is simpler than a dual verifier.
-
-## Coordination with PR #221
-
-After PR #221 lands, update its Zero Trust design, plan, and runbook to state:
-
-- Better Auth is the inner application-authentication gate.
-- `/app/desktop-auth` is the desktop approval route.
-- API device-code/polling endpoints remain outside Access.
-- Production desktop authorization remains operator-only because approval is under `/app`.
-- `/login?redirect=desktop`, auth deep links, and loopback verification are removed.
-
-Implementation can begin before PR #221 merges, but production rollout must reconcile both document sets.
+Rollback redeploys the previous API/web/desktop versions. Additive Better Auth tables may remain during rollback.
 
 ## Testing Strategy
 
 ### API
 
-- Generated schema/migration parity.
-- Better Auth GET/POST handler mounting.
-- Cookie and Bearer session resolution.
-- Missing/invalid session normalization.
-- Existing GraphQL scopes and REST authorization.
-- Credentialed CORS.
+Cover:
+
+- generated schema/migration contract;
+- auth handler routing;
+- credentialed CORS;
+- two Set-Cookie values survive `withCors`;
+- cookie and Bearer session resolution;
+- unsafe cookie request with allowed Origin;
+- unsafe cookie request with missing/disallowed Origin;
+- Bearer request with no Origin;
+- neutral `{ id }` user type through GraphQL/REST;
+- magic-link schema removal.
 
 ### Web
 
-- Server hook and safe redirects.
-- Password and Google sign-in.
-- Explicit linking and logout.
-- Browser cookie transport and service-binding cookie forwarding.
-- Device code claim, approve, deny, invalid, and expired UI.
+Cover:
+
+- session loading/rolling Set-Cookie propagation;
+- `/app` guard and safe `next`;
+- removal of desktop redirect/callback branches and desktop CSRF bypass;
+- password login;
+- Google login error mapping;
+- explicit Google linking;
+- logout;
+- browser GraphQL credentials;
+- service-binding Cookie + Origin forwarding;
+- single/bulk download credentials;
+- no remaining `getAccessTokenOrNull` mocks/imports;
+- device code claim/approve/deny.
 
 ### Desktop
 
-- Code request parsing.
-- Pending/slow-down polling.
-- Approval, denial, expiry, invalid grant, and network failure.
-- Stored-session validation and logout.
-- Renderer persistence and restore.
-- Google Drive session-generation invariants.
-- No callback listener or auth deep-link remains.
+Cover:
 
-### End-to-end
+- code request;
+- pending/slow-down/approve/deny/expiry/invalid-grant;
+- cancellation/generation races;
+- one-token persistence;
+- `SessionValidationStatus` valid/invalid/not-configured;
+- restore/logout;
+- Bearer API requests;
+- preserved session epoch/Drive reconciliation;
+- absence of magic-link/deep-link/loopback/JWT/refresh behavior.
 
-- Local D1 Better Auth user provisioning.
-- Web authenticated score flow.
-- Desktop Device Authorization, restore, and logout.
-- Pre-production production-like flow with Cloudflare Access.
+### E2E
 
-## Rejected Alternatives
+Web E2E uses a D1-seeded Better Auth user. Desktop integration uses the supported Device Authorization flow or seeded Better Auth session setup, without test-only auth protocols.
 
-- **Keep Supabase only for auth:** leaves the most complex cross-runtime dependency.
-- **Handcraft a device protocol:** Better Auth already owns the protocol and security rules.
-- **Keep magic links:** retains callback, deep-link, refresh, and JWT machinery.
-- **Use OAuth Provider/JWT:** unnecessary for one first-party desktop client and one resource server.
-- **Use Better Auth Electron plugin:** DTX Desktop is Tauri; Device Authorization is framework-neutral.
-- **Put Better Auth in `dtx-web`:** web has no D1 binding and desktop polling must stay outside Access.
-- **Create a dedicated auth Worker:** extra deployment boundary without another consumer.
-- **Keep bcrypt compatibility:** replacement passwords are cheaper than permanent legacy hashing.
-
-## Acceptance Criteria
+## Completion Definition
 
 The migration is complete when:
 
-1. D1 contains Better Auth core, device-code, and rate-limit tables.
-2. Password and Google web sign-in create valid Better Auth sessions.
-3. Browser GraphQL/REST authenticate through cookies.
-4. Desktop uses Device Authorization and an opaque Better Auth Bearer session.
-5. Existing ownership remains valid because user IDs are preserved.
-6. Google linking is explicit and implicit linking remains disabled.
-7. Public signup remains disabled.
-8. Desktop has no magic link, auth deep link, loopback callback, JWT decoder, or refresh-token rotation.
-9. No runtime package or active environment contract depends on Supabase.
-10. Unit, integration, Rust, web E2E, and desktop E2E checks pass.
-11. PR #221 documentation identifies Better Auth and `/app/desktop-auth`.
-12. Disabling Supabase causes no DTXWeb runtime failure.
-
-## References
-
-- Better Auth Cloudflare fixture v1.6.25: https://github.com/better-auth/better-auth/tree/v1.6.25/e2e/smoke/test/fixtures/cloudflare
-- Better Auth Drizzle adapter: https://better-auth.com/docs/adapters/drizzle
-- Drizzle Kit export: https://orm.drizzle.team/docs/drizzle-kit-export
-- Better Auth Device Authorization: https://better-auth.com/docs/plugins/device-authorization
-- Better Auth Bearer plugin: https://better-auth.com/docs/plugins/bearer
-- Better Auth cookies: https://better-auth.com/docs/concepts/cookies
-- Better Auth Supabase migration guide: https://better-auth.com/docs/guides/supabase-migration-guide
-- Better Auth CLI: https://better-auth.com/docs/concepts/cli
-- Better Auth 1.6.25: https://github.com/better-auth/better-auth/releases/tag/v1.6.25
+- D1 holds Better Auth core, Device Authorization, and rate-limit tables;
+- existing application owner UUIDs are preserved;
+- password and Google web sign-in use Better Auth;
+- implicit linking/signup remain disabled;
+- browser GraphQL/REST uses cookie sessions with unsafe-method Origin validation;
+- desktop uses Device Authorization and opaque Bearer sessions;
+- desktop retains the valid/invalid/not-configured restore contract;
+- no auth magic-link/deep-link/loopback/JWT/refresh-token machinery remains;
+- no active package/config/test depends on Supabase;
+- the obsolete root/turbo Supabase `gen-types` task is removed;
+- unit, integration, Rust, web E2E, and desktop E2E checks pass;
+- pre-production acceptance passes;
+- the production runbook is ready for operator execution.

--- a/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
@@ -2,26 +2,31 @@
 
 **Status:** Approved direction, implementation pending  
 **Date:** 2026-08-18  
+**Tracking:** HPA-644  
 **Repository:** `cwchanap/DTXWeb`
 
 ## Summary
 
 DTXWeb already stores application data in Cloudflare D1. Supabase remains as the authentication provider and as Supabase-shaped session plumbing across the web app, API, desktop app, E2E setup, dependencies, generated types, and environment configuration.
 
-Complete the migration by hosting Better Auth 1.6.25 in `dtx-api`, storing Better Auth tables in the existing D1 database, using cookies for web authentication, and replacing the desktop magic-link/deep-link protocol with Better Auth Device Authorization plus opaque Bearer sessions.
+Complete the migration by hosting Better Auth in `dtx-api`, storing Better Auth tables in the existing D1 database, using cookies for web authentication, and replacing the desktop magic-link/deep-link protocol with Better Auth Device Authorization plus opaque Bearer sessions.
 
-The cutover stays intentionally small:
+The architecture stays intentionally small:
 
 - one auth runtime in `dtx-api`;
-- one D1 database;
+- one existing D1 database per deployed environment;
 - the official Better Auth Drizzle adapter;
+- cookies for browser sessions;
+- Device Authorization + Bearer for desktop;
+- one-shot ID-preserving identity import;
 - no dual-auth compatibility mode;
 - no OAuth Provider/JWT/JWKS layer;
 - no second Worker;
 - no custom device protocol;
-- no permanent bcrypt compatibility.
+- no permanent bcrypt compatibility;
+- no foreign keys from application ownership columns to Better Auth tables.
 
-The migration invalidates active Supabase sessions. Existing application ownership identifiers are preserved exactly.
+Active Supabase sessions are invalidated at cutover. Existing application ownership identifiers are preserved exactly.
 
 ## Current State
 
@@ -31,7 +36,7 @@ The migration invalidates active Supabase sessions. Existing application ownersh
 
 Runtime application data no longer depends on Supabase tables or Supabase Storage.
 
-Application ownership is keyed by Supabase UUIDs stored as text, including `simfiles.user_id`, `user_profiles.user_id`, and `chart_scores.user_id`. Those columns do not need to become foreign keys to Better Auth.
+Application ownership is keyed by Supabase UUIDs stored as text, including `simfiles.user_id`, `user_profiles.user_id`, and `chart_scores.user_id`. Those columns intentionally remain text ownership keys without foreign keys to Better Auth. The import/reconciliation gate is the cheaper invariant for this project.
 
 ### Remaining Supabase responsibilities
 
@@ -43,7 +48,8 @@ Supabase still owns or shapes:
 - desktop magic-link generation and exchange;
 - desktop deep-link and loopback callback handling;
 - desktop JWT expiry parsing and refresh-token rotation;
-- E2E user provisioning;
+- desktop E2E auth seeding;
+- web E2E user provisioning;
 - environment variables, dependencies, generated Supabase types, and mocks.
 
 The desktop path has the largest simplification opportunity. Device Authorization removes the custom magic-link mutation, callback allowlists, auth URI schemes, loopback HTTP server, JWT decoder, refresh lock, and session-refresh events.
@@ -51,14 +57,16 @@ The desktop path has the largest simplification opportunity. Device Authorizatio
 ## Goals
 
 1. Make D1 the only database used by DTXWeb runtime services.
-2. Replace Supabase Auth with Better Auth 1.6.25.
+2. Replace Supabase Auth with an exactly pinned Better Auth 1.6.x patch selected at implementation start.
 3. Preserve every migrated Supabase UUID as the matching Better Auth `user.id`.
 4. Keep password and Google sign-in for existing users.
 5. Keep Google linking explicit and signup disabled.
 6. Authenticate browser API traffic with Better Auth cookies.
 7. Authenticate desktop API traffic with Device Authorization plus opaque Bearer sessions.
-8. Remove all runtime Supabase dependencies, variables, callbacks, refresh logic, generated types, and E2E bootstrap code.
-9. Keep production cutover operations in an operator runbook, not in the implementation task list.
+8. Preserve the existing desktop `valid | invalid | not-configured` restore contract and Drive session-epoch semantics.
+9. Remove all runtime Supabase dependencies, variables, callbacks, refresh logic, generated types, and E2E bootstrap code.
+10. Prove the additive Better Auth foundation separately before the destructive cutover.
+11. Keep production cutover operations in an operator runbook, not in implementation tasks.
 
 ## Non-goals
 
@@ -83,13 +91,13 @@ Google Drive OAuth remains separate from application authentication.
 
 `dtx-api` already owns D1 and the public API hostname. Mount Better Auth under `/api/auth/*` before the existing GraphQL and REST routes in the current hand-written router.
 
-`dtx-web` does not receive a D1 binding. Production web also has no API service binding today, so browser production traffic continues to call `PUBLIC_DTX_API_URL` directly.
+`dtx-web` does not receive a D1 binding. Do not add Hono or another router solely for authentication.
 
 This avoids two auth instances, another Worker, or a new internal auth service.
 
 ### 2. Use the official Drizzle-on-D1 adapter
 
-Follow Better Auth 1.6.25's Cloudflare pattern:
+Follow the Better Auth 1.6.x Cloudflare pattern:
 
 ```ts
 const db = drizzle(env.DB, { schema: authSchema });
@@ -99,61 +107,152 @@ database: drizzleAdapter(db, {
 });
 ```
 
-This mirrors the existing `createDrizzleDb()` shape in `@dtx/common/server`, but the Better Auth schema remains owned by `dtx-api` because it is auth-runtime data, not application-domain data.
+This mirrors the existing `createDrizzleDb()` pattern in `@dtx/common/server`, but the Better Auth schema remains owned by `dtx-api` because it is auth-runtime data, not application-domain data.
 
-The pinned Better Auth CLI generates `packages/dtx-api/src/auth/schema.ts`. `drizzle-kit export` produces reviewed flat SQL for `packages/dtx-api/d1-migrations/0008_better_auth.sql`. Wrangler remains the only production migration executor.
+The Better Auth CLI generates `packages/dtx-api/src/auth/schema.ts`. `drizzle-kit export` produces reviewed flat SQL for `packages/dtx-api/d1-migrations/0008_better_auth.sql`. Wrangler remains the only production migration executor.
 
-### 3. Keep one origin allowlist
+### 3. Pin the Better Auth 1.6 line at implementation start
 
-`CORS_ALLOWED_ORIGINS` is the single configured list of browser origins trusted to call `dtx-api`.
+Do not freeze the implementation to the patch that happened to be current when the first draft was written.
 
-Export the parser/read helper from `packages/dtx-api/src/lib/cors.ts` and reuse the same set for:
+At the start of Foundation Task 1:
 
-- CORS response headers;
-- Better Auth `trustedOrigins`;
-- cookie-authenticated unsafe API request validation.
+1. determine the current stable `1.6.x` tag;
+2. inspect changes since the version used to write this plan;
+3. verify Device Authorization, Bearer, Drizzle/D1, cookie, and schema-generation APIs used by this plan;
+4. pin `better-auth` and the `auth` CLI to the **same exact 1.6.x version**;
+5. record that exact version in the implementation PR and runbook.
 
-Do not introduce a second `TRUSTED_ORIGINS` setting.
+As of this review, repository tags `v1.6.30` and `v1.7.1` exist while `v1.6.31` does not. Stay on the 1.6 line for this migration unless a separate review explicitly accepts the 1.7 breaking surface.
 
-`DTX_WEB_URL` remains because Device Authorization needs one canonical web URL for `verificationUri`.
+The npm package named `auth` is intentionally the Better Auth CLI. Do not replace it with `@better-auth/cli` without re-checking the project/version contract.
 
-### 4. Use cross-subdomain cookies for web sessions
+### 4. Separate CORS configuration from the authentication trust boundary
 
-| Environment | API base URL | Web origin | Cookie domain |
-| --- | --- | --- | --- |
-| Production | `https://api.dtx.hapadona.com` | `https://dtx.hapadona.com` | `dtx.hapadona.com` |
-| Pre-production | `https://api.pre-prod.dtx.hapadona.com` | `https://pre-prod.dtx.hapadona.com` | `pre-prod.dtx.hapadona.com` |
-| Local | `http://localhost:8787` | `http://localhost:5173` | omitted |
+`CORS_ALLOWED_ORIGINS` remains a CORS configuration only. It may legitimately include localhost entries in deployed pre-production for developer tooling, so it must **not** be reused as an authentication/open-redirect trust boundary.
 
-CORS echoes only allow-listed origins, sets `Access-Control-Allow-Credentials: true`, and includes `Vary: Origin`. Browser auth, GraphQL, and authenticated REST requests use `credentials: 'include'`.
+`DTX_WEB_URL` is already required for Device Authorization and becomes the one canonical trusted web origin.
 
-Because the production cookie domain is a parent of pre-production hostnames, cookie authentication must not rely on CORS alone as its CSRF boundary.
+```ts
+const trustedWebOrigin = new URL(env.DTX_WEB_URL).origin;
 
-### 5. Enforce Origin on unsafe cookie-authenticated API requests
+trustedOrigins: [trustedWebOrigin];
+```
+
+Use the same exact origin for unsafe cookie-authenticated application API checks.
+
+This introduces no second origin list:
+
+- `CORS_ALLOWED_ORIGINS`: which browser origins may read API responses;
+- `DTX_WEB_URL`: the one web application origin trusted for auth redirects and cookie-authenticated mutations.
+
+Local development sets `DTX_WEB_URL=http://localhost:5173`. Production and pre-production set their deployed HTTPS web origins.
+
+Better Auth's default SameSite cookie behavior remains defense in depth, not the only application-CSRF boundary.
+
+### 5. Use cross-subdomain cookies with environment-specific prefixes
+
+| Environment | API base URL | Web origin | Cookie domain | Cookie prefix |
+| --- | --- | --- | --- | --- |
+| Production | `https://api.dtx.hapadona.com` | `https://dtx.hapadona.com` | `dtx.hapadona.com` | `dtx` |
+| Pre-production | `https://api.pre-prod.dtx.hapadona.com` | `https://pre-prod.dtx.hapadona.com` | `pre-prod.dtx.hapadona.com` | `dtx-preprod` |
+| Local | `http://localhost:8787` | `http://localhost:5173` | omitted | `dtx-local` |
+
+The production domain cookie is intentionally shared with `api.dtx.hapadona.com`, but that domain also covers nested pre-production hostnames. Without distinct names, a browser can send production and pre-production cookies with the same Better Auth cookie name to pre-production hosts.
+
+Set `advanced.cookiePrefix` from one environment field, `AUTH_COOKIE_PREFIX`, so the two environments never compete on the same cookie name.
+
+`pre-prod-prod-data` uses the pre-production web/API hostname and therefore the pre-production prefix; changing its backing D1 does not make it a production-origin browser session.
+
+### 6. Make credentialed CORS explicit
+
+Browser auth, GraphQL, and authenticated REST/download requests use `credentials: 'include'`.
+
+For an allowed CORS origin both current CORS paths must set:
+
+```text
+Access-Control-Allow-Origin: <exact origin>
+Access-Control-Allow-Credentials: true
+Vary: Origin
+```
+
+Specifically:
+
+- `handlePreflight()` changes its current `Access-Control-Allow-Credentials: false` to `true` for allowed origins;
+- `withCors()` sets `Access-Control-Allow-Credentials: true` on allowed normal responses.
+
+Denied origins receive no credentialed CORS grant. Never combine credentials with `Access-Control-Allow-Origin: *`.
+
+### 7. Enforce the canonical web Origin on unsafe cookie-authenticated application API requests
 
 `resolveAuthSession()` distinguishes authentication transport:
 
 - If a valid `Authorization: Bearer` header is present, validate it with Better Auth and do not require `Origin`. This is the desktop/native path.
-- If authentication comes from cookies and the method is `POST`, `PUT`, `PATCH`, or `DELETE`, require `Origin` to be present and contained in `CORS_ALLOWED_ORIGINS` before accepting the session.
-- Cookie-authenticated `GET`/`HEAD` stays usable without `Origin` so normal authenticated reads and navigation/download paths are not broken.
+- If authentication comes from cookies and the method is `POST`, `PUT`, `PATCH`, or `DELETE`, require `Origin` to equal `new URL(env.DTX_WEB_URL).origin` before accepting the session.
+- Cookie-authenticated `GET`/`HEAD` stays usable without `Origin` so authenticated reads and downloads are not broken.
 
-An unsafe request with a cookie but an absent/disallowed Origin is treated as unauthenticated at the shared session boundary. Protected GraphQL/REST code then returns its existing forbidden/unauthorized result.
+An unsafe request with a cookie but an absent/different Origin is treated as unauthenticated at the shared session boundary. Protected GraphQL/REST code then returns its existing forbidden/unauthorized result.
 
-SvelteKit service-binding GraphQL calls explicitly forward both the incoming cookie and the trusted web origin so they satisfy the same rule. Production, which has no service binding, uses normal browser `Origin` headers.
+SvelteKit service-binding GraphQL calls explicitly forward both the incoming cookie and the canonical external web Origin so they satisfy the same rule.
 
-Better Auth's own `/api/auth/*` handler keeps Better Auth's built-in origin/CSRF checks enabled.
+Better Auth's own `/api/auth/*` handler keeps Better Auth's built-in origin/CSRF checks enabled and uses `DTX_WEB_URL` as `trustedOrigins`.
 
-### 6. Preserve multiple `Set-Cookie` headers
+### 8. Preserve multiple `Set-Cookie` values without unnecessary CORS refactoring
 
-Cloudflare Workers exposes multiple `Set-Cookie` values separately. Any wrapper that reconstructs a `Response` must preserve their cardinality.
+The current `withCors()` copies `response.headers` via `new Headers(response.headers)`. Keep that implementation if the new two-cookie regression test proves cardinality survives in the supported Workers runtime.
 
-`withCors()` gets a regression test with two `Set-Cookie` values. When copying a response, preserve the array returned by the Workers `Headers` cookie API rather than flattening cookies through `headers.get('set-cookie')`.
+Do **not** rewrite `withCors()` around `headers.get('set-cookie')`, which can flatten cookie values.
 
-The SvelteKit session hook also reads all returned Set-Cookie values and appends each raw header to the eventual web response. It does not parse and reserialize Better Auth cookies.
+The SvelteKit session hook must likewise forward each Set-Cookie value individually using the runtime's multi-cookie API rather than reading a single flattened header.
 
-This keeps login/session rotation correct without adding a cookie-parsing dependency.
+The rule is test-first:
 
-### 7. Disable signup and implicit linking
+1. create a response with two Set-Cookie values;
+2. pass it through `withCors()`;
+3. assert both values remain individually retrievable;
+4. only change `withCors()` if that test fails.
+
+### 9. Add a production API service binding for SSR
+
+Production `dtx-web` currently lacks the `API` service binding already present in both pre-production stanzas.
+
+Add the root binding:
+
+```json
+{
+  "services": [{ "binding": "API", "service": "dtx-api" }]
+}
+```
+
+The server hook uses the service binding when available and falls back to `PUBLIC_DTX_API_URL` for local/non-Workers execution.
+
+This removes an avoidable public HTTP round-trip from every production SSR session lookup and makes production/pre-production use the same server-side auth seam.
+
+Browser requests still call the public API hostname directly.
+
+### 10. Keep Better Auth database rate limiting off the SSR session hot path
+
+Better Auth database-backed rate limiting is useful for client-initiated authentication abuse, but `/get-session` is called on normal SSR navigation and must not cause a D1 rate-limit write on every page render.
+
+Keep database rate limiting enabled, but explicitly exempt the high-frequency session-read endpoint:
+
+```ts
+rateLimit: {
+  enabled: true,
+  storage: 'database',
+  customRules: {
+    '/get-session': false,
+  },
+},
+```
+
+Retain Better Auth's default and plugin-specific limits for sign-in, device authorization, and other auth operations. Do not replace them with a broad catch-all allowlist unless implementation-time tests show another read endpoint is hot enough to justify an exemption.
+
+`cf-connecting-ip` remains the trusted IP header for browser-facing rate limits.
+
+Keep the existing `RATE_LIMIT_API` KV binding for downloads and other application API rate limits. Delete only magic-link-specific rate-limit code/configuration.
+
+### 11. Disable signup and implicit linking
 
 Use:
 
@@ -180,7 +279,7 @@ account: {
 
 Imported Google identities may sign in. An authenticated user links Google explicitly with `linkSocial()`.
 
-### 8. Reuse the existing web redirect/error allowlist
+### 12. Reuse the existing web redirect/error allowlist
 
 Do not create a second redirect helper.
 
@@ -193,25 +292,15 @@ Keep `packages/dtx-web/src/lib/auth/google.ts` as the application-auth redirect/
 
 Existing login and callback tests are retargeted so the current allowlist/error cases remain covered instead of being replaced by thinner tests.
 
-### 9. Use Device Authorization and Bearer for desktop
+### 13. Use Device Authorization and Bearer for desktop
 
 DTX Desktop is a first-party client of the same application. It does not need OAuth Provider, scopes, JWT access tokens, JWKS, or refresh-token rotation.
 
-Configure:
+Configure Device Authorization + Bearer using the exact APIs of the implementation-time pinned 1.6.x patch.
 
-```ts
-plugins: [
-  deviceAuthorization({
-    verificationUri: `${config.webURL}/app/desktop-auth`,
-    validateClient: (clientId) => clientId === 'dtx-desktop',
-  }),
-  bearer(),
-]
-```
+`/device/token` returns an opaque Better Auth session token in `access_token`. Desktop sends it as `Authorization: Bearer <token>`. The same Better Auth session resolver validates browser cookies and desktop bearer sessions.
 
-`/device/token` returns a Better Auth session token in `access_token`. Desktop sends it as `Authorization: Bearer <token>`. The same Better Auth `getSession` path validates browser cookies and desktop bearer sessions.
-
-### 10. Preserve desktop session-validation semantics
+### 14. Preserve desktop session-validation and E2E seams
 
 Keep the existing renderer/native contract:
 
@@ -224,15 +313,27 @@ valid | invalid | not-configured
 - missing/blank desktop API configuration => `not-configured`;
 - authenticated `/api/auth/get-session` returns the user => `valid`;
 - 401/no session => `invalid`;
-- transport/server failure remains fail-closed according to the current restore behavior and must not be mislabeled as local configuration absence.
+- transport/server failure remains fail-closed according to current restore behavior and must not be mislabeled as local configuration absence.
 
 The desktop never receives `BETTER_AUTH_SECRET`; that secret remains server-only.
 
-### 11. Keep API auth user types minimal
+The existing `e2e + debug_assertions` native auth seam is also retained and reshaped from Supabase's `{ access_token, refresh_token, user }` to Better Auth's `{ sessionToken, user }`.
+
+Retarget:
+
+- `AuthState::for_e2e_user`;
+- `SessionData`;
+- `e2e_session_matches_user`;
+- `src/tests/e2e_tests.rs`;
+- renderer E2E local-storage setup.
+
+Do not require a fake Better Auth refresh token. Do not add a production test-auth route.
+
+Feature-gated debug-only native commands/seeding remain acceptable for desktop E2E because that mechanism already exists and cannot ship in release builds.
+
+### 15. Keep API auth user types minimal
 
 After the magic-link mutation is removed, GraphQL/REST authorization only needs the user identifier.
-
-Use a neutral API type such as:
 
 ```ts
 type ApiAuthUser = {
@@ -240,66 +341,57 @@ type ApiAuthUser = {
 };
 ```
 
-Add `email` only at a boundary that actually renders or needs it. Do not re-export or emulate Supabase `User`/`Session` shapes.
+Add `email` only at a boundary that actually needs it. Do not re-export or emulate Supabase `User`/`Session` shapes.
 
-The web session model may expose Better Auth user fields needed by the UI; that is separate from `dtx-api`'s authorization type.
+The web session model may expose Better Auth user fields needed by UI; that is separate from `dtx-api`'s authorization type.
 
-## Better Auth Server
+## Target Runtime Architecture
 
-### File boundary
+```text
+                               Cloudflare D1
+                   app tables + Better Auth tables
+                                      ▲
+                                      │
+                       api.dtx.hapadona.com
+              ┌───────────────────────┴───────────────────────┐
+              │                                               │
+       /api/auth/*                                    /graphql + REST
+     Better Auth handler                           resolveAuthSession()
+              │                                               │
+      ┌───────┴────────┐                                     │
+      │                │                                     │
+Browser cookie   Desktop device flow ── opaque Bearer ───────┘
+      │
+dtx.hapadona.com
+login/account/
+app/desktop-auth
+```
+
+On SSR, `dtx-web` calls the same `dtx-api` Worker through the `API` service binding rather than a public Internet subrequest.
+
+## Better Auth Server Boundary
 
 ```text
 packages/dtx-api/src/auth/options.ts
 packages/dtx-api/src/auth/auth.ts
 packages/dtx-api/src/auth/auth.cli.ts
 packages/dtx-api/src/auth/schema.ts
-packages/dtx-api/src/auth/session.ts   # rename/rewrite of the current verifier seam
+packages/dtx-api/src/auth/session.ts
 packages/dtx-api/src/auth/*.test.ts
 packages/dtx-api/drizzle.auth.config.ts
 packages/dtx-api/d1-migrations/0008_better_auth.sql
 ```
 
-`createAuthOptions()` contains provider, cookie, rate-limit, origin, and plugin settings. Runtime supplies D1 and real secrets. CLI schema generation supplies non-production placeholders.
+`createAuthOptions()` contains provider, cookie-prefix, rate-limit, trusted-web-origin, and plugin settings. Runtime supplies D1 and real secrets. CLI schema generation supplies non-production placeholders.
 
-### Router order
-
-`packages/dtx-api/src/index.ts` handles:
+`packages/dtx-api/src/index.ts` routes requests in this order:
 
 1. CORS preflight;
 2. Better Auth `/api/auth/*` GET/POST;
-3. GraphQL and REST;
+3. existing GraphQL and REST;
 4. not-found.
 
-Do not add Hono solely to mount auth.
-
-### Neutral session resolver
-
-Rename/rewrite the current verifier seam into `packages/dtx-api/src/auth/session.ts`:
-
-```ts
-type ResolvedAuthSession = {
-  user: ApiAuthUser;
-  session: { id: string };
-};
-
-resolveAuthSession(request, env): Promise<ResolvedAuthSession | null>
-```
-
-The implementation:
-
-1. classifies Bearer versus cookie transport;
-2. applies the unsafe-cookie Origin rule;
-3. calls `createAuth(env).api.getSession({ headers: request.headers })`;
-4. normalizes provider-specific data to the local type;
-5. returns null for missing/invalid credentials.
-
-GraphQL context and protected REST routes use this one helper.
-
-### Auth rate limiting
-
-Use Better Auth's database-backed rate limiter with `cf-connecting-ip`.
-
-Keep `RATE_LIMIT_API` for downloads and other existing API rate limits. Delete only magic-link-specific keys/configuration.
+`resolveAuthSession()` normalizes Better Auth to local `ApiAuthUser` and session types. It applies the unsafe-cookie Origin rule before returning cookie-authenticated application sessions.
 
 ## Web Authentication
 
@@ -309,11 +401,12 @@ The hook no longer constructs a Supabase client.
 
 It:
 
-1. forwards the incoming `Cookie` header to `/api/auth/get-session`;
-2. captures all returned Set-Cookie headers;
-3. stores neutral user/session data in `event.locals`;
-4. appends each raw Set-Cookie header to the SvelteKit response;
-5. guards `/app` and preserves a validated `next` destination.
+1. uses `event.platform?.env.API` when available, otherwise `PUBLIC_DTX_API_URL`;
+2. forwards the incoming Cookie header to `/api/auth/get-session`;
+3. captures every returned Set-Cookie value individually;
+4. stores neutral user/session data in `event.locals`;
+5. appends each raw Set-Cookie header to the SvelteKit response;
+6. guards `/app` and preserves a validated `next` destination.
 
 Delete the old desktop-specific branches:
 
@@ -327,7 +420,7 @@ Device Authorization no longer posts forms from the desktop app into the web Wor
 
 Use the Better Auth browser client for password and Google sign-in. Preserve `safeAppRedirectPath()` and sanitized errors from `$lib/auth/google.ts`.
 
-Google callbacks terminate at `dtx-api`'s Better Auth handler. Delete the SvelteKit `/auth/callback` route after its reusable allowlist/error assertions have been moved to the retained helper/login/account tests.
+Google callbacks terminate at `dtx-api`'s Better Auth handler. Delete the SvelteKit `/auth/callback` route after its reusable allowlist/error assertions have moved to retained helper/login/account tests.
 
 ### Every web API call uses cookies
 
@@ -343,9 +436,9 @@ Update together:
 
 Browser GraphQL and download fetches use `credentials: 'include'` and no Authorization header.
 
-Service-binding SSR GraphQL forwards `Cookie` and the trusted web `Origin`. No token-shaped `ClientCtx.accessToken` remains.
+Service-binding SSR GraphQL forwards `Cookie` and `new URL(DTX_WEB_URL).origin`. No token-shaped `ClientCtx.accessToken` remains.
 
-Only after those imports/tests are gone is `packages/dtx-web/src/lib/api/token.ts` deleted.
+Only after all token imports/tests are gone is `packages/dtx-web/src/lib/api/token.ts` deleted.
 
 ## Desktop Authentication
 
@@ -391,9 +484,9 @@ Keep Device Authorization HTTP protocol code in `device_auth.rs`, independent of
 
 Define renderer-facing DTOs in `packages/dtx-desktop/src-tauri/src/api_contracts.rs` and generate TypeScript through the existing `ts-rs` export target.
 
-Preserve the current authenticated user ID, session generation, and session epoch used by Google Drive reconciliation.
+Preserve authenticated user ID, session generation, and `AuthSessionEpoch` used by Google Drive reconciliation.
 
-Remove:
+Remove production auth machinery for:
 
 - magic-link parsing/exchange;
 - auth deep-link handlers/queues;
@@ -408,8 +501,6 @@ Remove the auth deep-link plugin/config only after repository search proves it h
 
 ## Identity Migration
 
-### Preserve IDs
-
 Every imported Better Auth `user.id` equals the existing Supabase UUID. Application ownership rows are not rewritten.
 
 Import:
@@ -423,25 +514,11 @@ Import:
 
 Do not import Supabase sessions/access/refresh tokens.
 
-### Password policy
-
 Do not add bcrypt compatibility. Replacement credential passwords are hashed with Better Auth's own password helper during the one-shot import.
 
-### Import tooling
+The local-only import tool consumes a sanitized Supabase Admin export and emits reviewed D1 SQL under ignored `tmp/auth-migration/`. It validates UUIDs/emails/providers, generates deterministic account IDs, escapes SQL, excludes sessions, and reconciles every distinct application owner ID.
 
-Create a local-only script that consumes a sanitized Supabase Admin export and emits reviewed D1 SQL under `tmp/auth-migration/`.
-
-It must:
-
-- validate UUIDs and unique emails;
-- reject unsupported providers;
-- generate deterministic account IDs;
-- escape SQL values safely;
-- exclude sessions;
-- reconcile every distinct application owner ID;
-- never send Supabase secrets to a Worker.
-
-Local/E2E setup seeds the Better Auth test user into the same D1 prepared by `prepare-stack.ts`, which already applies every D1 migration in lexical order.
+Local/E2E setup seeds the Better Auth web test user into the same D1 prepared by `prepare-stack.ts`, which already applies every D1 migration lexically.
 
 ## Environment Contract
 
@@ -452,6 +529,7 @@ BETTER_AUTH_URL
 BETTER_AUTH_SECRET
 DTX_WEB_URL
 AUTH_COOKIE_DOMAIN
+AUTH_COOKIE_PREFIX
 GOOGLE_AUTH_CLIENT_ID
 GOOGLE_AUTH_CLIENT_SECRET
 ```
@@ -462,7 +540,7 @@ Continue using:
 CORS_ALLOWED_ORIGINS
 ```
 
-as the single browser-origin trust list.
+for CORS only.
 
 Keep desktop:
 
@@ -472,61 +550,114 @@ VITE_DTX_API_URL
 GOOGLE_DRIVE_OAUTH_CLIENT_ID
 ```
 
-Remove all Supabase and desktop auth-callback variables after the cutover implementation is complete.
+Remove all Supabase and desktop auth-callback variables after cutover implementation.
 
-## Cutover Strategy
+## Delivery Strategy
 
-### Code PR
+### PR A — additive Better Auth foundation
 
-The implementation PR ends when:
+Land and prove the non-destructive foundation first:
 
-- static/type/unit/Rust checks pass;
-- generated auth/GraphQL/native artifacts are clean;
-- Supabase residue gates pass;
-- web and desktop E2E pass without Supabase credentials;
-- pre-production migration/deployment/acceptance has been proven;
-- the production runbook is complete.
+1. select/pin the implementation-time Better Auth 1.6.x patch and matching `auth` CLI;
+2. generate Better Auth schema and `0008_better_auth.sql`;
+3. mount `/api/auth/*` without changing application authorization;
+4. make CORS credential-capable;
+5. add cookie prefix/trusted web origin/rate-limit configuration;
+6. add `resolveAuthSession()` plus tests but **leave `verifyToken()` wired into GraphQL/REST**;
+7. add the production `API -> dtx-api` service binding;
+8. deploy the additive foundation to pre-production and smoke-test migration/handler/session primitives.
 
-Do not execute production D1 identity import, production deployment, desktop publication, or credential removal as an implementation-plan task.
+During PR A, Supabase remains the only authorization source for existing application GraphQL/REST. Better Auth endpoints exist, but there is no compatibility path that accepts both providers for application data.
 
-### Operator runbook
+`0008_better_auth.sql` is additive. If PR A is rolled back, the new tables may remain unused.
 
-The runbook owns production actions:
+### PR B — atomic application cutover
 
-1. backup/export;
-2. configure Better Auth/Google secrets and callbacks;
-3. apply `0008_better_auth.sql`;
-4. apply reviewed identity-import SQL;
-5. reconcile owner IDs;
-6. deploy API then web;
-7. publish/install the desktop build;
-8. run web/desktop/Access smoke matrices;
-9. prove Supabase can be disabled;
-10. retain rollback artifacts for the cutover window.
+The second PR performs all consumer wiring and deletion together:
 
-Rollback redeploys the previous API/web/desktop versions. Additive Better Auth tables may remain during rollback.
+1. switch GraphQL/REST authorization to `resolveAuthSession()`;
+2. remove custom magic links;
+3. move web sessions/sign-in/linking/API traffic to Better Auth cookies;
+4. add browser desktop approval;
+5. move desktop to Device Authorization/Bearer;
+6. retarget native/renderer E2E auth seams;
+7. add identity import and D1 E2E seed;
+8. remove Supabase dependencies/config/typegen;
+9. run web/desktop E2E;
+10. write/reconcile the operator runbook and Zero Trust docs;
+11. prove the full candidate in pre-production.
+
+PR B is not deployable mid-commit. Its branch may temporarily contain consumer mismatches while individual tasks are developed; merge/deploy happens only after the final full-system gate passes.
+
+Production identity import/deploy remains a separate operator action after PR B review and pre-production proof.
+
+## Risks and Mitigations
+
+### Cross-environment cookie collision
+
+**Risk:** production domain cookies are sent to nested pre-production hosts.  
+**Mitigation:** distinct `cookiePrefix` values per environment, plus distinct backing D1/session tables.
+
+### Origin misconfiguration
+
+**Risk:** CORS pre-production localhost entries accidentally become auth/open-redirect trust.  
+**Mitigation:** `DTX_WEB_URL` alone defines Better Auth `trustedOrigins` and unsafe cookie mutation Origin.
+
+### SSR auth latency / D1 rate-limit writes
+
+**Risk:** public API round-trip and database limiter write on each session lookup.  
+**Mitigation:** production service binding + `/get-session` rate-limit exemption.
+
+### Identity drift
+
+**Risk:** imported auth IDs do not cover application ownership keys.  
+**Mitigation:** deterministic import + hard reconciliation query before pre-production/production cutover.
+
+### Desktop E2E drift
+
+**Risk:** existing E2E still requires Supabase refresh-token-shaped storage while production code no longer has refresh tokens.  
+**Mitigation:** explicitly retarget native E2E seed/validation and all renderer E2E session setup to `{ sessionToken, user }`.
+
+### OAuth callback/config drift
+
+**Risk:** Google callbacks or environment origins are misconfigured.  
+**Mitigation:** exact callback/origin matrix in pre-production proof and production runbook.
+
+### Rollback after foundation migration
+
+**Risk:** D1 contains Better Auth tables after code rollback.  
+**Mitigation:** tables are additive and can remain unused; rollback does not require destructive DDL.
 
 ## Testing Strategy
 
-### API
+### Foundation PR A
 
 Cover:
 
+- exact Better Auth/CLI version agreement;
 - generated schema/migration contract;
+- all D1 migrations apply to fresh local state;
 - auth handler routing;
-- credentialed CORS;
-- two Set-Cookie values survive `withCors`;
-- cookie and Bearer session resolution;
-- unsafe cookie request with allowed Origin;
-- unsafe cookie request with missing/disallowed Origin;
-- Bearer request with no Origin;
-- neutral `{ id }` user type through GraphQL/REST;
-- magic-link schema removal.
+- credentialed preflight/normal CORS;
+- two Set-Cookie values survive `withCors()`;
+- environment-specific cookie prefix;
+- canonical `DTX_WEB_URL` trusted origin;
+- `/get-session` rate-limit exemption;
+- neutral cookie/Bearer resolver unit tests;
+- `verifyToken()` remains the live GraphQL/REST authorization seam;
+- production service-binding config/type surface;
+- pre-production anonymous/session/device-handler smoke checks.
 
-### Web
+### Cutover PR B — API/Web
 
 Cover:
 
+- cookie and Bearer session resolution wired into GraphQL/REST;
+- unsafe cookie request with exact DTX web Origin;
+- unsafe cookie request with missing/different Origin;
+- Bearer request with no Origin;
+- neutral `{ id }` user through GraphQL/REST;
+- magic-link schema removal;
 - session loading/rolling Set-Cookie propagation;
 - `/app` guard and safe `next`;
 - removal of desktop redirect/callback branches and desktop CSRF bypass;
@@ -535,12 +666,12 @@ Cover:
 - explicit Google linking;
 - logout;
 - browser GraphQL credentials;
-- service-binding Cookie + Origin forwarding;
+- service-binding Cookie + canonical Origin forwarding;
 - single/bulk download credentials;
 - no remaining `getAccessTokenOrNull` mocks/imports;
 - device code claim/approve/deny.
 
-### Desktop
+### Cutover PR B — Desktop
 
 Cover:
 
@@ -552,26 +683,33 @@ Cover:
 - restore/logout;
 - Bearer API requests;
 - preserved session epoch/Drive reconciliation;
-- absence of magic-link/deep-link/loopback/JWT/refresh behavior.
-
-### E2E
-
-Web E2E uses a D1-seeded Better Auth user. Desktop integration uses the supported Device Authorization flow or seeded Better Auth session setup, without test-only auth protocols.
+- E2E `AuthState::for_e2e_user`/`SessionData`/validation shape;
+- WDIO/standalone session user injection;
+- renderer E2E session storage;
+- crash-recovery E2E session storage;
+- absence of production magic-link/deep-link/loopback/JWT/refresh behavior.
 
 ## Completion Definition
 
-The migration is complete when:
+The migration is ready for production operator execution when:
 
+- PR A has been merged/deployed and its additive pre-production smoke proof passes;
+- PR B static/type/unit/Rust/E2E checks pass;
 - D1 holds Better Auth core, Device Authorization, and rate-limit tables;
-- existing application owner UUIDs are preserved;
+- existing application owner UUIDs are preserved by import tooling;
 - password and Google web sign-in use Better Auth;
 - implicit linking/signup remain disabled;
-- browser GraphQL/REST uses cookie sessions with unsafe-method Origin validation;
+- `DTX_WEB_URL` is the authentication trust origin and `CORS_ALLOWED_ORIGINS` is CORS-only;
+- production/pre-production cookies have distinct prefixes;
+- credentialed CORS is enabled on preflight and normal responses;
+- `/get-session` does not use the database rate limiter;
+- browser GraphQL/REST uses cookie sessions with unsafe-method canonical-Origin validation;
+- production SSR uses the API service binding;
 - desktop uses Device Authorization and opaque Bearer sessions;
-- desktop retains the valid/invalid/not-configured restore contract;
-- no auth magic-link/deep-link/loopback/JWT/refresh-token machinery remains;
+- desktop retains valid/invalid/not-configured and Drive session-epoch semantics;
+- desktop E2E no longer requires refresh-token-shaped Supabase storage;
+- no production auth magic-link/deep-link/loopback/JWT/refresh-token machinery remains;
 - no active package/config/test depends on Supabase;
-- the obsolete root/turbo Supabase `gen-types` task is removed;
-- unit, integration, Rust, web E2E, and desktop E2E checks pass;
-- pre-production acceptance passes;
-- the production runbook is ready for operator execution.
+- obsolete root/turbo Supabase `gen-types` is removed;
+- full pre-production acceptance passes;
+- the production runbook is ready for separate operator execution.

--- a/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
@@ -1,0 +1,576 @@
+# Better Auth and Cloudflare D1 Migration Design
+
+**Status:** Approved direction, implementation pending  
+**Date:** 2026-08-18  
+**Repository:** `cwchanap/DTXWeb`
+
+## Summary
+
+DTXWeb already stores application data in Cloudflare D1. Supabase remains as the authentication provider and as Supabase-shaped session plumbing across the web app, API, desktop app, tests, environment configuration, and generated types.
+
+This design completes the migration by hosting Better Auth in `dtx-api`, storing Better Auth data in the existing D1 database, moving browser requests to Better Auth cookie sessions, and replacing the desktop magic-link/deep-link protocol with Better Auth Device Authorization plus Bearer sessions.
+
+The cutover is intentionally direct. There is no dual-auth feature flag, long-lived Supabase verifier, custom device protocol, OAuth Provider/JWT layer, or second auth Worker.
+
+## Current State
+
+### Application data
+
+The application data path is already D1-backed:
+
+- `dtx-api` owns the `DB` binding and versioned D1 migrations.
+- Shared server queries use the existing D1 schema for simfiles, DTX files, user profiles, chart scores, and scores.
+- Runtime code no longer uses Supabase tables or Supabase Storage.
+
+Application ownership is keyed by the current Supabase user UUID stored as text. At minimum, `simfiles.user_id`, `user_profiles.user_id`, and `chart_scores.user_id` depend on that value.
+
+### Remaining Supabase responsibilities
+
+Supabase still owns or shapes:
+
+- Web SSR/browser session creation and validation.
+- Password sign-in, Google OAuth, explicit provider linking, and logout.
+- API bearer-token validation.
+- Desktop magic-link generation and exchange.
+- Desktop deep-link and loopback callback handling.
+- Desktop JWT expiry parsing and refresh-token rotation.
+- E2E user provisioning.
+- Environment variables, dependencies, generated Supabase types, and mocks.
+
+The desktop path has the largest migration payoff. Better Auth Device Authorization replaces the custom GraphQL magic-link mutation, callback validation, URI schemes, loopback server, JWT decoding, refresh lock, and session-refresh events.
+
+## Goals
+
+1. Make D1 the only database used by DTXWeb runtime services.
+2. Replace Supabase Auth with Better Auth 1.6.25.
+3. Preserve every migrated user's existing UUID as the Better Auth user ID.
+4. Keep password and Google sign-in for existing users.
+5. Keep Google account linking explicit.
+6. Use Better Auth Device Authorization for desktop sign-in.
+7. Use Better Auth's Bearer plugin for desktop GraphQL and REST requests.
+8. Remove runtime Supabase dependencies, variables, callbacks, refresh logic, generated types, and test bootstrap code.
+9. Keep the architecture small and first-party-client focused.
+
+## Non-goals
+
+This migration does not add:
+
+- Public registration.
+- Password-reset or email-verification delivery.
+- Passkeys, two-factor authentication, organizations, roles, or an admin dashboard.
+- Better Auth Infrastructure.
+- An OAuth 2.1/OIDC provider, JWT/JWKS issuance, scopes, or API keys.
+- A second auth Worker or second D1 database.
+- KV/Redis session storage.
+- Desktop keychain migration.
+- Backward compatibility for active Supabase sessions.
+- A permanent bcrypt compatibility layer.
+
+Active Supabase sessions are invalidated at cutover. Users sign in again through Better Auth.
+
+## Decisions
+
+### 1. Host Better Auth in `dtx-api`
+
+`dtx-api` already owns D1 and the public API hostname. It mounts Better Auth under `/api/auth/*` before the existing GraphQL and REST router.
+
+This avoids giving the web Worker a D1 binding, running two auth instances, sharing auth internals between Workers, or making desktop polling depend on a Cloudflare Access-protected hostname.
+
+`dtx-web` remains the browser UI and desktop approval surface.
+
+### 2. Use Better Auth's official Drizzle adapter over D1
+
+Better Auth 1.6.25's Cloudflare fixture uses a request-scoped Drizzle client and the official adapter:
+
+```ts
+database: drizzleAdapter(drizzle(env.DB, { schema }), {
+  provider: "sqlite",
+})
+```
+
+The generated auth schema lives at `packages/dtx-api/src/auth/schema.ts`. The existing application-data schema remains unchanged.
+
+The pinned Better Auth CLI generates the Drizzle schema. `drizzle-kit export` emits reviewed SQL into the repository's existing Wrangler D1 migration flow. Wrangler remains the only production migration executor.
+
+### 3. Keep auth rate limiting inside Better Auth
+
+Better Auth uses its database-backed rate limiter. Behind Cloudflare it reads `cf-connecting-ip` rather than trusting a client-controlled forwarded chain.
+
+The existing `RATE_LIMIT_API` KV binding remains for downloads and other API features. Only magic-link-specific rate-limit code and variables are removed.
+
+### 4. Use cross-subdomain cookies for web sessions
+
+Better Auth runs on the API hostname while SvelteKit runs on the web hostname.
+
+| Environment | API base URL | Web origin | Cookie domain |
+| --- | --- | --- | --- |
+| Production | `https://api.dtx.hapadona.com` | `https://dtx.hapadona.com` | `dtx.hapadona.com` |
+| Pre-production | `https://api.pre-prod.dtx.hapadona.com` | `https://pre-prod.dtx.hapadona.com` | `pre-prod.dtx.hapadona.com` |
+| Local | `http://localhost:8787` | `http://localhost:5173` | omitted |
+
+CORS echoes only configured origins, sets `Access-Control-Allow-Credentials: true`, and includes `Vary: Origin`. Browser auth and GraphQL requests use `credentials: "include"`.
+
+### 5. Disable signup and implicit linking
+
+```ts
+emailAndPassword: {
+  enabled: true,
+  disableSignUp: true,
+},
+socialProviders: {
+  google: {
+    clientId: env.GOOGLE_AUTH_CLIENT_ID,
+    clientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
+    disableSignUp: true,
+    disableImplicitSignUp: true,
+  },
+},
+account: {
+  accountLinking: {
+    enabled: true,
+    disableImplicitLinking: true,
+  },
+},
+```
+
+Imported Google accounts can sign in. An authenticated user can link Google explicitly with `linkSocial()`.
+
+The Google Auth client is separate from the existing Google Drive OAuth client used by the desktop app.
+
+### 6. Use Device Authorization and Bearer, not OAuth Provider/JWT
+
+DTX Desktop is a first-party client of the same application. It does not need third-party client registration, scopes, resource audiences, refresh tokens, JWT verification, or JWKS.
+
+```ts
+plugins: [
+  deviceAuthorization({
+    verificationUri: `${env.DTX_WEB_URL}/app/desktop-auth`,
+    validateClient: (clientId) => clientId === "dtx-desktop",
+  }),
+  bearer(),
+]
+```
+
+`/device/token` returns a Better Auth session token in `access_token`. Desktop sends that opaque token as `Authorization: Bearer <token>`. `auth.api.getSession({ headers })` validates both browser cookies and desktop bearer sessions.
+
+## Target Architecture
+
+```text
+                                 Cloudflare D1
+                    application tables + Better Auth tables
+                                        ▲
+                                        │
+                         api.dtx.hapadona.com
+                 ┌──────────────────────┴──────────────────────┐
+                 │                                             │
+          /api/auth/*                                  /graphql + REST
+        Better Auth handler                         resolve Better Auth session
+                 │                                             │
+       ┌─────────┴─────────┐                                   │
+       │                   │                                   │
+Web browser cookie    Desktop device flow ── Bearer session ───┘
+       │
+dtx.hapadona.com
+login, account, and
+/app/desktop-auth UI
+```
+
+## Better Auth Server
+
+### File boundary
+
+```text
+packages/dtx-api/src/auth/options.ts
+packages/dtx-api/src/auth/auth.ts
+packages/dtx-api/src/auth/auth.cli.ts
+packages/dtx-api/src/auth/schema.ts
+packages/dtx-api/src/auth/session.ts
+packages/dtx-api/src/auth/*.test.ts
+packages/dtx-api/drizzle.auth.config.ts
+packages/dtx-api/d1-migrations/0008_better_auth.sql
+```
+
+`createAuthOptions(config)` contains shared provider, cookie, rate-limit, and plugin settings. Runtime supplies D1 and real secrets. CLI schema generation supplies non-production placeholders and the pinned Drizzle SQLite adapter metadata.
+
+### Runtime instance
+
+```ts
+export const createAuth = (env: Env) =>
+  betterAuth({
+    ...createAuthOptions({
+      baseURL: env.BETTER_AUTH_URL,
+      webURL: env.DTX_WEB_URL,
+      cookieDomain: env.AUTH_COOKIE_DOMAIN,
+      googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
+      googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
+      secret: env.BETTER_AUTH_SECRET,
+    }),
+    database: drizzleAdapter(drizzle(env.DB, { schema }), {
+      provider: "sqlite",
+    }),
+  });
+```
+
+The instance is request-scoped because the Cloudflare D1 binding is request-scoped.
+
+### Router order
+
+`packages/dtx-api/src/index.ts` handles requests in this order:
+
+1. CORS preflight.
+2. Better Auth `/api/auth/*` GET/POST handler.
+3. Existing GraphQL and REST routes.
+4. Existing not-found response.
+
+The Worker does not add Hono or another router solely for auth mounting.
+
+### Neutral session resolver
+
+`packages/dtx-api/src/auth/session.ts` exposes one boundary:
+
+```ts
+resolveAuthSession(request, env): Promise<{
+  user: AuthUser | null;
+  session: AuthSession | null;
+}>
+```
+
+It calls `createAuth(env).api.getSession({ headers: request.headers })` and normalizes missing or invalid sessions to null.
+
+GraphQL context and protected REST routes use the same helper. The current `verifyToken()` function is removed.
+
+### Remove custom magic links
+
+Delete:
+
+- GraphQL `generateMagicLink` mutation and service.
+- Generated web GraphQL operation and wrapper.
+- Web `/app?redirect=desktop` handoff.
+- Magic-link rate-limit configuration.
+
+Device Authorization endpoints become the only desktop authentication protocol.
+
+## Web Authentication
+
+### Server hook
+
+The SvelteKit hook no longer constructs a Supabase client. It calls the API session endpoint with the incoming cookie header, stores neutral user/session data in `event.locals`, and keeps the existing `/app` route guard and safe `next` handling.
+
+When Better Auth rotates a cookie, the hook forwards all returned `Set-Cookie` headers to the browser.
+
+### Browser client
+
+Create one Better Auth Svelte client pointed at `PUBLIC_DTX_API_URL` with `credentials: "include"` and the Device Authorization client plugin.
+
+The root layout stops exposing a Supabase client. Page data contains only neutral session/user data.
+
+### Login and Google OAuth
+
+The login page uses:
+
+```ts
+authClient.signIn.email({ email, password })
+authClient.signIn.social({ provider: "google", callbackURL })
+```
+
+After password sign-in, the page performs a full navigation to the validated `next` route. Google callbacks terminate at the API hostname; the custom SvelteKit `/auth/callback` route is removed.
+
+### GraphQL transport
+
+The generated GraphQL layer remains unchanged.
+
+- Browser requests use `credentials: "include"` and no bearer header.
+- SvelteKit service-binding requests forward the incoming `Cookie` header.
+- Desktop requests keep `Authorization: Bearer`, now carrying a Better Auth session token.
+
+`packages/dtx-web/src/lib/api/token.ts` is removed.
+
+### Logout and account linking
+
+Logout calls `authClient.signOut()` and navigates to `/login`.
+
+The account page uses Better Auth account APIs and explicit `linkSocial({ provider: "google" })`. Supabase identity objects disappear from the UI contract.
+
+## Desktop Authentication
+
+### Browser approval flow
+
+1. Rust posts to `/api/auth/device/code` with `client_id=dtx-desktop`.
+2. Better Auth returns device/user codes, verification URLs, interval, and expiry.
+3. Rust stores only the opaque `device_code` in native memory and returns display-safe attempt data.
+4. The renderer calls the existing `open_external_url` command with `verification_uri_complete` and shows `user_code`.
+5. The browser reaches `/app/desktop-auth?user_code=...`.
+6. The web auth guard requires a Better Auth browser session.
+7. The page calls the Device Authorization verification endpoint to claim the code for that session.
+8. The page shows the code/client and requires explicit Approve or Deny.
+9. Rust polls `/api/auth/device/token` at the server interval.
+10. On approval, Better Auth returns the opaque session token.
+11. Rust calls `/api/auth/get-session` with Bearer auth to obtain the user.
+12. Native and renderer state persist one session token plus user data.
+
+The API hostname stays outside Cloudflare Access so issuance and polling work. The approval route remains under `/app`, preserving PR #221's operator-only production gate.
+
+### Native command boundary
+
+```text
+begin_device_authorization
+poll_device_authorization
+cancel_device_authorization
+validate_session
+get_current_session
+logout_session
+open_external_url
+```
+
+The migration preserves the existing `validate_session`, `get_current_session`, `logout_session`, and `open_external_url` names. Only their Supabase-shaped payloads change.
+
+`begin_device_authorization` returns `userCode`, `verificationUri`, `verificationUriComplete`, and `expiresAt`. It never exposes `device_code`.
+
+`poll_device_authorization` handles:
+
+- `authorization_pending`: continue.
+- `slow_down`: add five seconds.
+- `access_denied`: stop with denial.
+- `expired_token`: stop and require restart.
+- `invalid_grant`: clear the attempt.
+- Network failure: return a retryable error.
+
+Only one pending attempt exists. A generation counter or cancellation token prevents an older poll from committing after cancel/restart.
+
+### Native state and persistence
+
+Replace arbitrary Supabase JSON with typed `DesktopAuthUser`, `DesktopAuthSession`, and `DeviceAuthorizationAttempt` contracts generated from `src-tauri/src/api_contracts.rs` into `src/renderer/src/lib/generated/native-api-contracts.ts`.
+
+Renderer persistence stores only:
+
+```ts
+interface StoredDesktopAuthSession {
+  sessionToken: string;
+  user: DesktopAuthUser;
+}
+```
+
+Keep the existing local-storage mechanism for this migration. Moving the token to the OS keychain is a separate hardening task.
+
+Preserve the current authenticated user ID, session generation, and session epoch used by Google Drive state reconciliation.
+
+### Remove callback machinery
+
+Delete:
+
+- Magic-link parsing/exchange.
+- Auth deep-link handlers and queues.
+- Loopback TCP callback server.
+- Callback URL/port validation.
+- JWT payload parsing.
+- Supabase refresh/logout REST calls.
+- Refresh single-flight mutex.
+- `magic-link-result` and `session-refreshed` events.
+
+Remove `tauri-plugin-deep-link` after no non-test use remains. Keep `tauri-plugin-single-instance` for window focusing, without auth URL extraction.
+
+## Identity Migration
+
+### Preserve IDs
+
+Every Better Auth `user.id` must equal the existing Supabase UUID. Application ownership rows are not rewritten.
+
+The migration imports:
+
+- User ID.
+- Email and name.
+- Email verification state.
+- Created/updated timestamps.
+- Google provider/account identity.
+- Credential account only when a replacement password is supplied.
+
+Do not import Supabase sessions, access tokens, or refresh tokens.
+
+### Password policy
+
+Supabase password hashes are bcrypt while Better Auth defaults to scrypt. There are no external users and backward compatibility is not required, so do not add permanent bcrypt verification.
+
+For each credential user, provide a replacement password during the one-shot import and hash it with Better Auth's own password helper. Users without a replacement password use an imported Google account or are reset manually before cutover.
+
+### One-shot import tool
+
+Create a local-only script that consumes a sanitized Supabase Admin export and emits reviewed D1 SQL. It must:
+
+- Validate UUIDs and unique emails.
+- Reject unsupported providers instead of guessing.
+- Generate deterministic account IDs.
+- Escape SQL values safely.
+- Exclude sessions.
+- Reconcile every distinct application owner ID against imported users.
+- Write only under `tmp/auth-migration/`, which remains ignored.
+- Never send Supabase secrets to a Worker.
+
+## Environment Contract
+
+Add to `dtx-api`:
+
+```text
+BETTER_AUTH_URL
+BETTER_AUTH_SECRET
+DTX_WEB_URL
+AUTH_COOKIE_DOMAIN
+GOOGLE_AUTH_CLIENT_ID
+GOOGLE_AUTH_CLIENT_SECRET
+```
+
+Secrets are Wrangler secrets. URL/domain/client-ID values are environment vars.
+
+Keep desktop:
+
+```text
+VITE_DTX_SERVER_URL
+VITE_DTX_API_URL
+GOOGLE_DRIVE_OAUTH_CLIENT_ID
+```
+
+Remove Supabase and desktop auth-callback variables after cutover.
+
+## Error Handling
+
+### Web
+
+- Invalid credentials remain on login with a sanitized message.
+- `account_not_linked` instructs the user to sign in with the existing method and link Google explicitly.
+- Invalid/expired device codes show a restart message.
+- Approval/denial controls disable while in flight.
+
+### Desktop
+
+- Pending and slow-down are internal polling states.
+- Denial and expiry are distinct user-facing outcomes.
+- Invalid stored sessions clear local/native state.
+- Logout clears local state even when server revocation fails.
+- Browser-opening failure shows the plain verification URL and code.
+
+### API
+
+- Better Auth owns auth endpoint errors.
+- GraphQL and REST preserve current unauthorized semantics.
+- Public download behavior remains controlled by the existing flag.
+- Credentialed CORS never uses `*`.
+
+## Security Boundary
+
+Better Auth owns password hashing, OAuth state/callback validation, signed cookies, session storage/expiry, CSRF/origin checks, device-code generation/claiming/approval/polling/expiry, Bearer validation/revocation, and auth rate limiting.
+
+DTXWeb owns exact origins/cookie domains, secret storage, Access placement, approval UI, ownership-ID preservation, and local desktop cleanup.
+
+## Deployment and Cutover
+
+The implementation ships as one code PR but is proved in stages.
+
+### Pre-production
+
+1. Apply `0008_better_auth.sql`.
+2. Configure Better Auth and Google secrets.
+3. Import pre-production identities.
+4. Deploy API and web.
+5. Build desktop against pre-production.
+6. Prove password, Google, linking, logout, GraphQL, REST, device approval/denial/expiry/restore/logout.
+7. Confirm API auth endpoints remain outside Access and `/app/desktop-auth` remains protected.
+
+### Production
+
+1. Export and back up Supabase Auth data.
+2. Apply the D1 auth migration.
+3. Generate, review, and apply identity-import SQL.
+4. Deploy API and web in the same cutover window.
+5. Release the Better Auth desktop build.
+6. Require users to sign in again.
+7. Run ownership and end-to-end checks.
+8. Remove/revoke Supabase credentials only after acceptance.
+
+A short coordinated cutover is simpler than a dual verifier.
+
+## Coordination with PR #221
+
+After PR #221 lands, update its Zero Trust design, plan, and runbook to state:
+
+- Better Auth is the inner application-authentication gate.
+- `/app/desktop-auth` is the desktop approval route.
+- API device-code/polling endpoints remain outside Access.
+- Production desktop authorization remains operator-only because approval is under `/app`.
+- `/login?redirect=desktop`, auth deep links, and loopback verification are removed.
+
+Implementation can begin before PR #221 merges, but production rollout must reconcile both document sets.
+
+## Testing Strategy
+
+### API
+
+- Generated schema/migration parity.
+- Better Auth GET/POST handler mounting.
+- Cookie and Bearer session resolution.
+- Missing/invalid session normalization.
+- Existing GraphQL scopes and REST authorization.
+- Credentialed CORS.
+
+### Web
+
+- Server hook and safe redirects.
+- Password and Google sign-in.
+- Explicit linking and logout.
+- Browser cookie transport and service-binding cookie forwarding.
+- Device code claim, approve, deny, invalid, and expired UI.
+
+### Desktop
+
+- Code request parsing.
+- Pending/slow-down polling.
+- Approval, denial, expiry, invalid grant, and network failure.
+- Stored-session validation and logout.
+- Renderer persistence and restore.
+- Google Drive session-generation invariants.
+- No callback listener or auth deep-link remains.
+
+### End-to-end
+
+- Local D1 Better Auth user provisioning.
+- Web authenticated score flow.
+- Desktop Device Authorization, restore, and logout.
+- Pre-production production-like flow with Cloudflare Access.
+
+## Rejected Alternatives
+
+- **Keep Supabase only for auth:** leaves the most complex cross-runtime dependency.
+- **Handcraft a device protocol:** Better Auth already owns the protocol and security rules.
+- **Keep magic links:** retains callback, deep-link, refresh, and JWT machinery.
+- **Use OAuth Provider/JWT:** unnecessary for one first-party desktop client and one resource server.
+- **Use Better Auth Electron plugin:** DTX Desktop is Tauri; Device Authorization is framework-neutral.
+- **Put Better Auth in `dtx-web`:** web has no D1 binding and desktop polling must stay outside Access.
+- **Create a dedicated auth Worker:** extra deployment boundary without another consumer.
+- **Keep bcrypt compatibility:** replacement passwords are cheaper than permanent legacy hashing.
+
+## Acceptance Criteria
+
+The migration is complete when:
+
+1. D1 contains Better Auth core, device-code, and rate-limit tables.
+2. Password and Google web sign-in create valid Better Auth sessions.
+3. Browser GraphQL/REST authenticate through cookies.
+4. Desktop uses Device Authorization and an opaque Better Auth Bearer session.
+5. Existing ownership remains valid because user IDs are preserved.
+6. Google linking is explicit and implicit linking remains disabled.
+7. Public signup remains disabled.
+8. Desktop has no magic link, auth deep link, loopback callback, JWT decoder, or refresh-token rotation.
+9. No runtime package or active environment contract depends on Supabase.
+10. Unit, integration, Rust, web E2E, and desktop E2E checks pass.
+11. PR #221 documentation identifies Better Auth and `/app/desktop-auth`.
+12. Disabling Supabase causes no DTXWeb runtime failure.
+
+## References
+
+- Better Auth Cloudflare fixture v1.6.25: https://github.com/better-auth/better-auth/tree/v1.6.25/e2e/smoke/test/fixtures/cloudflare
+- Better Auth Drizzle adapter: https://better-auth.com/docs/adapters/drizzle
+- Drizzle Kit export: https://orm.drizzle.team/docs/drizzle-kit-export
+- Better Auth Device Authorization: https://better-auth.com/docs/plugins/device-authorization
+- Better Auth Bearer plugin: https://better-auth.com/docs/plugins/bearer
+- Better Auth cookies: https://better-auth.com/docs/concepts/cookies
+- Better Auth Supabase migration guide: https://better-auth.com/docs/guides/supabase-migration-guide
+- Better Auth CLI: https://better-auth.com/docs/concepts/cli
+- Better Auth 1.6.25: https://github.com/better-auth/better-auth/releases/tag/v1.6.25


### PR DESCRIPTION
## Summary

- documents the Better Auth + Cloudflare D1 target architecture for HPA-644
- uses the official Better Auth Drizzle-on-D1 pattern in `dtx-api`
- replaces desktop magic-link/deep-link auth with Device Authorization + opaque Bearer sessions
- preserves existing application user IDs and keeps production cutover operator-owned
- splits implementation into an additive foundation PR and a later atomic application-cutover PR

## Scope

Documentation only. No runtime code, secrets, Cloudflare resources, Supabase state, or D1 data changed.

## Key decisions

- Better Auth lives in `dtx-api` under `/api/auth/*`; no second Worker or web D1 binding
- Better Auth and the npm `auth` CLI are pinned to the same exact stable **1.6.x** patch selected at implementation start
- generated Better Auth schema stays in `dtx-api`; reviewed SQL lands as `0008_better_auth.sql`; Wrangler remains the migration executor
- `DTX_WEB_URL` is the single application-auth trusted web origin for Better Auth `trustedOrigins` and unsafe cookie-authenticated application requests
- `CORS_ALLOWED_ORIGINS` remains CORS-only and may continue containing pre-production localhost origins
- cookie names use per-environment prefixes (`dtx`, `dtx-preprod`, `dtx-local`) so production cookies cannot collide with nested pre-production hosts
- credentialed CORS explicitly sets `Access-Control-Allow-Credentials: true` for both preflight and normal allowed responses
- browser GraphQL/REST/download traffic uses cookies with `credentials: include`; Desktop stays Bearer
- production `dtx-web` gains the same `API -> dtx-api` service-binding seam already used by pre-production for SSR auth/session traffic
- Better Auth database rate limiting stays enabled, but `/get-session` is exempt so ordinary SSR session lookup does not write a D1 rate-limit row on every navigation
- multi-value `Set-Cookie` is regression-tested; current `withCors()` header-copy structure is kept unless the test proves it loses cardinality
- desktop keeps `validate_session`, `get_current_session`, `logout_session`, `open_external_url`, `valid | invalid | not-configured`, and Drive session-generation/epoch invariants
- the existing native `e2e + debug_assertions` auth seed remains, reshaped to `{ sessionToken, user }`; no fake refresh token and no production test-auth route
- `ApiAuthUser` stays `{ id: string }`; no Supabase user type and no auth-table FKs for application ownership rows
- no dual-auth application authorization, OAuth Provider/JWT/JWKS, custom device protocol, bcrypt shim, or second database

## Review changes addressed

- stops using `CORS_ALLOWED_ORIGINS` as an auth/open-redirect trust boundary because deployed pre-production intentionally includes localhost
- adds environment-specific Better Auth cookie prefixes to prevent production/pre-production cookie-name collisions
- adds the missing native/WDIO/standalone/crash-recovery desktop E2E session-shape migration
- explicitly flips credentialed CORS at both existing CORS call sites
- adds the production API service binding and makes the SvelteKit hook prefer it over a public API round-trip
- exempts only `/get-session` from database-backed rate limiting while retaining Better Auth default/plugin limits elsewhere
- changes the frozen `1.6.25` instruction to implementation-time exact pinning of the then-current stable 1.6.x patch; the npm package named `auth` remains intentional
- adds an explicit Risks section
- changes delivery from one large implementation PR to two implementation PRs at the additive/destructive seam

## Delivery shape

### PR A — additive foundation

1. choose and pin the reviewed Better Auth 1.6.x patch + matching `auth` CLI
2. generate Better Auth schema and `0008_better_auth.sql`
3. mount `/api/auth/*`, make CORS credential-capable, add cookie-prefix/trusted-origin/rate-limit configuration
4. add an **unwired** neutral `resolveAuthSession()` and keep `verifyToken()` live for GraphQL/REST
5. add the production `API -> dtx-api` service binding
6. deploy/prove the additive migration and auth primitives in pre-production before merge

### PR B — application cutover

4. switch GraphQL/REST to Better Auth sessions
5. remove custom magic links/web desktop callback handoff
6. replace SvelteKit Supabase session plumbing
7. migrate password/Google/link/logout using the existing redirect/error seam
8. convert every browser/SSR API call and download to cookies
9. add `/app/desktop-auth`
10. migrate native desktop auth + native E2E session shape
11. migrate renderer persistence and all existing desktop E2E session seeds
12. add ID-preserving identity import + Better Auth web E2E seed
13. remove Supabase dependencies/config/generated typegen
14. cover E2E and write/reconcile the operator/Zero Trust runbooks
15. run full verification and pre-production proof, then stop before production execution

## Coordination

PR #221's Zero Trust plan remains a dependency for the final documentation/acceptance pass. API device endpoints stay outside Cloudflare Access; `/app/desktop-auth` stays inside the protected application surface.

## Validation

- current Wrangler CORS/D1/service-binding topology rechecked
- current desktop native + WDIO + standalone + crash-recovery auth seams rechecked
- Better Auth `v1.6.30`, `v1.7.1`, matching `auth` CLI packaging, cookie prefix, and rate-limit custom-rule behavior rechecked from upstream primary sources
- branch remains documentation-only; implementation behavior is unchanged by this PR
