### PR TITLE
chore: format dependency audit baseline docs

### DIFF
--- a/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-613-affected-ci.md
@@ -53,6 +53,7 @@ Commit: `ci: stop packaging desktop apps on pull requests`
 ## A3. Path-filter non-required validation
 
 **Modify:**
+
 - `.github/workflows/e2e-test.yml`
 - `.github/workflows/desktop-e2e-test.yml`
 - `.github/workflows/tauri-rust-ci.yml`
@@ -124,6 +125,7 @@ Commit: `ci: skip codeql for non-source pull requests`
 ## A6. Add Codecov flags + carryforward
 
 **Modify:**
+
 - `codecov.yml`
 - `.github/workflows/unit-test.yml`
 - `.github/workflows/tauri-rust-ci.yml`
@@ -145,13 +147,13 @@ Commit: `ci: carry forward partial coverage streams`
 
 Expected after PR A:
 
-| Change | Result |
-| --- | --- |
-| docs only | required unit/lint still full; packaging/E2E/Rust/CodeQL skip |
-| web-only | web E2E runs; desktop/Rust/packaging skip |
+| Change           | Result                                                                   |
+| ---------------- | ------------------------------------------------------------------------ |
+| docs only        | required unit/lint still full; packaging/E2E/Rust/CodeQL skip            |
+| web-only         | web E2E runs; desktop/Rust/packaging skip                                |
 | desktop renderer | desktop E2E + Rust CI run; web E2E skips unless shared/web input changed |
-| desktop Rust | Rust CI + desktop E2E run; packaging skips |
-| common/shared | web E2E + desktop E2E run; Rust CI stays skipped without native changes |
+| desktop Rust     | Rust CI + desktop E2E run; packaging skips                               |
+| common/shared    | web E2E + desktop E2E run; Rust CI stays skipped without native changes  |
 
 **Decision rule:** measurement can justify editing HPA-613, but do not silently mark the issue done. As written, the ticket still requires cheap docs-only required jobs and relevant-language PR CodeQL.
 
@@ -162,6 +164,7 @@ Expected after PR A:
 ## B1. Add one tested fail-open detector
 
 **Create:**
+
 - `.github/scripts/ci-affected-scope.sh`
 - `.github/scripts/ci-affected-scope.test.sh`
 - minimal Turbo JSON fixtures under `.github/scripts/fixtures/`
@@ -278,8 +281,8 @@ Commit: `ci: add codeql language scope mode`
 
 ```yaml
 with:
-  languages: ${{ matrix.language }}
-  build-mode: none
+    languages: ${{ matrix.language }}
+    build-mode: none
 ```
 
 Do not leave `build-mode: ${{ matrix.build-mode }}` after removing the current `matrix.include` structure.
@@ -299,14 +302,14 @@ Commit: `ci: scope codeql by changed language`
 
 Document the final matrix and invariants:
 
-| Change | Unit | ESLint/Prettier | Heavy lint | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| docs only | skip | run | skip | skip | skip | skip | skip | skip |
-| web/API | run | run | run | run | skip | skip | skip | JS/TS |
-| common/ui | run | run | run | run | run | skip | skip | JS/TS |
-| desktop renderer | run | run | run | skip | run | run | skip | JS/TS |
-| desktop Rust | run | run | run | skip | run | run | skip | Rust |
-| `tsconfig.base.json` | run | run | run | run | run | skip | skip | JS/TS |
+| Change               | Unit | ESLint/Prettier | Heavy lint | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
+| -------------------- | ---- | --------------- | ---------- | ------- | ----------- | ------- | --------- | ------ |
+| docs only            | skip | run             | skip       | skip    | skip        | skip    | skip      | skip   |
+| web/API              | run  | run             | run        | run     | skip        | skip    | skip      | JS/TS  |
+| common/ui            | run  | run             | run        | run     | run         | skip    | skip      | JS/TS  |
+| desktop renderer     | run  | run             | run        | skip    | run         | run     | skip      | JS/TS  |
+| desktop Rust         | run  | run             | run        | skip    | run         | run     | skip      | Rust   |
+| `tsconfig.base.json` | run  | run             | run        | run     | run         | skip    | skip      | JS/TS  |
 
 Also document:
 

--- a/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
+++ b/docs/superpowers/plans/2026-08-18-better-auth-d1-migration.md
@@ -110,48 +110,48 @@ The package named `auth` is the Better Auth CLI.
 const trustedWebOrigin = new URL(config.webURL).origin;
 
 return {
-  baseURL: config.baseURL,
-  secret: config.secret,
-  trustedOrigins: [trustedWebOrigin],
-  emailAndPassword: {
-    enabled: true,
-    disableSignUp: true,
-  },
-  socialProviders: {
-    google: {
-      clientId: config.googleClientId,
-      clientSecret: config.googleClientSecret,
-      disableSignUp: true,
-      disableImplicitSignUp: true,
-    },
-  },
-  account: {
-    accountLinking: {
-      enabled: true,
-      disableImplicitLinking: true,
-    },
-  },
-  advanced: {
-    cookiePrefix: config.cookiePrefix,
-    crossSubDomainCookies: config.cookieDomain
-      ? { enabled: true, domain: config.cookieDomain }
-      : { enabled: false },
-    ipAddress: { ipAddressHeaders: ['cf-connecting-ip'] },
-  },
-  rateLimit: {
-    enabled: true,
-    storage: 'database',
-    customRules: {
-      '/get-session': false,
-    },
-  },
-  plugins: [
-    deviceAuthorization({
-      verificationUri: `${config.webURL}/app/desktop-auth`,
-      validateClient: (clientId) => clientId === 'dtx-desktop',
-    }),
-    bearer(),
-  ],
+	baseURL: config.baseURL,
+	secret: config.secret,
+	trustedOrigins: [trustedWebOrigin],
+	emailAndPassword: {
+		enabled: true,
+		disableSignUp: true
+	},
+	socialProviders: {
+		google: {
+			clientId: config.googleClientId,
+			clientSecret: config.googleClientSecret,
+			disableSignUp: true,
+			disableImplicitSignUp: true
+		}
+	},
+	account: {
+		accountLinking: {
+			enabled: true,
+			disableImplicitLinking: true
+		}
+	},
+	advanced: {
+		cookiePrefix: config.cookiePrefix,
+		crossSubDomainCookies: config.cookieDomain
+			? { enabled: true, domain: config.cookieDomain }
+			: { enabled: false },
+		ipAddress: { ipAddressHeaders: ['cf-connecting-ip'] }
+	},
+	rateLimit: {
+		enabled: true,
+		storage: 'database',
+		customRules: {
+			'/get-session': false
+		}
+	},
+	plugins: [
+		deviceAuthorization({
+			verificationUri: `${config.webURL}/app/desktop-auth`,
+			validateClient: (clientId) => clientId === 'dtx-desktop'
+		}),
+		bearer()
+	]
 };
 ```
 
@@ -165,9 +165,9 @@ Add scripts using the selected exact CLI:
 
 ```json
 {
-  "auth:schema:generate": "auth generate --config src/auth/auth.cli.ts --output src/auth/schema.ts --adapter drizzle --dialect sqlite --yes",
-  "auth:schema:export": "drizzle-kit export --config drizzle.auth.config.ts --sql=true",
-  "auth:schema:check": "bun run auth:schema:generate && git diff --exit-code -- src/auth/schema.ts"
+	"auth:schema:generate": "auth generate --config src/auth/auth.cli.ts --output src/auth/schema.ts --adapter drizzle --dialect sqlite --yes",
+	"auth:schema:export": "drizzle-kit export --config drizzle.auth.config.ts --sql=true",
+	"auth:schema:check": "bun run auth:schema:generate && git diff --exit-code -- src/auth/schema.ts"
 }
 ```
 
@@ -294,20 +294,20 @@ If the supported Workers test runtime proves cardinality is lost, implement the 
 
 ```ts
 export const createAuth = (env: Env) =>
-  betterAuth({
-    ...createAuthOptions({
-      baseURL: env.BETTER_AUTH_URL,
-      webURL: env.DTX_WEB_URL,
-      cookieDomain: env.AUTH_COOKIE_DOMAIN,
-      cookiePrefix: env.AUTH_COOKIE_PREFIX,
-      googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
-      googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
-      secret: env.BETTER_AUTH_SECRET,
-    }),
-    database: drizzleAdapter(drizzle(env.DB, { schema: authSchema }), {
-      provider: 'sqlite',
-    }),
-  });
+	betterAuth({
+		...createAuthOptions({
+			baseURL: env.BETTER_AUTH_URL,
+			webURL: env.DTX_WEB_URL,
+			cookieDomain: env.AUTH_COOKIE_DOMAIN,
+			cookiePrefix: env.AUTH_COOKIE_PREFIX,
+			googleClientId: env.GOOGLE_AUTH_CLIENT_ID,
+			googleClientSecret: env.GOOGLE_AUTH_CLIENT_SECRET,
+			secret: env.BETTER_AUTH_SECRET
+		}),
+		database: drizzleAdapter(drizzle(env.DB, { schema: authSchema }), {
+			provider: 'sqlite'
+		})
+	});
 ```
 
 - [ ] **Step 5: Mount handler before GraphQL/REST.**
@@ -370,12 +370,12 @@ const hasBearer = request.headers.get('authorization')?.startsWith('Bearer ') ==
 const hasCookie = request.headers.has('cookie');
 
 if (
-  !hasBearer &&
-  hasCookie &&
-  UNSAFE_METHODS.has(request.method) &&
-  request.headers.get('origin') !== trustedWebOrigin
+	!hasBearer &&
+	hasCookie &&
+	UNSAFE_METHODS.has(request.method) &&
+	request.headers.get('origin') !== trustedWebOrigin
 ) {
-  return null;
+	return null;
 }
 ```
 
@@ -680,10 +680,10 @@ Assert browser GraphQL uses `credentials: 'include'` and no Authorization header
 
 ```ts
 export type ClientCtx = {
-  fetch?: typeof fetch;
-  platform?: App.Platform;
-  cookieHeader?: string | null;
-  origin?: string | null;
+	fetch?: typeof fetch;
+	platform?: App.Platform;
+	cookieHeader?: string | null;
+	origin?: string | null;
 };
 ```
 
@@ -896,8 +896,8 @@ Store one neutral object:
 
 ```ts
 {
-  sessionToken: string;
-  user: DesktopAuthUser;
+	sessionToken: string;
+	user: DesktopAuthUser;
 }
 ```
 

--- a/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-613-affected-ci-design.md
@@ -94,17 +94,17 @@ Therefore:
 
 ## Reuse decisions
 
-| Proposed work | Decision |
-| --- | --- |
-| Affected workspace calculation | Reuse Turborepo `turbo ls --affected --output=json` |
-| Root config invalidation | Extend existing `turbo.json` `globalDependencies` with `tsconfig.base.json` |
-| Non-required workflow filtering | Reuse native `pull_request.paths`; desktop E2E already demonstrates the pattern |
-| Root unit coverage | Reuse `bun run test:coverage`; do not split |
-| Required-job routing | New only if PR B proceeds: one small `.github/scripts/ci-affected-scope.sh` |
-| Scope regression coverage | New only with PR B: `.github/scripts/ci-affected-scope.test.sh` plus small fixtures |
-| Packaging reduction | Reuse existing release triggers; delete ordinary PR packaging branches |
-| CodeQL | PR A uses native `paths`; PR C adds language selection using the proven scope seam |
-| Coverage aggregation | Extend existing three Codecov uploads with flags/carryforward |
+| Proposed work                   | Decision                                                                            |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| Affected workspace calculation  | Reuse Turborepo `turbo ls --affected --output=json`                                 |
+| Root config invalidation        | Extend existing `turbo.json` `globalDependencies` with `tsconfig.base.json`         |
+| Non-required workflow filtering | Reuse native `pull_request.paths`; desktop E2E already demonstrates the pattern     |
+| Root unit coverage              | Reuse `bun run test:coverage`; do not split                                         |
+| Required-job routing            | New only if PR B proceeds: one small `.github/scripts/ci-affected-scope.sh`         |
+| Scope regression coverage       | New only with PR B: `.github/scripts/ci-affected-scope.test.sh` plus small fixtures |
+| Packaging reduction             | Reuse existing release triggers; delete ordinary PR packaging branches              |
+| CodeQL                          | PR A uses native `paths`; PR C adds language selection using the proven scope seam  |
+| Coverage aggregation            | Extend existing three Codecov uploads with flags/carryforward                       |
 
 ## Goals
 
@@ -346,8 +346,8 @@ Keep the selector output simple and hardcode:
 
 ```yaml
 with:
-  languages: ${{ matrix.language }}
-  build-mode: none
+    languages: ${{ matrix.language }}
+    build-mode: none
 ```
 
 Do not rely on `matrix.build-mode` after replacing the current `matrix.include` shape.
@@ -423,18 +423,18 @@ Codecov is intentionally different: HPA-613 requires upload transport failure to
 
 ## Resulting ready-PR matrix after all HPA-613 phases
 
-| Change | Unit coverage | ESLint/Prettier | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| docs only | skip | run | skip | skip | skip | skip | skip | skip |
-| `dtx-web` | run | run | run | run | skip | skip | skip | JS/TS |
-| `dtx-api` | run | run | run | run | skip | skip | skip | JS/TS |
-| `common` | run | run | run | run | run | skip | skip | JS/TS |
-| `ui-components` | run | run | run | run | run | skip | skip | JS/TS |
-| desktop renderer | run | run | run | skip | run | run | skip | JS/TS |
-| desktop Rust | run | run | run | skip | run | run | skip | Rust |
-| web E2E only | skip | run | run | run | skip | skip | skip | JS/TS when source matches |
-| desktop E2E only | skip | run | run | skip | run | run | skip | JS/TS when source matches |
-| `tsconfig.base.json` | run | run | run | run | run | skip | skip | JS/TS |
+| Change               | Unit coverage | ESLint/Prettier | Heavy lint/codegen | Web E2E | Desktop E2E | Rust CI | Packaging | CodeQL                    |
+| -------------------- | ------------- | --------------- | ------------------ | ------- | ----------- | ------- | --------- | ------------------------- |
+| docs only            | skip          | run             | skip               | skip    | skip        | skip    | skip      | skip                      |
+| `dtx-web`            | run           | run             | run                | run     | skip        | skip    | skip      | JS/TS                     |
+| `dtx-api`            | run           | run             | run                | run     | skip        | skip    | skip      | JS/TS                     |
+| `common`             | run           | run             | run                | run     | run         | skip    | skip      | JS/TS                     |
+| `ui-components`      | run           | run             | run                | run     | run         | skip    | skip      | JS/TS                     |
+| desktop renderer     | run           | run             | run                | skip    | run         | run     | skip      | JS/TS                     |
+| desktop Rust         | run           | run             | run                | skip    | run         | run     | skip      | Rust                      |
+| web E2E only         | skip          | run             | run                | run     | skip        | skip    | skip      | JS/TS when source matches |
+| desktop E2E only     | skip          | run             | run                | skip    | run         | run     | skip      | JS/TS when source matches |
+| `tsconfig.base.json` | run           | run             | run                | run     | run         | skip    | skip      | JS/TS                     |
 
 ## Decision
 

--- a/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-better-auth-d1-migration-design.md
@@ -103,7 +103,7 @@ Follow the Better Auth 1.6.x Cloudflare pattern:
 const db = drizzle(env.DB, { schema: authSchema });
 
 database: drizzleAdapter(db, {
-  provider: 'sqlite',
+	provider: 'sqlite'
 });
 ```
 
@@ -152,11 +152,11 @@ Better Auth's default SameSite cookie behavior remains defense in depth, not the
 
 ### 5. Use cross-subdomain cookies with environment-specific prefixes
 
-| Environment | API base URL | Web origin | Cookie domain | Cookie prefix |
-| --- | --- | --- | --- | --- |
-| Production | `https://api.dtx.hapadona.com` | `https://dtx.hapadona.com` | `dtx.hapadona.com` | `dtx` |
+| Environment    | API base URL                            | Web origin                          | Cookie domain               | Cookie prefix |
+| -------------- | --------------------------------------- | ----------------------------------- | --------------------------- | ------------- |
+| Production     | `https://api.dtx.hapadona.com`          | `https://dtx.hapadona.com`          | `dtx.hapadona.com`          | `dtx`         |
 | Pre-production | `https://api.pre-prod.dtx.hapadona.com` | `https://pre-prod.dtx.hapadona.com` | `pre-prod.dtx.hapadona.com` | `dtx-preprod` |
-| Local | `http://localhost:8787` | `http://localhost:5173` | omitted | `dtx-local` |
+| Local          | `http://localhost:8787`                 | `http://localhost:5173`             | omitted                     | `dtx-local`   |
 
 The production domain cookie is intentionally shared with `api.dtx.hapadona.com`, but that domain also covers nested pre-production hostnames. Without distinct names, a browser can send production and pre-production cookies with the same Better Auth cookie name to pre-production hosts.
 
@@ -220,7 +220,7 @@ Add the root binding:
 
 ```json
 {
-  "services": [{ "binding": "API", "service": "dtx-api" }]
+	"services": [{ "binding": "API", "service": "dtx-api" }]
 }
 ```
 
@@ -337,7 +337,7 @@ After the magic-link mutation is removed, GraphQL/REST authorization only needs 
 
 ```ts
 type ApiAuthUser = {
-  id: string;
+	id: string;
 };
 ```
 


### PR DESCRIPTION
## Summary
- format the four plan/spec files newly added to `main`
- restore the repo-wide Prettier gate so rebased dependency PRs can be evaluated on their own changes
- unblock Dependabot PR #231

## Verification
- `/Users/chanwaichan/workspace/drumery/node_modules/.bin/prettier --check .`
- `git diff --check`