### PR TITLE
refactor(common, desktop): extract Preview helpers and desktop SongDetails/simfile modules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "drumery",

--- a/packages/common/src/lib/game/audio/soundChipPreparation.test.ts
+++ b/packages/common/src/lib/game/audio/soundChipPreparation.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SoundChip } from '../../chart/dtx';
+
+vi.mock('$lib/browser/audioDecoder', () => ({
+	XAaudioContext: { decodeAudioData: vi.fn() }
+}));
+
+import { XAaudioContext } from '$lib/browser/audioDecoder';
+import {
+	getSoundCacheKey,
+	audioBufferToWavBlob,
+	prepareSoundChipAudioSource
+} from './soundChipPreparation';
+
+describe('getSoundCacheKey', () => {
+	it('generates a lowercase cache key from soundChip fileName', () => {
+		const soundChip = { id: 1, fileName: 'Drum.WAV' } as SoundChip;
+		expect(getSoundCacheKey(soundChip)).toBe('soundchip_drum.wav');
+	});
+
+	it('handles already lowercase filenames', () => {
+		const soundChip = { id: 2, fileName: 'snare.wav' } as SoundChip;
+		expect(getSoundCacheKey(soundChip)).toBe('soundchip_snare.wav');
+	});
+
+	it('handles mixed-case filenames', () => {
+		const soundChip = { id: 3, fileName: 'HiHat.ogg' } as SoundChip;
+		expect(getSoundCacheKey(soundChip)).toBe('soundchip_hihat.ogg');
+	});
+});
+
+describe('audioBufferToWavBlob', () => {
+	it('returns a Blob of type audio/wav', () => {
+		const mockAudioBuffer = {
+			numberOfChannels: 1,
+			length: 4,
+			sampleRate: 44100,
+			getChannelData: vi.fn().mockReturnValue(new Float32Array([0, 0.5, -0.5, 1]))
+		} as unknown as AudioBuffer;
+
+		const result = audioBufferToWavBlob(mockAudioBuffer);
+		expect(result).toBeInstanceOf(Blob);
+		expect(result.type).toBe('audio/wav');
+	});
+
+	it('produces correct WAV byte size for stereo audio', () => {
+		const frames = 10;
+		const channels = 2;
+		const mockAudioBuffer = {
+			numberOfChannels: channels,
+			length: frames,
+			sampleRate: 44100,
+			getChannelData: vi.fn().mockReturnValue(new Float32Array(frames).fill(0))
+		} as unknown as AudioBuffer;
+
+		const result = audioBufferToWavBlob(mockAudioBuffer);
+		// Expected size = frames * channels * 2 (bytes per sample) + 44 (header)
+		expect(result.size).toBe(frames * channels * 2 + 44);
+	});
+
+	it('clamps audio samples to [-1, 1] range without throwing', () => {
+		const mockAudioBuffer = {
+			numberOfChannels: 1,
+			length: 3,
+			sampleRate: 44100,
+			getChannelData: vi.fn().mockReturnValue(new Float32Array([2.0, -2.0, 0.5]))
+		} as unknown as AudioBuffer;
+
+		expect(() => audioBufferToWavBlob(mockAudioBuffer)).not.toThrow();
+	});
+});
+
+describe('prepareSoundChipAudioSource', () => {
+	beforeEach(() => {
+		global.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+	});
+
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it('creates an object URL directly from the file for non-XA formats', async () => {
+		const soundChip = { fileName: 'kick.wav' } as SoundChip;
+		const file = new File(['audio'], 'kick.wav', { type: 'audio/wav' });
+
+		const result = await prepareSoundChipAudioSource(file, soundChip);
+
+		expect(result.cacheKey).toBe('soundchip_kick.wav');
+		expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+		expect(result.objectUrl).toBe('blob:mock-url');
+		expect(result.wavBlob).toBeUndefined();
+	});
+
+	it('decodes via XAaudioContext and returns a fresh wavBlob when no cachedBlob is provided', async () => {
+		const soundChip = { fileName: 'drum.xa' } as SoundChip;
+		const file = new File([new Uint8Array(4)], 'drum.xa', { type: 'audio/xa' });
+		Object.defineProperty(file, 'arrayBuffer', {
+			value: vi.fn().mockResolvedValue(new ArrayBuffer(4))
+		});
+		const mockAudioBuffer = {
+			numberOfChannels: 1,
+			sampleRate: 44100,
+			length: 100,
+			getChannelData: vi.fn().mockReturnValue(new Float32Array(100))
+		} as unknown as AudioBuffer;
+
+		(XAaudioContext.decodeAudioData as ReturnType<typeof vi.fn>).mockResolvedValue(
+			mockAudioBuffer
+		);
+
+		const result = await prepareSoundChipAudioSource(file, soundChip);
+
+		expect(result.cacheKey).toBe('soundchip_drum.xa');
+		expect(XAaudioContext.decodeAudioData).toHaveBeenCalledWith(expect.any(ArrayBuffer));
+		expect(result.wavBlob).toBeInstanceOf(Blob);
+		expect(URL.createObjectURL).toHaveBeenCalledWith(result.wavBlob);
+		expect(result.objectUrl).toBe('blob:mock-url');
+	});
+
+	it('reuses a provided cachedBlob for XA files without decoding, and returns no fresh wavBlob', async () => {
+		const soundChip = { fileName: 'snare.xa' } as SoundChip;
+		const file = new File([new Uint8Array(4)], 'snare.xa');
+		const cachedBlob = new Blob(['wav-data'], { type: 'audio/wav' });
+
+		const result = await prepareSoundChipAudioSource(file, soundChip, cachedBlob);
+
+		expect(XAaudioContext.decodeAudioData).not.toHaveBeenCalled();
+		expect(URL.createObjectURL).toHaveBeenCalledWith(cachedBlob);
+		expect(result.objectUrl).toBe('blob:mock-url');
+		expect(result.wavBlob).toBeUndefined();
+	});
+
+	it('propagates the error when XA decoding fails, letting the caller handle it', async () => {
+		const soundChip = { fileName: 'bad.xa' } as SoundChip;
+		const file = new File([new Uint8Array(4)], 'bad.xa');
+		Object.defineProperty(file, 'arrayBuffer', {
+			value: vi.fn().mockResolvedValue(new ArrayBuffer(4))
+		});
+
+		(XAaudioContext.decodeAudioData as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error('decode failed')
+		);
+
+		await expect(prepareSoundChipAudioSource(file, soundChip)).rejects.toThrow('decode failed');
+	});
+
+	it('treats file extension matching case-insensitively for the XA branch', async () => {
+		const soundChip = { fileName: 'DRUM.XA' } as SoundChip;
+		const file = new File([new Uint8Array(4)], 'DRUM.XA');
+		const cachedBlob = new Blob(['wav-data'], { type: 'audio/wav' });
+
+		const result = await prepareSoundChipAudioSource(file, soundChip, cachedBlob);
+
+		expect(result.cacheKey).toBe('soundchip_drum.xa');
+		expect(URL.createObjectURL).toHaveBeenCalledWith(cachedBlob);
+	});
+});

--- a/packages/common/src/lib/game/audio/soundChipPreparation.ts
+++ b/packages/common/src/lib/game/audio/soundChipPreparation.ts
@@ -1,11 +1,11 @@
 import { XAaudioContext } from '../../browser/audioDecoder';
 import type { SoundChip } from '../../chart/dtx';
 
-export function getSoundCacheKey(soundChip: SoundChip): string {
+export const getSoundCacheKey = (soundChip: SoundChip): string => {
 	return `soundchip_${soundChip.fileName.toLowerCase()}`;
-}
+};
 
-export function audioBufferToWavBlob(audioBuffer: AudioBuffer): Blob {
+export const audioBufferToWavBlob = (audioBuffer: AudioBuffer): Blob => {
 	const numberOfChannels = audioBuffer.numberOfChannels;
 	const length = audioBuffer.length * numberOfChannels * 2 + 44;
 	const arrayBuffer = new ArrayBuffer(length);
@@ -60,7 +60,7 @@ export function audioBufferToWavBlob(audioBuffer: AudioBuffer): Blob {
 	}
 
 	return new Blob([arrayBuffer], { type: 'audio/wav' });
-}
+};
 
 export interface PreparedSoundChipAudioSource {
 	cacheKey: string;
@@ -77,11 +77,11 @@ export interface PreparedSoundChipAudioSource {
  * URL.createObjectURL/XAaudioContext.decodeAudioData calls — no Phaser
  * dependency. Errors are not caught here; callers decide how to handle them.
  */
-export async function prepareSoundChipAudioSource(
+export const prepareSoundChipAudioSource = async (
 	file: File,
 	soundChip: SoundChip,
 	cachedBlob?: Blob
-): Promise<PreparedSoundChipAudioSource> {
+): Promise<PreparedSoundChipAudioSource> => {
 	const cacheKey = getSoundCacheKey(soundChip);
 
 	if (soundChip.fileName.toLowerCase().endsWith('.xa')) {
@@ -103,4 +103,4 @@ export async function prepareSoundChipAudioSource(
 
 	const objectUrl = URL.createObjectURL(file);
 	return { cacheKey, objectUrl };
-}
+};

--- a/packages/common/src/lib/game/audio/soundChipPreparation.ts
+++ b/packages/common/src/lib/game/audio/soundChipPreparation.ts
@@ -1,0 +1,106 @@
+import { XAaudioContext } from '../../browser/audioDecoder';
+import type { SoundChip } from '../../chart/dtx';
+
+export function getSoundCacheKey(soundChip: SoundChip): string {
+	return `soundchip_${soundChip.fileName.toLowerCase()}`;
+}
+
+export function audioBufferToWavBlob(audioBuffer: AudioBuffer): Blob {
+	const numberOfChannels = audioBuffer.numberOfChannels;
+	const length = audioBuffer.length * numberOfChannels * 2 + 44;
+	const arrayBuffer = new ArrayBuffer(length);
+	const view = new DataView(arrayBuffer);
+	const channels = [];
+	let pos = 0;
+
+	// Collect audio data from all channels
+	for (let i = 0; i < numberOfChannels; i++) {
+		channels.push(audioBuffer.getChannelData(i));
+	}
+
+	// Write WAV header
+	const writeString = (str: string) => {
+		for (let i = 0; i < str.length; i++) {
+			view.setUint8(pos + i, str.charCodeAt(i));
+		}
+		pos += str.length;
+	};
+
+	const writeUint32 = (data: number) => {
+		view.setUint32(pos, data, true);
+		pos += 4;
+	};
+
+	const writeUint16 = (data: number) => {
+		view.setUint16(pos, data, true);
+		pos += 2;
+	};
+
+	writeString('RIFF');
+	writeUint32(length - 8);
+	writeString('WAVE');
+	writeString('fmt ');
+	writeUint32(16);
+	writeUint16(1);
+	writeUint16(numberOfChannels);
+	writeUint32(audioBuffer.sampleRate);
+	writeUint32(audioBuffer.sampleRate * 2 * numberOfChannels);
+	writeUint16(numberOfChannels * 2);
+	writeUint16(16);
+	writeString('data');
+	writeUint32(length - pos - 4);
+
+	// Write interleaved audio data
+	for (let i = 0; i < audioBuffer.length; i++) {
+		for (let channel = 0; channel < numberOfChannels; channel++) {
+			const sample = Math.max(-1, Math.min(1, channels[channel][i]));
+			view.setInt16(pos, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+			pos += 2;
+		}
+	}
+
+	return new Blob([arrayBuffer], { type: 'audio/wav' });
+}
+
+export interface PreparedSoundChipAudioSource {
+	cacheKey: string;
+	objectUrl: string;
+	// Only set when a new XA decode happened; callers use this to update
+	// their own processed-blob cache (e.g. Preview.soundCacheMap).
+	wavBlob?: Blob;
+}
+
+/**
+ * Prepares the audio source for a sound chip: computes its cache key and
+ * produces an object URL for loading, decoding XA files (or reusing an
+ * already-decoded cachedBlob) as needed. Pure aside from the DOM
+ * URL.createObjectURL/XAaudioContext.decodeAudioData calls — no Phaser
+ * dependency. Errors are not caught here; callers decide how to handle them.
+ */
+export async function prepareSoundChipAudioSource(
+	file: File,
+	soundChip: SoundChip,
+	cachedBlob?: Blob
+): Promise<PreparedSoundChipAudioSource> {
+	const cacheKey = getSoundCacheKey(soundChip);
+
+	if (soundChip.fileName.toLowerCase().endsWith('.xa')) {
+		let wavBlob: Blob | undefined;
+		let blobToLoad: Blob;
+
+		if (cachedBlob) {
+			blobToLoad = cachedBlob;
+		} else {
+			const arrayBuffer = await file.arrayBuffer();
+			const audioBuffer = await XAaudioContext.decodeAudioData(arrayBuffer);
+			wavBlob = audioBufferToWavBlob(audioBuffer);
+			blobToLoad = wavBlob;
+		}
+
+		const objectUrl = URL.createObjectURL(blobToLoad);
+		return { cacheKey, objectUrl, wavBlob };
+	}
+
+	const objectUrl = URL.createObjectURL(file);
+	return { cacheKey, objectUrl };
+}

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -302,7 +302,10 @@ describe('Preview Scene', () => {
 		it('should cache results and not recompute on repeated calls', () => {
 			previewScene.init(baseData);
 			const firstCall = previewScene.getTimeElapsed(2);
-			const cache = (previewScene as any)['timeElapsedCache'] as Map<number, number>;
+			const cache = (previewScene as any)['calculations']['timeElapsedCache'] as Map<
+				number,
+				number
+			>;
 			expect(cache.has(2)).toBe(true);
 			const cacheSizeAfterFirst = cache.size;
 			const secondCall = previewScene.getTimeElapsed(2);
@@ -320,7 +323,10 @@ describe('Preview Scene', () => {
 			previewScene.init(baseData);
 			// Prime the hash so validateCache won't call clear() during the spied call
 			previewScene.getTimeElapsed(0);
-			const cache = (previewScene as any)['timeElapsedCache'] as Map<number, number>;
+			const cache = (previewScene as any)['calculations']['timeElapsedCache'] as Map<
+				number,
+				number
+			>;
 			const getSpy = vi.spyOn(cache, 'get');
 			const setSpy = vi.spyOn(cache, 'set');
 
@@ -388,7 +394,10 @@ describe('Preview Scene', () => {
 				startMeasure: 0
 			});
 			const first = previewScene.getTotalMesaureOffest(2);
-			const cache = (previewScene as any)['measureOffsetCache'] as Map<number, number>;
+			const cache = (previewScene as any)['calculations']['measureOffsetCache'] as Map<
+				number,
+				number
+			>;
 			expect(cache.has(2)).toBe(true);
 			const cacheSizeAfterFirst = cache.size;
 			const second = previewScene.getTotalMesaureOffest(2);
@@ -584,46 +593,8 @@ describe('Preview Scene', () => {
 		});
 	});
 
-	describe('audioBufferToWavBlob', () => {
-		it('should return a Blob of type audio/wav', () => {
-			const mockAudioBuffer = {
-				numberOfChannels: 1,
-				length: 4,
-				sampleRate: 44100,
-				getChannelData: vi.fn().mockReturnValue(new Float32Array([0, 0.5, -0.5, 1]))
-			} as unknown as AudioBuffer;
-
-			const result = previewScene['audioBufferToWavBlob'](mockAudioBuffer);
-			expect(result).toBeInstanceOf(Blob);
-			expect(result.type).toBe('audio/wav');
-		});
-
-		it('should produce correct WAV byte size for stereo audio', () => {
-			const frames = 10;
-			const channels = 2;
-			const mockAudioBuffer = {
-				numberOfChannels: channels,
-				length: frames,
-				sampleRate: 44100,
-				getChannelData: vi.fn().mockReturnValue(new Float32Array(frames).fill(0))
-			} as unknown as AudioBuffer;
-
-			const result = previewScene['audioBufferToWavBlob'](mockAudioBuffer);
-			// Expected size = frames * channels * 2 (bytes per sample) + 44 (header)
-			expect(result.size).toBe(frames * channels * 2 + 44);
-		});
-
-		it('should clamp audio samples to [-1, 1] range without throwing', () => {
-			const mockAudioBuffer = {
-				numberOfChannels: 1,
-				length: 3,
-				sampleRate: 44100,
-				getChannelData: vi.fn().mockReturnValue(new Float32Array([2.0, -2.0, 0.5]))
-			} as unknown as AudioBuffer;
-
-			expect(() => previewScene['audioBufferToWavBlob'](mockAudioBuffer)).not.toThrow();
-		});
-	});
+	// audioBufferToWavBlob moved verbatim to game/audio/soundChipPreparation.ts;
+	// see soundChipPreparation.test.ts for its coverage.
 
 	describe('drawNote', () => {
 		beforeEach(() => {
@@ -685,6 +656,9 @@ describe('Preview Scene', () => {
 	});
 
 	describe('cache management', () => {
+		// The cache bookkeeping (lastDataHash/calculationsValid/validateCache/
+		// invalidateCache) now lives on the Phaser-free PreviewCalculations
+		// helper (previewScene['calculations']) rather than directly on Preview.
 		it('should validate cache and update lastDataHash', () => {
 			previewScene.init({
 				measureCount: 5,
@@ -694,12 +668,12 @@ describe('Preview Scene', () => {
 				startMeasure: 0
 			});
 			// Initially no hash stored
-			expect(previewScene['lastDataHash']).toBe('');
+			expect(previewScene['calculations']['lastDataHash']).toBe('');
 
 			// validateCache should update the hash
-			previewScene['validateCache']();
-			expect(previewScene['lastDataHash']).not.toBe('');
-			expect(previewScene['calculationsValid']).toBe(true);
+			previewScene['calculations']['validateCache']();
+			expect(previewScene['calculations']['lastDataHash']).not.toBe('');
+			expect(previewScene['calculations']['calculationsValid']).toBe(true);
 		});
 
 		it('should invalidate cache when called', () => {
@@ -711,12 +685,12 @@ describe('Preview Scene', () => {
 				startMeasure: 0
 			});
 
-			previewScene['validateCache']();
-			expect(previewScene['calculationsValid']).toBe(true);
+			previewScene['calculations']['validateCache']();
+			expect(previewScene['calculations']['calculationsValid']).toBe(true);
 
-			previewScene['invalidateCache']();
-			expect(previewScene['calculationsValid']).toBe(false);
-			expect(previewScene['lastDataHash']).toBe('');
+			previewScene['calculations'].invalidate();
+			expect(previewScene['calculations']['calculationsValid']).toBe(false);
+			expect(previewScene['calculations']['lastDataHash']).toBe('');
 		});
 
 		it('should reinvalidate cache when data hash changes', () => {
@@ -728,14 +702,14 @@ describe('Preview Scene', () => {
 				startMeasure: 0
 			});
 
-			previewScene['validateCache']();
-			const firstHash = previewScene['lastDataHash'];
+			previewScene['calculations']['validateCache']();
+			const firstHash = previewScene['calculations']['lastDataHash'];
 
 			// Change BPM (which changes the hash)
-			previewScene['bpm'] = 200;
+			previewScene['calculations']['bpm'] = 200;
 
-			previewScene['validateCache']();
-			const secondHash = previewScene['lastDataHash'];
+			previewScene['calculations']['validateCache']();
+			const secondHash = previewScene['calculations']['lastDataHash'];
 
 			expect(firstHash).not.toBe(secondHash);
 		});

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -659,8 +659,8 @@ describe('Preview Scene', () => {
 	});
 
 	describe('cache management', () => {
-		// The cache bookkeeping (lastDataHash/calculationsValid/validateCache/
-		// invalidateCache) now lives on the Phaser-free PreviewCalculations
+		// The cache bookkeeping (lastDataHash/validateCache/invalidateCache)
+		// now lives on the Phaser-free PreviewCalculations
 		// helper (previewScene['calculations']) rather than directly on Preview.
 		it('should validate cache and update lastDataHash', () => {
 			previewScene.init({
@@ -676,7 +676,6 @@ describe('Preview Scene', () => {
 			// validateCache should update the hash
 			previewScene['calculations']['validateCache']();
 			expect(previewScene['calculations']['lastDataHash']).not.toBe('');
-			expect(previewScene['calculations']['calculationsValid']).toBe(true);
 		});
 
 		it('should invalidate cache when called', () => {
@@ -689,10 +688,9 @@ describe('Preview Scene', () => {
 			});
 
 			previewScene['calculations']['validateCache']();
-			expect(previewScene['calculations']['calculationsValid']).toBe(true);
+			expect(previewScene['calculations']['lastDataHash']).not.toBe('');
 
 			previewScene['calculations'].invalidate();
-			expect(previewScene['calculations']['calculationsValid']).toBe(false);
 			expect(previewScene['calculations']['lastDataHash']).toBe('');
 		});
 

--- a/packages/common/src/lib/game/scenes/Preview.test.ts
+++ b/packages/common/src/lib/game/scenes/Preview.test.ts
@@ -14,13 +14,16 @@ const mockStore = vi.hoisted(() => ({
 	playSpeed: {
 		subscribe: vi.fn((callback) => {
 			callback(1);
-			return { unsubscribe: vi.fn() };
+			return vi.fn();
 		})
 	},
 	currentSoundChip: {
+		// Real Svelte stores return the unsubscribe function directly (not an
+		// { unsubscribe } object) — Preview.ts calls this return value as a
+		// function in shutdown(), so the mock must match that contract.
 		subscribe: vi.fn((callback) => {
 			callback([]);
-			return { unsubscribe: vi.fn() };
+			return vi.fn();
 		})
 	}
 }));
@@ -1031,7 +1034,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (v: null) => void) => {
 					callback(null);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 			await expect(previewScene['setupSoundsAsync']()).resolves.toBeUndefined();
@@ -1042,7 +1045,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (v: typeof mockSoundChips) => void) => {
 					callback(mockSoundChips);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 
@@ -1064,7 +1067,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (v: typeof mockSoundChips) => void) => {
 					callback(mockSoundChips);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 
@@ -1099,7 +1102,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (v: typeof mockSoundChips) => void) => {
 					callback(mockSoundChips);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 
@@ -1135,7 +1138,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (v: typeof mockSoundChips) => void) => {
 					callback(mockSoundChips);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 
@@ -1155,7 +1158,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (v: typeof mockSoundChips) => void) => {
 					callback(mockSoundChips);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 
@@ -1177,40 +1180,89 @@ describe('Preview Scene', () => {
 		});
 	});
 
-	describe('create() setTimeout subscription', () => {
-		afterEach(() => {
-			vi.runAllTimers();
-			vi.useRealTimers();
-		});
-
-		it('should subscribe to currentSoundChip after 100ms when scene is active', async () => {
-			vi.useFakeTimers();
+	describe('create() sound-chip subscription', () => {
+		// The store subscription is now created synchronously inside create()
+		// (no setTimeout/isActive() gate). Svelte stores invoke the subscriber
+		// immediately with the current value on subscribe; skipInitialSoundChipReplay
+		// guards against that initial replay triggering a redundant sound reload.
+		// startPreview() is mocked in all three tests (matching the pattern used
+		// elsewhere in this file) so its own real setupSoundsAsync().then(...) chain
+		// doesn't fire asynchronously against a panelContainer-less scene later.
+		it('should subscribe to currentSoundChip synchronously within create()', async () => {
+			const drawPanelSpy = vi
+				.spyOn(previewScene as any, 'drawPanel')
+				.mockImplementation(() => {});
+			const drawNotesSpy = vi
+				.spyOn(previewScene as any, 'drawNotes')
+				.mockImplementation(() => {});
+			const startPreviewSpy = vi
+				.spyOn(previewScene as any, 'startPreview')
+				.mockImplementation(() => {});
 
 			await previewScene.create();
 
-			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(true);
+			expect(previewScene['storeUnsubscribe']).toBeDefined();
+			expect(mockStore.currentSoundChip.subscribe).toHaveBeenCalled();
+
+			drawPanelSpy.mockRestore();
+			drawNotesSpy.mockRestore();
+			startPreviewSpy.mockRestore();
+		});
+
+		it('should not reload sounds for the subscription initial replay', async () => {
+			const drawPanelSpy = vi
+				.spyOn(previewScene as any, 'drawPanel')
+				.mockImplementation(() => {});
+			const drawNotesSpy = vi
+				.spyOn(previewScene as any, 'drawNotes')
+				.mockImplementation(() => {});
+			const startPreviewSpy = vi
+				.spyOn(previewScene as any, 'startPreview')
+				.mockImplementation(() => {});
 			const setupSoundsAsyncSpy = vi
 				.spyOn(previewScene as any, 'setupSoundsAsync')
 				.mockResolvedValue(undefined);
 
-			// Advance past the 100ms setTimeout
-			vi.advanceTimersByTime(200);
+			await previewScene.create();
 
-			expect(previewScene['storeUnsubscribe']).toBeDefined();
+			// create() itself triggers setupSoundsAsync via its own direct call
+			// (startPreview is mocked here, so its internal call doesn't count);
+			// the store's immediate replay on subscribe() must not add a
+			// redundant second reload on top of that one.
+			expect(setupSoundsAsyncSpy).toHaveBeenCalledTimes(1);
 
+			drawPanelSpy.mockRestore();
+			drawNotesSpy.mockRestore();
+			startPreviewSpy.mockRestore();
 			setupSoundsAsyncSpy.mockRestore();
 		});
 
-		it('should not subscribe when scene is not active after 100ms', async () => {
-			vi.useFakeTimers();
+		it('should reload sounds when currentSoundChip changes after scene creation', async () => {
+			const drawPanelSpy = vi
+				.spyOn(previewScene as any, 'drawPanel')
+				.mockImplementation(() => {});
+			const drawNotesSpy = vi
+				.spyOn(previewScene as any, 'drawNotes')
+				.mockImplementation(() => {});
+			const startPreviewSpy = vi
+				.spyOn(previewScene as any, 'startPreview')
+				.mockImplementation(() => {});
+			const setupSoundsAsyncSpy = vi
+				.spyOn(previewScene as any, 'setupSoundsAsync')
+				.mockResolvedValue(undefined);
 
 			await previewScene.create();
+			const callsAfterCreate = setupSoundsAsyncSpy.mock.calls.length;
 
-			(previewScene['scene'] as any).isActive = vi.fn().mockReturnValue(false);
+			const subscribeCallback = mockStore.currentSoundChip.subscribe.mock.calls[0][0];
+			await subscribeCallback([]);
 
-			vi.advanceTimersByTime(200);
+			expect(setupSoundsAsyncSpy.mock.calls.length).toBe(callsAfterCreate + 1);
 
-			expect(previewScene['storeUnsubscribe']).toBeFalsy();
+			drawPanelSpy.mockRestore();
+			drawNotesSpy.mockRestore();
+			startPreviewSpy.mockRestore();
+			setupSoundsAsyncSpy.mockRestore();
 		});
 	});
 
@@ -1710,7 +1762,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (chips: any[]) => void) => {
 					callback([mockSoundChip]);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 			(previewScene.sound.get as ReturnType<typeof vi.fn>).mockReturnValue(mockAudio);
@@ -1758,7 +1810,7 @@ describe('Preview Scene', () => {
 			mockStore.currentSoundChip.subscribe.mockImplementationOnce(
 				(callback: (chips: any[]) => void) => {
 					callback([mockSoundChip]);
-					return { unsubscribe: vi.fn() };
+					return vi.fn();
 				}
 			);
 			(previewScene.sound.get as ReturnType<typeof vi.fn>).mockReturnValue(mockAudio);

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -4,13 +4,14 @@ import EventType from '../EventType';
 import { get } from 'svelte/store';
 import store from '../../store';
 import { getFileProvider } from '../../services/fileProvider';
-import { XAaudioContext } from '../../browser/audioDecoder';
 import type { LaneMeasureNote } from '../../chart/note';
 import type { SoundChip } from '../../chart/dtx';
 import { BaseGame } from './BaseGame';
 import { AssetName, type LaneConfig } from '../interface';
 import { getAssetPath } from '../utils';
 import { calculateHighResolutionPosition } from '../utils/notePositioning';
+import { PreviewCalculations } from './previewCalculations';
+import { getSoundCacheKey, prepareSoundChipAudioSource } from '../audio/soundChipPreparation';
 
 interface Data {
 	measureCount: number;
@@ -55,11 +56,18 @@ export class Preview extends BaseGame {
 	private static animationsCreated = false;
 	private static soundCacheMap = new Map<string, { blob: Blob; processed: boolean }>();
 
-	// Performance caches for expensive calculations
-	private timeElapsedCache = new Map<number, number>();
-	private measureOffsetCache = new Map<number, number>();
-	private lastDataHash: string = '';
-	private calculationsValid = false;
+	// Phaser-free timing/measure-offset calculations, kept in sync with this
+	// scene's chart data at the same points it was previously updated directly
+	// (init() and updateData()).
+	private calculations: PreviewCalculations = new PreviewCalculations({
+		bpm: this.bpm,
+		notes: this.notes,
+		bpmNotes: this.bpmNotes,
+		measureCount: this.measureCount,
+		measureLength: this.measureLength,
+		cellHeight: this.cellHeight,
+		cellsPerMeasure: this.cellsPerMeasure
+	});
 
 	constructor() {
 		super({ key: Preview.key });
@@ -78,6 +86,14 @@ export class Preview extends BaseGame {
 		this.bpm = data.bpm;
 		this.bpmNotes = data.bpmNotes;
 		this.startMeasure = data.startMeasure;
+
+		this.calculations.update({
+			bpm: this.bpm,
+			notes: this.notes,
+			bpmNotes: this.bpmNotes,
+			measureCount: this.measureCount,
+			measureLength: this.measureLength
+		});
 
 		store.playSpeed.subscribe((value) => {
 			const seekTime =
@@ -201,8 +217,14 @@ export class Preview extends BaseGame {
 		this.measureCount = data.measureCount;
 		this.startMeasure = data.startMeasure;
 
-		// Invalidate caches since data changed
-		this.invalidateCache();
+		// Sync the calculations helper with the new data (also invalidates its caches)
+		this.calculations.update({
+			bpm: this.bpm,
+			notes: this.notes,
+			bpmNotes: this.bpmNotes,
+			measureCount: this.measureCount,
+			measureLength: this.measureLength
+		});
 
 		// Parse measure lengths with new data
 		this.parseMesaureLength();
@@ -228,40 +250,6 @@ export class Preview extends BaseGame {
 
 		// Restart preview with new data
 		this.startPreview();
-	}
-
-	/**
-	 * Generate hash of current data for cache validation
-	 */
-	private generateDataHash(): string {
-		return JSON.stringify({
-			bpm: this.bpm,
-			measureCount: this.measureCount,
-			measureLength: this.measureLength,
-			bpmNotes: this.bpmNotes
-		});
-	}
-
-	/**
-	 * Invalidate performance caches when data changes
-	 */
-	private invalidateCache(): void {
-		this.timeElapsedCache.clear();
-		this.measureOffsetCache.clear();
-		this.calculationsValid = false;
-		this.lastDataHash = '';
-	}
-
-	/**
-	 * Validate cache and update if needed
-	 */
-	private validateCache(): void {
-		const currentHash = this.generateDataHash();
-		if (this.lastDataHash !== currentHash) {
-			this.invalidateCache();
-			this.lastDataHash = currentHash;
-		}
-		this.calculationsValid = true;
 	}
 
 	private async setupSoundsAsync(): Promise<void> {
@@ -350,33 +338,21 @@ export class Preview extends BaseGame {
 		return new Promise<void>((resolve) => {
 			const setupListenersAndLoad = async () => {
 				try {
-					// Load the audio file into cache
-					if (soundChip.fileName.toLowerCase().endsWith('.xa')) {
-						// Use cached blob if available, otherwise process XA file
-						let wavBlob: Blob;
-						if (cachedBlob) {
-							wavBlob = cachedBlob;
-						} else {
-							// Process XA file and cache result
-							const arrayBuffer = await actualFile.arrayBuffer();
-							const audioBuffer = await XAaudioContext.decodeAudioData(arrayBuffer);
-							wavBlob = this.audioBufferToWavBlob(audioBuffer);
-							// Cache the processed blob
-							Preview.soundCacheMap.set(cacheKey, { blob: wavBlob, processed: true });
-						}
-						const objectUrl = URL.createObjectURL(wavBlob);
+					const { objectUrl, wavBlob } = await prepareSoundChipAudioSource(
+						actualFile,
+						soundChip,
+						cachedBlob
+					);
 
-						// Add listeners and load
-						this.setupAudioListeners(cacheKey, resolve);
-						this.load.audio(cacheKey, objectUrl);
-						this.load.start();
-					} else {
-						// For other formats, load as usual
-						this.setupAudioListeners(cacheKey, resolve);
-						const objectUrl = URL.createObjectURL(actualFile);
-						this.load.audio(cacheKey, objectUrl);
-						this.load.start();
+					// A freshly-decoded XA file produces a wavBlob; cache it for reuse
+					if (wavBlob) {
+						Preview.soundCacheMap.set(cacheKey, { blob: wavBlob, processed: true });
 					}
+
+					// Add listeners and load
+					this.setupAudioListeners(cacheKey, resolve);
+					this.load.audio(cacheKey, objectUrl);
+					this.load.start();
 				} catch (error) {
 					console.warn(`Failed to decode XA file ${soundChip.fileName}:`, error);
 					resolve();
@@ -561,169 +537,18 @@ export class Preview extends BaseGame {
 	}
 
 	getTimeElapsed(measure: number, noteChipPosition: number = 0) {
-		this.validateCache();
-
-		// Use cache for measure-level calculations (when noteChipPosition is 0)
-		if (noteChipPosition === 0) {
-			const cached = this.timeElapsedCache.get(measure);
-			if (cached !== undefined) {
-				return cached;
-			}
-		}
-
-		let elapsedTime = 0;
-		let currentBPM = this.bpm;
-
-		// Calculate time for completed measures (up to but not including the current measure)
-		for (let i = 0; i < measure; i++) {
-			const measureLength = this.measureLength[i] || 1;
-			const bpmNotes =
-				this.notes[Preview.bpmNoteID]?.filter((note) => note.measure === i) || [];
-			if (bpmNotes.length === 0) {
-				// No BPM changes in this measure, use the current BPM for the whole measure
-				elapsedTime += (60 / currentBPM) * 4 * measureLength;
-			} else {
-				// Calculate time for each segment within the measure
-				let lastPosition = 0;
-				bpmNotes.forEach((bpmNote) => {
-					// Set the measureLength for the note
-					if (bpmNote.measureLength === 1) {
-						bpmNote.measureLength = measureLength;
-					}
-					bpmNote.notes.forEach((note: { noteID: string; position: number }) => {
-						const position = note.position;
-						elapsedTime +=
-							(60 / currentBPM) * 4 * (position - lastPosition) * measureLength;
-						currentBPM = this.bpmNotes[note.noteID];
-						lastPosition = position;
-					});
-				});
-				// Add the remaining time in the measure after the last BPM change
-				elapsedTime += (60 / currentBPM) * 4 * (1 - lastPosition) * measureLength;
-			}
-		}
-
-		// Calculate time within the current measure up to the noteChipPosition
-		if (noteChipPosition > 0) {
-			const measureLength = this.measureLength[measure] || 1;
-			const bpmNotes =
-				this.notes[Preview.bpmNoteID]?.filter((note) => note.measure === measure) || [];
-
-			if (bpmNotes.length === 0) {
-				// No BPM changes in this measure
-				elapsedTime += (60 / currentBPM) * 4 * noteChipPosition;
-			} else {
-				// Calculate time for each segment within the measure up to noteChipPosition
-				let lastPosition = 0;
-				bpmNotes.forEach((bpmNote) => {
-					// Set the measureLength for the note
-					if (bpmNote.measureLength === 1) {
-						bpmNote.measureLength = measureLength;
-					}
-					bpmNote.notes.forEach((note: { noteID: string; position: number }) => {
-						const position = note.position;
-						if (position > noteChipPosition) {
-							// Past the noteChipPosition, stop calculating
-							return;
-						}
-						const noteId = note.noteID;
-						if (noteId !== '00') {
-							elapsedTime += (60 / currentBPM) * 4 * (position - lastPosition);
-							currentBPM = this.bpmNotes[noteId];
-							lastPosition = position;
-						}
-					});
-				});
-
-				// Add time from last BPM change to noteChipPosition
-				if (noteChipPosition > lastPosition) {
-					elapsedTime += (60 / currentBPM) * 4 * (noteChipPosition - lastPosition);
-				}
-			}
-		}
-
-		// Cache the result for measure-level calculations (when noteChipPosition is 0)
-		if (noteChipPosition === 0) {
-			this.timeElapsedCache.set(measure, elapsedTime);
-		}
-
-		return elapsedTime;
+		return this.calculations.getTimeElapsed(measure, noteChipPosition);
 	}
 
 	// Override getTotalMesaureOffest with caching for performance
 	override getTotalMesaureOffest(measure: number): number {
-		this.validateCache();
-
-		const cached = this.measureOffsetCache.get(measure);
-		if (cached !== undefined) {
-			return cached;
-		}
-
-		// Use parent implementation but cache the result
-		const result = super.getTotalMesaureOffest(measure);
-		this.measureOffsetCache.set(measure, result);
-		return result;
+		return this.calculations.getCachedMeasureOffset(measure, () =>
+			super.getTotalMesaureOffest(measure)
+		);
 	}
 
 	getCacheKey(soundChip: SoundChip) {
-		return `soundchip_${soundChip.fileName.toLowerCase()}`;
-	}
-
-	private audioBufferToWavBlob(audioBuffer: AudioBuffer): Blob {
-		const numberOfChannels = audioBuffer.numberOfChannels;
-		const length = audioBuffer.length * numberOfChannels * 2 + 44;
-		const arrayBuffer = new ArrayBuffer(length);
-		const view = new DataView(arrayBuffer);
-		const channels = [];
-		let pos = 0;
-
-		// Collect audio data from all channels
-		for (let i = 0; i < numberOfChannels; i++) {
-			channels.push(audioBuffer.getChannelData(i));
-		}
-
-		// Write WAV header
-		const writeString = (str: string) => {
-			for (let i = 0; i < str.length; i++) {
-				view.setUint8(pos + i, str.charCodeAt(i));
-			}
-			pos += str.length;
-		};
-
-		const writeUint32 = (data: number) => {
-			view.setUint32(pos, data, true);
-			pos += 4;
-		};
-
-		const writeUint16 = (data: number) => {
-			view.setUint16(pos, data, true);
-			pos += 2;
-		};
-
-		writeString('RIFF');
-		writeUint32(length - 8);
-		writeString('WAVE');
-		writeString('fmt ');
-		writeUint32(16);
-		writeUint16(1);
-		writeUint16(numberOfChannels);
-		writeUint32(audioBuffer.sampleRate);
-		writeUint32(audioBuffer.sampleRate * 2 * numberOfChannels);
-		writeUint16(numberOfChannels * 2);
-		writeUint16(16);
-		writeString('data');
-		writeUint32(length - pos - 4);
-
-		// Write interleaved audio data
-		for (let i = 0; i < audioBuffer.length; i++) {
-			for (let channel = 0; channel < numberOfChannels; channel++) {
-				const sample = Math.max(-1, Math.min(1, channels[channel][i]));
-				view.setInt16(pos, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
-				pos += 2;
-			}
-		}
-
-		return new Blob([arrayBuffer], { type: 'audio/wav' });
+		return getSoundCacheKey(soundChip);
 	}
 
 	override setCameraBounds() {
@@ -859,58 +684,7 @@ export class Preview extends BaseGame {
 	}
 
 	getCellHeight(measure: number, cell: number): number {
-		// For given measure and cell, calculate the height of the cell based on the BPM
-		const referenceBPM = 120;
-
-		// Find all BPM notes that apply to this measure
-		const measureBpmNotes = this.notes[Preview.bpmNoteID]
-			?.filter((note) => note.measure <= measure)
-			.sort((a, b) => {
-				// Sort by measure (ascending)
-				if (a.measure !== b.measure) return a.measure - b.measure;
-				// For notes in the same measure, we'll handle them later
-				return 0;
-			});
-
-		if (!measureBpmNotes || measureBpmNotes.length === 0) {
-			// No BPM changes, use the default BPM
-			return (this.cellHeight / this.bpm) * referenceBPM;
-		}
-
-		// Find the most recent BPM change before or at our current cell position
-		const lastBpmNote = measureBpmNotes[measureBpmNotes.length - 1];
-		let currentBPM = this.bpm; // Default to the initial BPM
-
-		if (lastBpmNote.measure < measure) {
-			// BPM change in a previous measure, need to find the last BPM in that measure
-			const bpmNotes = lastBpmNote.notes;
-
-			// Find the last BPM change in the notes array
-			for (const note of bpmNotes) {
-				if (note.noteID !== '00') {
-					currentBPM = this.bpmNotes[note.noteID];
-				}
-			}
-		} else if (lastBpmNote.measure === measure) {
-			// BPM change in the current measure
-			const bpmNotes = lastBpmNote.notes;
-
-			// Find the last BPM change before or at our cell position
-			for (const note of bpmNotes) {
-				const cellPosition = Math.floor(note.position * this.cellsPerMeasure);
-				if (cellPosition > cell) {
-					break; // This BPM change is after our current cell
-				}
-
-				if (note.noteID !== '00') {
-					currentBPM = this.bpmNotes[note.noteID];
-				}
-			}
-		}
-
-		// Calculate the adjusted cell height based on the BPM
-		// Slower BPM = taller cells, faster BPM = shorter cells
-		return (this.cellHeight / currentBPM) * referenceBPM;
+		return this.calculations.getCellHeight(measure, cell);
 	}
 
 	drawFooterLane(laneConfig: LaneConfig, currentX: number) {

--- a/packages/common/src/lib/game/scenes/Preview.ts
+++ b/packages/common/src/lib/game/scenes/Preview.ts
@@ -151,15 +151,18 @@ export class Preview extends BaseGame {
 		// Start preview only once after everything is set up
 		this.startPreview();
 
-		// Defer store subscription until after initial setup
-		setTimeout(() => {
-			if (this.scene.isActive()) {
-				this.storeUnsubscribe = store.currentSoundChip.subscribe(async () => {
-					// Only reload sounds, don't restart preview
-					await this.setupSoundsAsync();
-				});
+		// Subscribe to currentSoundChip changes so sounds reload when the chip
+		// changes after scene creation. Svelte stores invoke the subscriber
+		// immediately with the current value on subscribe; skip that initial
+		// replay so we don't redundantly reload sounds we just set up above.
+		let skipInitialSoundChipReplay = true;
+		this.storeUnsubscribe = store.currentSoundChip.subscribe(async () => {
+			if (skipInitialSoundChipReplay) {
+				skipInitialSoundChipReplay = false;
+				return;
 			}
-		}, 100);
+			await this.setupSoundsAsync();
+		});
 
 		this.isInitialized = true;
 		EventBus.emit(EventType.SCENE_READY, this);

--- a/packages/common/src/lib/game/scenes/previewCalculations.test.ts
+++ b/packages/common/src/lib/game/scenes/previewCalculations.test.ts
@@ -283,24 +283,22 @@ describe('PreviewCalculations.getCachedMeasureOffset', () => {
 });
 
 describe('PreviewCalculations cache management', () => {
-	it('validateCache updates lastDataHash and calculationsValid', () => {
+	it('validateCache updates lastDataHash', () => {
 		const calc = makeCalculations();
 		expect((calc as any)['lastDataHash']).toBe('');
 
 		(calc as any)['validateCache']();
 
 		expect((calc as any)['lastDataHash']).not.toBe('');
-		expect((calc as any)['calculationsValid']).toBe(true);
 	});
 
-	it('invalidate resets calculationsValid and lastDataHash', () => {
+	it('invalidate resets lastDataHash', () => {
 		const calc = makeCalculations();
 		(calc as any)['validateCache']();
-		expect((calc as any)['calculationsValid']).toBe(true);
+		expect((calc as any)['lastDataHash']).not.toBe('');
 
 		calc.invalidate();
 
-		expect((calc as any)['calculationsValid']).toBe(false);
 		expect((calc as any)['lastDataHash']).toBe('');
 	});
 

--- a/packages/common/src/lib/game/scenes/previewCalculations.test.ts
+++ b/packages/common/src/lib/game/scenes/previewCalculations.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PreviewCalculations, generateDataHash } from './previewCalculations';
+import type { LaneMeasureNote } from '../../chart/note';
+
+type Notes = Record<string, LaneMeasureNote[]>;
+
+const makeCalculations = (
+	overrides: Partial<Parameters<typeof PreviewCalculations.prototype.update>[0]> & {
+		cellHeight?: number;
+		cellsPerMeasure?: number;
+	} = {}
+) => {
+	return new PreviewCalculations({
+		bpm: 120,
+		notes: {},
+		bpmNotes: {},
+		measureCount: 5,
+		measureLength: [],
+		cellHeight: 50,
+		cellsPerMeasure: 16,
+		...overrides
+	});
+};
+
+describe('generateDataHash', () => {
+	it('produces the same hash for identical input', () => {
+		const input = { bpm: 120, measureCount: 5, measureLength: [1, 1], bpmNotes: { '08': 120 } };
+		expect(generateDataHash(input)).toBe(generateDataHash({ ...input }));
+	});
+
+	it('produces a different hash when bpm changes', () => {
+		const base = { bpm: 120, measureCount: 5, measureLength: [], bpmNotes: {} };
+		expect(generateDataHash(base)).not.toBe(generateDataHash({ ...base, bpm: 240 }));
+	});
+
+	it('produces a different hash when measureCount changes', () => {
+		const base = { bpm: 120, measureCount: 5, measureLength: [], bpmNotes: {} };
+		expect(generateDataHash(base)).not.toBe(generateDataHash({ ...base, measureCount: 6 }));
+	});
+
+	it('produces a different hash when measureLength changes', () => {
+		const base = { bpm: 120, measureCount: 5, measureLength: [1], bpmNotes: {} };
+		expect(generateDataHash(base)).not.toBe(generateDataHash({ ...base, measureLength: [2] }));
+	});
+
+	it('produces a different hash when bpmNotes changes', () => {
+		const base = { bpm: 120, measureCount: 5, measureLength: [], bpmNotes: {} };
+		expect(generateDataHash(base)).not.toBe(
+			generateDataHash({ ...base, bpmNotes: { '08': 100 } })
+		);
+	});
+});
+
+describe('PreviewCalculations.getTimeElapsed', () => {
+	it('returns 0 for measure 0 with no note offset', () => {
+		const calc = makeCalculations();
+		expect(calc.getTimeElapsed(0)).toBe(0);
+	});
+
+	it('calculates time for a single measure at 120 BPM (2 seconds)', () => {
+		const calc = makeCalculations();
+		expect(calc.getTimeElapsed(1)).toBeCloseTo(2, 5);
+	});
+
+	it('calculates time for multiple measures', () => {
+		const calc = makeCalculations();
+		expect(calc.getTimeElapsed(3)).toBeCloseTo(6, 5);
+	});
+
+	it('caches results and does not recompute on repeated calls', () => {
+		const calc = makeCalculations();
+		const first = calc.getTimeElapsed(2);
+		const cache = (calc as any)['timeElapsedCache'] as Map<number, number>;
+		expect(cache.has(2)).toBe(true);
+		const cacheSizeAfterFirst = cache.size;
+		const second = calc.getTimeElapsed(2);
+		expect(second).toBe(first);
+		expect(cache.size).toBe(cacheSizeAfterFirst);
+	});
+
+	it('calculates in-measure time when noteChipPosition is provided', () => {
+		const calc = makeCalculations();
+		expect(calc.getTimeElapsed(0, 0.5)).toBeCloseTo(1, 5);
+	});
+
+	it('does not read or write the cache when noteChipPosition is non-zero', () => {
+		const calc = makeCalculations();
+		calc.getTimeElapsed(0);
+		const cache = (calc as any)['timeElapsedCache'] as Map<number, number>;
+		const getSpy = vi.spyOn(cache, 'get');
+		const setSpy = vi.spyOn(cache, 'set');
+
+		calc.getTimeElapsed(0, 0.25);
+
+		expect(getSpy).not.toHaveBeenCalled();
+		expect(setSpy).not.toHaveBeenCalled();
+	});
+
+	it('handles BPM changes within a measure via bpmNotes', () => {
+		const notes: Notes = {
+			'08': [
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: 'bpm150', position: 0.5 }]
+				} as unknown as LaneMeasureNote
+			]
+		};
+		const calc = makeCalculations({ notes, bpmNotes: { bpm150: 150 } });
+		const elapsed = calc.getTimeElapsed(1);
+		expect(elapsed).toBeCloseTo(1.8, 5);
+	});
+
+	it('mutates a bpmNote measureLength of 1 in place to the real measure length', () => {
+		const bpmNote = {
+			measure: 0,
+			measureLength: 1,
+			notes: [{ noteID: 'bpm150', position: 0.5 }]
+		} as unknown as LaneMeasureNote;
+		const notes: Notes = { '08': [bpmNote] };
+		const calc = makeCalculations({
+			notes,
+			bpmNotes: { bpm150: 150 },
+			measureLength: [3]
+		});
+
+		calc.getTimeElapsed(1);
+
+		expect(bpmNote.measureLength).toBe(3);
+	});
+
+	it('does not overwrite an already-set (non-1) bpmNote measureLength', () => {
+		const bpmNote = {
+			measure: 0,
+			measureLength: 7,
+			notes: [{ noteID: 'bpm150', position: 0.5 }]
+		} as unknown as LaneMeasureNote;
+		const notes: Notes = { '08': [bpmNote] };
+		const calc = makeCalculations({
+			notes,
+			bpmNotes: { bpm150: 150 },
+			measureLength: [3]
+		});
+
+		calc.getTimeElapsed(1);
+
+		expect(bpmNote.measureLength).toBe(7);
+	});
+
+	it('skips noteID 00 when calculating in-measure time up to noteChipPosition', () => {
+		const notes: Notes = {
+			'08': [
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: '00', position: 0.25 }]
+				} as unknown as LaneMeasureNote
+			]
+		};
+		const calc = makeCalculations({ notes, bpmNotes: {} });
+		const elapsed = calc.getTimeElapsed(0, 0.5);
+		expect(elapsed).toBeCloseTo(1.0, 5);
+	});
+
+	it('invalidates cache and recomputes when update() is called with new data', () => {
+		const calc = makeCalculations();
+		const originalTime = calc.getTimeElapsed(1);
+
+		calc.update({
+			bpm: 240,
+			notes: {},
+			bpmNotes: {},
+			measureCount: 5,
+			measureLength: []
+		});
+
+		const newTime = calc.getTimeElapsed(1);
+		expect(newTime).toBeCloseTo(originalTime / 2, 5);
+	});
+});
+
+describe('PreviewCalculations.getCellHeight', () => {
+	it('returns scaled cellHeight when no bpm notes exist', () => {
+		const calc = makeCalculations();
+		expect(calc.getCellHeight(0, 0)).toBeCloseTo(50, 5);
+	});
+
+	it('returns half cellHeight at double BPM', () => {
+		const calc = makeCalculations({ bpm: 240 });
+		expect(calc.getCellHeight(0, 0)).toBeCloseTo(50 * 0.5, 5);
+	});
+
+	it('uses bpm from a previous measure bpm note', () => {
+		const notes: Notes = {
+			'08': [
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: 'bpm200', position: 0 }]
+				} as unknown as LaneMeasureNote
+			]
+		};
+		const calc = makeCalculations({ notes, bpmNotes: { bpm200: 200 } });
+		const result = calc.getCellHeight(1, 0);
+		expect(result).toBeCloseTo(50 * (120 / 200), 5);
+	});
+
+	it('uses bpm from a current measure bpm note before the current cell', () => {
+		const notes: Notes = {
+			'08': [
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: 'bpm180', position: 0.25 }]
+				} as unknown as LaneMeasureNote
+			]
+		};
+		const calc = makeCalculations({ notes, bpmNotes: { bpm180: 180 } });
+		const cellsPerMeasure = 16;
+		const cellAfterChange = Math.floor(0.5 * cellsPerMeasure);
+		const result = calc.getCellHeight(0, cellAfterChange);
+		expect(result).toBeCloseTo(50 * (120 / 180), 5);
+	});
+
+	it('does not apply a BPM change that occurs after the current cell', () => {
+		const notes: Notes = {
+			'08': [
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: 'bpm240', position: 0.75 }]
+				} as unknown as LaneMeasureNote
+			]
+		};
+		const calc = makeCalculations({ notes, bpmNotes: { bpm240: 240 } });
+		const cellsPerMeasure = 16;
+		const cellBeforeChange = Math.floor(0.25 * cellsPerMeasure);
+		const result = calc.getCellHeight(0, cellBeforeChange);
+		expect(result).toBeCloseTo(50, 5);
+	});
+
+	it('handles two BPM notes sharing the same measure (sort comparator returns 0)', () => {
+		const notes: Notes = {
+			'08': [
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: 'bpm150', position: 0.1 }]
+				} as unknown as LaneMeasureNote,
+				{
+					measure: 0,
+					measureLength: 1,
+					notes: [{ noteID: 'bpm160', position: 0.9 }]
+				} as unknown as LaneMeasureNote
+			]
+		};
+		const calc = makeCalculations({ notes, bpmNotes: { bpm150: 150, bpm160: 160 } });
+		expect(() => calc.getCellHeight(0, 15)).not.toThrow();
+	});
+});
+
+describe('PreviewCalculations.getCachedMeasureOffset', () => {
+	it('caches the result and only invokes compute once for the same measure', () => {
+		const calc = makeCalculations();
+		const compute = vi.fn().mockReturnValue(42);
+
+		const first = calc.getCachedMeasureOffset(2, compute);
+		const second = calc.getCachedMeasureOffset(2, compute);
+
+		expect(first).toBe(42);
+		expect(second).toBe(42);
+		expect(compute).toHaveBeenCalledTimes(1);
+	});
+
+	it('invokes compute again for a different measure', () => {
+		const calc = makeCalculations();
+		const compute = vi.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+
+		expect(calc.getCachedMeasureOffset(1, compute)).toBe(1);
+		expect(calc.getCachedMeasureOffset(2, compute)).toBe(2);
+		expect(compute).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('PreviewCalculations cache management', () => {
+	it('validateCache updates lastDataHash and calculationsValid', () => {
+		const calc = makeCalculations();
+		expect((calc as any)['lastDataHash']).toBe('');
+
+		(calc as any)['validateCache']();
+
+		expect((calc as any)['lastDataHash']).not.toBe('');
+		expect((calc as any)['calculationsValid']).toBe(true);
+	});
+
+	it('invalidate resets calculationsValid and lastDataHash', () => {
+		const calc = makeCalculations();
+		(calc as any)['validateCache']();
+		expect((calc as any)['calculationsValid']).toBe(true);
+
+		calc.invalidate();
+
+		expect((calc as any)['calculationsValid']).toBe(false);
+		expect((calc as any)['lastDataHash']).toBe('');
+	});
+
+	it('re-invalidates cache when data hash changes via update()', () => {
+		const calc = makeCalculations();
+		(calc as any)['validateCache']();
+		const firstHash = (calc as any)['lastDataHash'];
+
+		calc.update({ bpm: 200, notes: {}, bpmNotes: {}, measureCount: 5, measureLength: [] });
+		(calc as any)['validateCache']();
+		const secondHash = (calc as any)['lastDataHash'];
+
+		expect(firstHash).not.toBe(secondHash);
+	});
+});

--- a/packages/common/src/lib/game/scenes/previewCalculations.ts
+++ b/packages/common/src/lib/game/scenes/previewCalculations.ts
@@ -1,0 +1,274 @@
+import type { LaneMeasureNote } from '../../chart/note';
+
+// Mirrors Preview.bpmNoteID. Duplicated here (rather than imported from Preview.ts)
+// to keep this module Phaser-free and avoid a circular import with Preview.ts.
+const BPM_NOTE_ID = '08';
+
+export interface PreviewCalculationsHashInput {
+	bpm: number;
+	measureCount: number;
+	measureLength: number[];
+	bpmNotes: Record<string, number>;
+}
+
+export interface PreviewCalculationsData {
+	bpm: number;
+	notes: Record<string, LaneMeasureNote[]>;
+	bpmNotes: Record<string, number>;
+	measureCount: number;
+	measureLength: number[];
+}
+
+export interface PreviewCalculationsConfig extends PreviewCalculationsData {
+	cellHeight: number;
+	cellsPerMeasure: number;
+}
+
+/**
+ * Generate a hash of the data that affects timing/measure calculations,
+ * used to detect when the performance caches need to be invalidated.
+ */
+export function generateDataHash(data: PreviewCalculationsHashInput): string {
+	return JSON.stringify({
+		bpm: data.bpm,
+		measureCount: data.measureCount,
+		measureLength: data.measureLength,
+		bpmNotes: data.bpmNotes
+	});
+}
+
+/**
+ * Phaser-free timing/measure-offset calculations extracted from Preview.
+ * Holds its own copy of the chart data, refreshed explicitly via update()
+ * (mirroring the sync points Preview.ts already had: init() and updateData()).
+ */
+export class PreviewCalculations {
+	private bpm: number;
+	private notes: Record<string, LaneMeasureNote[]>;
+	private bpmNotes: Record<string, number>;
+	private measureCount: number;
+	private measureLength: number[];
+	private readonly cellHeight: number;
+	private readonly cellsPerMeasure: number;
+
+	// Performance caches for expensive calculations
+	private timeElapsedCache = new Map<number, number>();
+	private measureOffsetCache = new Map<number, number>();
+	private lastDataHash = '';
+	private calculationsValid = false;
+
+	constructor(config: PreviewCalculationsConfig) {
+		this.bpm = config.bpm;
+		this.notes = config.notes;
+		this.bpmNotes = config.bpmNotes;
+		this.measureCount = config.measureCount;
+		this.measureLength = config.measureLength;
+		this.cellHeight = config.cellHeight;
+		this.cellsPerMeasure = config.cellsPerMeasure;
+	}
+
+	/**
+	 * Refresh the chart data used for calculations and invalidate the caches.
+	 * Mirrors the data-refresh portion of Preview.updateData().
+	 */
+	update(data: PreviewCalculationsData): void {
+		this.bpm = data.bpm;
+		this.notes = data.notes;
+		this.bpmNotes = data.bpmNotes;
+		this.measureCount = data.measureCount;
+		this.measureLength = data.measureLength;
+		this.invalidate();
+	}
+
+	/**
+	 * Invalidate performance caches when data changes
+	 */
+	invalidate(): void {
+		this.timeElapsedCache.clear();
+		this.measureOffsetCache.clear();
+		this.calculationsValid = false;
+		this.lastDataHash = '';
+	}
+
+	/**
+	 * Validate cache and update if needed
+	 */
+	private validateCache(): void {
+		const currentHash = this.generateDataHash();
+		if (this.lastDataHash !== currentHash) {
+			this.invalidate();
+			this.lastDataHash = currentHash;
+		}
+		this.calculationsValid = true;
+	}
+
+	generateDataHash(): string {
+		return generateDataHash({
+			bpm: this.bpm,
+			measureCount: this.measureCount,
+			measureLength: this.measureLength,
+			bpmNotes: this.bpmNotes
+		});
+	}
+
+	getTimeElapsed(measure: number, noteChipPosition: number = 0): number {
+		this.validateCache();
+
+		// Use cache for measure-level calculations (when noteChipPosition is 0)
+		if (noteChipPosition === 0) {
+			const cached = this.timeElapsedCache.get(measure);
+			if (cached !== undefined) {
+				return cached;
+			}
+		}
+
+		let elapsedTime = 0;
+		let currentBPM = this.bpm;
+
+		// Calculate time for completed measures (up to but not including the current measure)
+		for (let i = 0; i < measure; i++) {
+			const measureLength = this.measureLength[i] || 1;
+			const bpmNotes = this.notes[BPM_NOTE_ID]?.filter((note) => note.measure === i) || [];
+			if (bpmNotes.length === 0) {
+				// No BPM changes in this measure, use the current BPM for the whole measure
+				elapsedTime += (60 / currentBPM) * 4 * measureLength;
+			} else {
+				// Calculate time for each segment within the measure
+				let lastPosition = 0;
+				bpmNotes.forEach((bpmNote) => {
+					// Set the measureLength for the note
+					if (bpmNote.measureLength === 1) {
+						bpmNote.measureLength = measureLength;
+					}
+					bpmNote.notes.forEach((note: { noteID: string; position: number }) => {
+						const position = note.position;
+						elapsedTime +=
+							(60 / currentBPM) * 4 * (position - lastPosition) * measureLength;
+						currentBPM = this.bpmNotes[note.noteID];
+						lastPosition = position;
+					});
+				});
+				// Add the remaining time in the measure after the last BPM change
+				elapsedTime += (60 / currentBPM) * 4 * (1 - lastPosition) * measureLength;
+			}
+		}
+
+		// Calculate time within the current measure up to the noteChipPosition
+		if (noteChipPosition > 0) {
+			const measureLength = this.measureLength[measure] || 1;
+			const bpmNotes =
+				this.notes[BPM_NOTE_ID]?.filter((note) => note.measure === measure) || [];
+
+			if (bpmNotes.length === 0) {
+				// No BPM changes in this measure
+				elapsedTime += (60 / currentBPM) * 4 * noteChipPosition;
+			} else {
+				// Calculate time for each segment within the measure up to noteChipPosition
+				let lastPosition = 0;
+				bpmNotes.forEach((bpmNote) => {
+					// Set the measureLength for the note
+					if (bpmNote.measureLength === 1) {
+						bpmNote.measureLength = measureLength;
+					}
+					bpmNote.notes.forEach((note: { noteID: string; position: number }) => {
+						const position = note.position;
+						if (position > noteChipPosition) {
+							// Past the noteChipPosition, stop calculating
+							return;
+						}
+						const noteId = note.noteID;
+						if (noteId !== '00') {
+							elapsedTime += (60 / currentBPM) * 4 * (position - lastPosition);
+							currentBPM = this.bpmNotes[noteId];
+							lastPosition = position;
+						}
+					});
+				});
+
+				// Add time from last BPM change to noteChipPosition
+				if (noteChipPosition > lastPosition) {
+					elapsedTime += (60 / currentBPM) * 4 * (noteChipPosition - lastPosition);
+				}
+			}
+		}
+
+		// Cache the result for measure-level calculations (when noteChipPosition is 0)
+		if (noteChipPosition === 0) {
+			this.timeElapsedCache.set(measure, elapsedTime);
+		}
+
+		return elapsedTime;
+	}
+
+	getCellHeight(measure: number, cell: number): number {
+		// For given measure and cell, calculate the height of the cell based on the BPM
+		const referenceBPM = 120;
+
+		// Find all BPM notes that apply to this measure
+		const measureBpmNotes = this.notes[BPM_NOTE_ID]?.filter(
+			(note) => note.measure <= measure
+		).sort((a, b) => {
+			// Sort by measure (ascending)
+			if (a.measure !== b.measure) return a.measure - b.measure;
+			// For notes in the same measure, we'll handle them later
+			return 0;
+		});
+
+		if (!measureBpmNotes || measureBpmNotes.length === 0) {
+			// No BPM changes, use the default BPM
+			return (this.cellHeight / this.bpm) * referenceBPM;
+		}
+
+		// Find the most recent BPM change before or at our current cell position
+		const lastBpmNote = measureBpmNotes[measureBpmNotes.length - 1];
+		let currentBPM = this.bpm; // Default to the initial BPM
+
+		if (lastBpmNote.measure < measure) {
+			// BPM change in a previous measure, need to find the last BPM in that measure
+			const bpmNotes = lastBpmNote.notes;
+
+			// Find the last BPM change in the notes array
+			for (const note of bpmNotes) {
+				if (note.noteID !== '00') {
+					currentBPM = this.bpmNotes[note.noteID];
+				}
+			}
+		} else if (lastBpmNote.measure === measure) {
+			// BPM change in the current measure
+			const bpmNotes = lastBpmNote.notes;
+
+			// Find the last BPM change before or at our cell position
+			for (const note of bpmNotes) {
+				const cellPosition = Math.floor(note.position * this.cellsPerMeasure);
+				if (cellPosition > cell) {
+					break; // This BPM change is after our current cell
+				}
+
+				if (note.noteID !== '00') {
+					currentBPM = this.bpmNotes[note.noteID];
+				}
+			}
+		}
+
+		// Calculate the adjusted cell height based on the BPM
+		// Slower BPM = taller cells, faster BPM = shorter cells
+		return (this.cellHeight / currentBPM) * referenceBPM;
+	}
+
+	/**
+	 * Wraps a Phaser-dependent measure-offset computation with caching.
+	 * `compute` is expected to be `super.getTotalMesaureOffest(measure)`.
+	 */
+	getCachedMeasureOffset(measure: number, compute: () => number): number {
+		this.validateCache();
+
+		const cached = this.measureOffsetCache.get(measure);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		const result = compute();
+		this.measureOffsetCache.set(measure, result);
+		return result;
+	}
+}

--- a/packages/common/src/lib/game/scenes/previewCalculations.ts
+++ b/packages/common/src/lib/game/scenes/previewCalculations.ts
@@ -55,7 +55,6 @@ export class PreviewCalculations {
 	private timeElapsedCache = new Map<number, number>();
 	private measureOffsetCache = new Map<number, number>();
 	private lastDataHash = '';
-	private calculationsValid = false;
 
 	constructor(config: PreviewCalculationsConfig) {
 		this.bpm = config.bpm;
@@ -86,7 +85,6 @@ export class PreviewCalculations {
 	invalidate(): void {
 		this.timeElapsedCache.clear();
 		this.measureOffsetCache.clear();
-		this.calculationsValid = false;
 		this.lastDataHash = '';
 	}
 
@@ -99,7 +97,6 @@ export class PreviewCalculations {
 			this.invalidate();
 			this.lastDataHash = currentHash;
 		}
-		this.calculationsValid = true;
 	}
 
 	generateDataHash(): string {

--- a/packages/dtx-desktop/src-tauri/src/api.rs
+++ b/packages/dtx-desktop/src-tauri/src/api.rs
@@ -1,15 +1,9 @@
-use crate::api_contracts::{
-    CreateSimfileRecordInput, CreateSimfileRecordResult, FetchCloudSongResult,
-    FetchUserSimfilesResult, NativeSimfile, NativeSimfileDtxFile, UpdateSimfileRecordInput,
-    UpdateSimfileRecordResult,
-};
 use crate::auth::AuthState;
 use crate::error::{DesktopError, Result};
 use crate::google_drive::{DriveMetadataError, ExpectedPreviousDriveFile, OwnerDriveSimfile};
 use crate::workspace::WorkspaceRootState;
 use reqwest::multipart::{Form, Part};
 use serde_json::{json, Value};
-use std::path::Path;
 use std::time::Duration;
 use tauri::{AppHandle, Manager, Runtime, State};
 use tokio::fs;
@@ -17,10 +11,6 @@ use tokio::fs;
 const API_REQUEST_TIMEOUT_MS: u64 = 30_000;
 
 const SIMFILE_FULL_FRAGMENT: &str = include_str!("../graphql/simfiles/simfile-full.graphql");
-
-const LIST_SIMFILES_QUERY: &str = include_str!("../graphql/simfiles/list-simfiles.graphql");
-
-const GET_SIMFILE_QUERY: &str = include_str!("../graphql/simfiles/get-simfile.graphql");
 
 const GET_SIMFILE_WITH_FILES_QUERY: &str = r#"
 query GetSimfileWithFiles($id: ID!) {
@@ -35,8 +25,6 @@ query GetSimfileWithFiles($id: ID!) {
 }
 "#;
 
-const NEXT_DISPLAY_ID_QUERY: &str = include_str!("../graphql/simfiles/next-display-id.graphql");
-
 const SIMFILE_SEARCH_QUERY: &str = r#"
 query SimfileSearch($query: String!, $excludeIds: [ID!], $limit: Int) {
   simfileSearch(query: $query, excludeIds: $excludeIds, limit: $limit) {
@@ -48,10 +36,6 @@ query SimfileSearch($query: String!, $excludeIds: [ID!], $limit: Int) {
   }
 }
 "#;
-
-const CREATE_SIMFILE_MUTATION: &str = include_str!("../graphql/simfiles/create-simfile.graphql");
-
-const UPDATE_SIMFILE_MUTATION: &str = include_str!("../graphql/simfiles/update-simfile.graphql");
 
 const OWNER_DRIVE_SIMFILE_QUERY: &str = r#"
 query OwnerDriveSimfile($id: ID!) {
@@ -115,7 +99,7 @@ pub enum ApiResultValue {
 }
 
 impl ApiResultValue {
-    fn success_data(self) -> std::result::Result<Value, (String, Option<String>)> {
+    pub(crate) fn success_data(self) -> std::result::Result<Value, (String, Option<String>)> {
         match self {
             ApiResultValue::Success { data } => Ok(data),
             ApiResultValue::Failure { error, code } => Err((error, code)),
@@ -133,7 +117,7 @@ pub fn api_base_url_from_values(api_url: Option<&str>) -> Result<String> {
     Ok(url.trim().trim_end_matches('/').to_string())
 }
 
-fn api_base_url_from_env() -> Result<String> {
+pub(crate) fn api_base_url_from_env() -> Result<String> {
     api_base_url_from_values(config_env!("VITE_DTX_API_URL").as_deref())
 }
 
@@ -146,7 +130,7 @@ fn bucket_base_url_from_env() -> Result<String> {
     Ok(url.trim().trim_end_matches('/').to_string())
 }
 
-async fn access_token_from_auth_state<R: Runtime>(
+pub(crate) async fn access_token_from_auth_state<R: Runtime>(
     state: &AuthState,
     app: Option<&AppHandle<R>>,
 ) -> Result<String> {
@@ -158,7 +142,7 @@ async fn access_token_from_auth_state<R: Runtime>(
     crate::auth::ensure_valid_access_token(state, app).await
 }
 
-fn graphql_document(operation: &str) -> String {
+pub(crate) fn graphql_document(operation: &str) -> String {
     format!("{SIMFILE_FULL_FRAGMENT}\n{operation}")
 }
 
@@ -286,102 +270,6 @@ async fn run_graphql_value_with_client(
     ApiResultValue::Success {
         data: body.get("data").cloned().unwrap_or(Value::Null),
     }
-}
-
-fn number_id(value: &Value) -> Result<i64> {
-    if let Some(id) = value.as_i64() {
-        return Ok(id);
-    }
-    if let Some(id) = value.as_u64().and_then(|id| i64::try_from(id).ok()) {
-        return Ok(id);
-    }
-    if let Some(id) = value.as_str().and_then(|id| id.parse::<i64>().ok()) {
-        return Ok(id);
-    }
-    Err(DesktopError::Message(format!(
-        "Invalid simfile id: {value}"
-    )))
-}
-
-fn field_error(value: &Value, field: &str) -> DesktopError {
-    DesktopError::Message(format!(
-        "Invalid simfile field {field}: {}",
-        value.get(field).unwrap_or(&Value::Null)
-    ))
-}
-
-fn required_string(value: &Value, field: &str) -> Result<String> {
-    value
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-        .ok_or_else(|| field_error(value, field))
-}
-
-fn nullable_string(value: &Value, field: &str) -> Result<Option<String>> {
-    match value.get(field) {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::String(value)) => Ok(Some(value.clone())),
-        Some(_) => Err(field_error(value, field)),
-    }
-}
-
-fn nullable_i64(value: &Value, field: &str) -> Result<Option<i64>> {
-    match value.get(field) {
-        None | Some(Value::Null) => Ok(None),
-        Some(field_value) => field_value
-            .as_i64()
-            .map(Some)
-            .ok_or_else(|| field_error(value, field)),
-    }
-}
-
-fn required_f64(value: &Value, field: &str) -> Result<f64> {
-    value
-        .get(field)
-        .and_then(Value::as_f64)
-        .ok_or_else(|| field_error(value, field))
-}
-
-fn required_bool(value: &Value, field: &str) -> Result<bool> {
-    value
-        .get(field)
-        .and_then(Value::as_bool)
-        .ok_or_else(|| field_error(value, field))
-}
-
-pub fn native_simfile_from_graphql(simfile: &Value) -> Result<NativeSimfile> {
-    let dtx_files = simfile
-        .get("dtxFiles")
-        .and_then(Value::as_array)
-        .ok_or_else(|| field_error(simfile, "dtxFiles"))?
-        .iter()
-        .map(|file| {
-            Ok(NativeSimfileDtxFile {
-                id: number_id(&file["id"])?,
-                label: required_string(file, "label")?,
-                level: required_f64(file, "level")?,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(NativeSimfile {
-        id: number_id(&simfile["id"])?,
-        display_id: nullable_i64(simfile, "displayId")?,
-        title: required_string(simfile, "title")?,
-        artist: required_string(simfile, "artist")?,
-        bpm: required_f64(simfile, "bpm")?,
-        user_id: nullable_string(simfile, "userId")?,
-        google_drive_file_id: nullable_string(simfile, "googleDriveFileId")?,
-        is_published: required_bool(simfile, "isPublished")?,
-        download_url: nullable_string(simfile, "downloadUrl")?,
-        preview_url: nullable_string(simfile, "previewUrl")?,
-        video_preview_url: nullable_string(simfile, "videoPreviewUrl")?,
-        publish_date: required_string(simfile, "publishDate")?,
-        created_at: required_string(simfile, "createdAt")?,
-        updated_at: required_string(simfile, "updatedAt")?,
-        dtx_files,
-    })
 }
 
 fn owner_drive_simfile_from_graphql(
@@ -639,7 +527,7 @@ pub(crate) async fn graphql_result_with_url(
     Ok(run_graphql_value(base_url, token, query, variables).await)
 }
 
-async fn upload_bytes_to_api(
+pub(crate) async fn upload_bytes_to_api(
     base_url: &str,
     token: &str,
     bytes: Vec<u8>,
@@ -777,182 +665,6 @@ pub async fn upload_file_to_api(
     upload_bytes_to_api(base_url, token, bytes, &upload_name, simfile_id, None).await
 }
 
-async fn upload_preview_if_present(
-    base_url: &str,
-    token: &str,
-    song_path: &str,
-    workspace_root: &str,
-    simfile_id: &str,
-    file_name: &str,
-    content_type: &str,
-) -> Option<String> {
-    let bytes = match read_preview_within_workspace(song_path, workspace_root, file_name).await {
-        Ok(Some(bytes)) => bytes,
-        Ok(None) => return None,
-        Err(error) => return Some(error),
-    };
-    let result = upload_bytes_to_api(
-        base_url,
-        token,
-        bytes,
-        file_name,
-        simfile_id,
-        Some(content_type),
-    )
-    .await;
-    if result.get("success").and_then(Value::as_bool) == Some(true) {
-        None
-    } else {
-        Some(
-            result
-                .get("error")
-                .and_then(Value::as_str)
-                .unwrap_or("Unknown error")
-                .to_string(),
-        )
-    }
-}
-
-/// Reads a preview file from `song_path/file_name` only after confirming
-/// `song_path` is contained within `workspace_root`. Returns:
-/// - `Ok(Some(bytes))` when the file exists and is within the workspace,
-/// - `Ok(None)` when the file is absent (no preview to upload, not an error),
-/// - `Err(message)` when containment fails or the workspace root is missing.
-async fn read_preview_within_workspace(
-    song_path: &str,
-    workspace_root: &str,
-    file_name: &str,
-) -> std::result::Result<Option<Vec<u8>>, String> {
-    if workspace_root.trim().is_empty() {
-        return Err("A workspace root is required to upload previews".to_string());
-    }
-    // Verify root exists with an actionable message before routing the
-    // containment check through canonicalize_within_workspace (which would
-    // surface a generic I/O error otherwise).
-    if fs::canonicalize(workspace_root).await.is_err() {
-        return Err(format!("Workspace root not found: {workspace_root}"));
-    }
-    // Route the song-folder containment check through the canonical primitive
-    // so the symlink-safe invariant lives in one tested place.
-    let canonical_song =
-        match crate::filesystem::canonicalize_within_workspace(song_path, Some(workspace_root))
-            .await
-        {
-            Ok(path) => path,
-            Err(DesktopError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Err(format!("Song folder not found: {song_path}"));
-            }
-            Err(error) => return Err(error.to_string()),
-        };
-    // Canonicalize the preview file through the same primitive so a symlinked
-    // preview.jpg/mp3 cannot exfiltrate bytes from outside the workspace. A
-    // missing preview is not an error — map NotFound to Ok(None).
-    let preview_path = canonical_song.join(file_name);
-    let preview_path_str = preview_path
-        .to_str()
-        .ok_or_else(|| "Preview path is not valid UTF-8".to_string())?;
-    let canonical_preview = match crate::filesystem::canonicalize_within_workspace(
-        preview_path_str,
-        Some(workspace_root),
-    )
-    .await
-    {
-        Ok(path) => path,
-        Err(DesktopError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(None);
-        }
-        Err(error) => return Err(error.to_string()),
-    };
-    match fs::read(&canonical_preview).await {
-        Ok(bytes) => Ok(Some(bytes)),
-        Err(_) => Ok(None),
-    }
-}
-
-pub(crate) async fn fetch_user_simfiles_impl(
-    base_url: &str,
-    token: &str,
-) -> Result<FetchUserSimfilesResult> {
-    let mut all_data: Vec<NativeSimfile> = Vec::new();
-    let page_size = 100;
-    let mut page = 1;
-
-    loop {
-        let result = graphql_result_with_url(
-            base_url,
-            token,
-            &graphql_document(LIST_SIMFILES_QUERY),
-            json!({ "scope": "MINE", "page": page, "pageSize": page_size }),
-        )
-        .await;
-
-        let data = match result {
-            Ok(ApiResultValue::Success { data }) => data,
-            Ok(ApiResultValue::Failure { error, .. }) => {
-                return Ok(FetchUserSimfilesResult {
-                    success: false,
-                    data: all_data,
-                    from_cache: false,
-                    error: Some(error),
-                });
-            }
-            Err(error) => {
-                return Ok(FetchUserSimfilesResult {
-                    success: false,
-                    data: all_data,
-                    from_cache: false,
-                    error: Some(error.to_string()),
-                });
-            }
-        };
-
-        let simfiles = &data["simfiles"];
-        let page_data = simfiles
-            .get("data")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        for simfile in page_data {
-            all_data.push(native_simfile_from_graphql(&simfile)?);
-        }
-
-        let count = simfiles.get("count").and_then(Value::as_i64).unwrap_or(0);
-        let total_pages = ((count + page_size - 1) / page_size).max(1);
-        if page >= total_pages {
-            break;
-        }
-        page += 1;
-    }
-
-    Ok(FetchUserSimfilesResult {
-        success: true,
-        data: all_data,
-        from_cache: false,
-        error: None,
-    })
-}
-
-#[tauri::command]
-pub async fn fetch_user_simfiles(app: AppHandle) -> Result<FetchUserSimfilesResult> {
-    let base_url = api_base_url_from_env()?;
-    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
-    fetch_user_simfiles_impl(&base_url, &token).await
-}
-
-pub(crate) async fn get_next_display_id_impl(base_url: &str, token: &str) -> Result<i64> {
-    let data = graphql_data_with_url(base_url, token, NEXT_DISPLAY_ID_QUERY, json!({})).await?;
-    data.get("nextDisplayId")
-        .and_then(Value::as_i64)
-        .ok_or_else(|| DesktopError::Message("Invalid nextDisplayId in API response".to_string()))
-}
-
-#[tauri::command]
-pub async fn get_next_display_id(app: AppHandle) -> Result<i64> {
-    let base_url = api_base_url_from_env()?;
-    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
-    get_next_display_id_impl(&base_url, &token).await
-}
-
 pub(crate) async fn search_cloud_songs_impl(
     base_url: &str,
     token: &str,
@@ -1013,53 +725,6 @@ pub async fn search_cloud_songs(
     let base_url = api_base_url_from_env()?;
     let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
     search_cloud_songs_impl(&base_url, &token, query, limit, exclude_linked_song_ids).await
-}
-
-pub(crate) async fn fetch_cloud_song_impl(
-    base_url: &str,
-    token: &str,
-    cloud_song_id: String,
-) -> Result<FetchCloudSongResult> {
-    let result = graphql_result_with_url(
-        base_url,
-        token,
-        &graphql_document(GET_SIMFILE_QUERY),
-        json!({ "id": cloud_song_id }),
-    )
-    .await?;
-    let data = match result.success_data() {
-        Ok(data) => data,
-        Err((error, _)) => {
-            return Ok(FetchCloudSongResult {
-                success: false,
-                cloud_song_data: None,
-                error: Some(error),
-            });
-        }
-    };
-    let Some(simfile) = data.get("simfile").filter(|simfile| !simfile.is_null()) else {
-        return Ok(FetchCloudSongResult {
-            success: false,
-            cloud_song_data: None,
-            error: Some("Simfile not found".to_string()),
-        });
-    };
-
-    Ok(FetchCloudSongResult {
-        success: true,
-        cloud_song_data: Some(native_simfile_from_graphql(simfile)?),
-        error: None,
-    })
-}
-
-#[tauri::command]
-pub async fn fetch_cloud_song(
-    app: AppHandle,
-    cloud_song_id: String,
-) -> Result<FetchCloudSongResult> {
-    let base_url = api_base_url_from_env()?;
-    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
-    fetch_cloud_song_impl(&base_url, &token, cloud_song_id).await
 }
 
 pub(crate) async fn fetch_cloud_song_charts_impl(
@@ -1221,151 +886,6 @@ pub async fn upload_scores(app: AppHandle, payload: Value) -> Result<Value> {
     let base_url = api_base_url_from_env()?;
     let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
     upload_scores_impl(&base_url, &token, payload).await
-}
-
-pub(crate) async fn update_simfile_record_impl(
-    base_url: &str,
-    token: &str,
-    simfile_id: String,
-    update_data: UpdateSimfileRecordInput,
-) -> Result<UpdateSimfileRecordResult> {
-    let input = serde_json::to_value(&update_data)?;
-    let result = graphql_result_with_url(
-        base_url,
-        token,
-        &graphql_document(UPDATE_SIMFILE_MUTATION),
-        json!({
-            "id": simfile_id,
-            "input": input,
-        }),
-    )
-    .await?;
-    let data = match result.success_data() {
-        Ok(data) => data,
-        Err((error, _)) => {
-            return Ok(UpdateSimfileRecordResult {
-                success: false,
-                data: None,
-                error: Some(error),
-            });
-        }
-    };
-
-    Ok(UpdateSimfileRecordResult {
-        success: true,
-        data: Some(native_simfile_from_graphql(&data["updateSimfile"])?),
-        error: None,
-    })
-}
-
-#[tauri::command]
-pub async fn update_simfile_record(
-    app: AppHandle,
-    simfile_id: String,
-    update_data: UpdateSimfileRecordInput,
-) -> Result<UpdateSimfileRecordResult> {
-    let base_url = api_base_url_from_env()?;
-    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
-    update_simfile_record_impl(&base_url, &token, simfile_id, update_data).await
-}
-
-pub(crate) async fn create_simfile_record_impl(
-    base_url: &str,
-    token: &str,
-    simfile_data: CreateSimfileRecordInput,
-    workspace_root: &Path,
-) -> Result<CreateSimfileRecordResult> {
-    let mut input = serde_json::to_value(&simfile_data)?;
-    if let Value::Object(input) = &mut input {
-        input.remove("songPath");
-        if let Some(levels) = input.remove("levels") {
-            input.insert("dtxFiles".to_string(), levels);
-        }
-    }
-    let result = run_graphql_value(
-        base_url,
-        token,
-        &graphql_document(CREATE_SIMFILE_MUTATION),
-        json!({ "input": input }),
-    )
-    .await;
-    let data = match result.success_data() {
-        Ok(data) => data,
-        Err((error, _)) => {
-            return Ok(CreateSimfileRecordResult {
-                success: false,
-                simfile_id: None,
-                data: None,
-                error: Some(error),
-                warnings: None,
-            });
-        }
-    };
-
-    let simfile = &data["createSimfile"];
-    let simfile_id = number_id(&simfile["id"])?.to_string();
-    let mut warnings = Vec::new();
-
-    let workspace_root = workspace_root.to_string_lossy();
-    if !simfile_data.song_path.is_empty() {
-        if let Some(error) = upload_preview_if_present(
-            base_url,
-            token,
-            &simfile_data.song_path,
-            &workspace_root,
-            &simfile_id,
-            "preview.jpg",
-            "image/jpeg",
-        )
-        .await
-        {
-            warnings.push(format!("Preview image: {error}"));
-        }
-        if let Some(error) = upload_preview_if_present(
-            base_url,
-            token,
-            &simfile_data.song_path,
-            &workspace_root,
-            &simfile_id,
-            "preview.mp3",
-            "audio/mpeg",
-        )
-        .await
-        {
-            warnings.push(format!("Sound preview: {error}"));
-        }
-    }
-
-    Ok(CreateSimfileRecordResult {
-        success: true,
-        simfile_id: Some(simfile_id),
-        data: Some(native_simfile_from_graphql(simfile)?),
-        error: None,
-        warnings: (!warnings.is_empty()).then_some(warnings),
-    })
-}
-
-#[tauri::command]
-pub async fn create_simfile_record(
-    app: AppHandle,
-    simfile_data: CreateSimfileRecordInput,
-    state: State<'_, WorkspaceRootState>,
-) -> Result<CreateSimfileRecordResult> {
-    let workspace_root = state.current()?;
-    let base_url = api_base_url_from_env()?;
-    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
-    create_simfile_record_impl(&base_url, &token, simfile_data, &workspace_root).await
-}
-
-#[cfg(test)]
-pub(crate) async fn create_simfile_record_with_workspace_state(
-    base_url: &str,
-    token: &str,
-    simfile_data: CreateSimfileRecordInput,
-    state: &WorkspaceRootState,
-) -> Result<CreateSimfileRecordResult> {
-    let workspace_root = state.current()?;
-    create_simfile_record_impl(base_url, token, simfile_data, &workspace_root).await
 }
 
 pub(crate) async fn load_asset_files_impl(

--- a/packages/dtx-desktop/src-tauri/src/lib.rs
+++ b/packages/dtx-desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod macros;
 
 mod api;
 mod api_contracts;
+mod simfile;
 // Auth tests deliberately hold a process-global environment lock across async
 // requests so no parallel test can observe partially updated configuration.
 #[cfg_attr(test, allow(clippy::await_holding_lock))]
@@ -180,12 +181,12 @@ pub fn run() {
             auth::get_current_session,
             auth::logout_session,
             auth::drain_pending_auth_events,
-            api::fetch_user_simfiles,
-            api::get_next_display_id,
+            simfile::fetch_user_simfiles,
+            simfile::get_next_display_id,
             api::search_cloud_songs,
-            api::fetch_cloud_song,
-            api::update_simfile_record,
-            api::create_simfile_record,
+            simfile::fetch_cloud_song,
+            simfile::update_simfile_record,
+            simfile::create_simfile_record,
             api::load_asset_files,
             api::get_preview_url,
             api::get_sound_preview_url,

--- a/packages/dtx-desktop/src-tauri/src/simfile.rs
+++ b/packages/dtx-desktop/src-tauri/src/simfile.rs
@@ -1,0 +1,494 @@
+use crate::api::{
+    access_token_from_auth_state, api_base_url_from_env, graphql_data_with_url, graphql_document,
+    graphql_result_with_url, run_graphql_value, upload_bytes_to_api, ApiResultValue,
+};
+use crate::api_contracts::{
+    CreateSimfileRecordInput, CreateSimfileRecordResult, FetchCloudSongResult,
+    FetchUserSimfilesResult, NativeSimfile, NativeSimfileDtxFile, UpdateSimfileRecordInput,
+    UpdateSimfileRecordResult,
+};
+use crate::auth::AuthState;
+use crate::error::{DesktopError, Result};
+use crate::workspace::WorkspaceRootState;
+use serde_json::{json, Value};
+use std::path::Path;
+use tauri::{AppHandle, Manager, State};
+use tokio::fs;
+
+const LIST_SIMFILES_QUERY: &str = include_str!("../graphql/simfiles/list-simfiles.graphql");
+
+const GET_SIMFILE_QUERY: &str = include_str!("../graphql/simfiles/get-simfile.graphql");
+
+const NEXT_DISPLAY_ID_QUERY: &str = include_str!("../graphql/simfiles/next-display-id.graphql");
+
+const CREATE_SIMFILE_MUTATION: &str = include_str!("../graphql/simfiles/create-simfile.graphql");
+
+const UPDATE_SIMFILE_MUTATION: &str = include_str!("../graphql/simfiles/update-simfile.graphql");
+
+fn number_id(value: &Value) -> Result<i64> {
+    if let Some(id) = value.as_i64() {
+        return Ok(id);
+    }
+    if let Some(id) = value.as_u64().and_then(|id| i64::try_from(id).ok()) {
+        return Ok(id);
+    }
+    if let Some(id) = value.as_str().and_then(|id| id.parse::<i64>().ok()) {
+        return Ok(id);
+    }
+    Err(DesktopError::Message(format!(
+        "Invalid simfile id: {value}"
+    )))
+}
+
+fn field_error(value: &Value, field: &str) -> DesktopError {
+    DesktopError::Message(format!(
+        "Invalid simfile field {field}: {}",
+        value.get(field).unwrap_or(&Value::Null)
+    ))
+}
+
+fn required_string(value: &Value, field: &str) -> Result<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| field_error(value, field))
+}
+
+fn nullable_string(value: &Value, field: &str) -> Result<Option<String>> {
+    match value.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(field_error(value, field)),
+    }
+}
+
+fn nullable_i64(value: &Value, field: &str) -> Result<Option<i64>> {
+    match value.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(field_value) => field_value
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| field_error(value, field)),
+    }
+}
+
+fn required_f64(value: &Value, field: &str) -> Result<f64> {
+    value
+        .get(field)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| field_error(value, field))
+}
+
+fn required_bool(value: &Value, field: &str) -> Result<bool> {
+    value
+        .get(field)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| field_error(value, field))
+}
+
+pub fn native_simfile_from_graphql(simfile: &Value) -> Result<NativeSimfile> {
+    let dtx_files = simfile
+        .get("dtxFiles")
+        .and_then(Value::as_array)
+        .ok_or_else(|| field_error(simfile, "dtxFiles"))?
+        .iter()
+        .map(|file| {
+            Ok(NativeSimfileDtxFile {
+                id: number_id(&file["id"])?,
+                label: required_string(file, "label")?,
+                level: required_f64(file, "level")?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(NativeSimfile {
+        id: number_id(&simfile["id"])?,
+        display_id: nullable_i64(simfile, "displayId")?,
+        title: required_string(simfile, "title")?,
+        artist: required_string(simfile, "artist")?,
+        bpm: required_f64(simfile, "bpm")?,
+        user_id: nullable_string(simfile, "userId")?,
+        google_drive_file_id: nullable_string(simfile, "googleDriveFileId")?,
+        is_published: required_bool(simfile, "isPublished")?,
+        download_url: nullable_string(simfile, "downloadUrl")?,
+        preview_url: nullable_string(simfile, "previewUrl")?,
+        video_preview_url: nullable_string(simfile, "videoPreviewUrl")?,
+        publish_date: required_string(simfile, "publishDate")?,
+        created_at: required_string(simfile, "createdAt")?,
+        updated_at: required_string(simfile, "updatedAt")?,
+        dtx_files,
+    })
+}
+
+async fn upload_preview_if_present(
+    base_url: &str,
+    token: &str,
+    song_path: &str,
+    workspace_root: &str,
+    simfile_id: &str,
+    file_name: &str,
+    content_type: &str,
+) -> Option<String> {
+    let bytes = match read_preview_within_workspace(song_path, workspace_root, file_name).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return None,
+        Err(error) => return Some(error),
+    };
+    let result = upload_bytes_to_api(
+        base_url,
+        token,
+        bytes,
+        file_name,
+        simfile_id,
+        Some(content_type),
+    )
+    .await;
+    if result.get("success").and_then(Value::as_bool) == Some(true) {
+        None
+    } else {
+        Some(
+            result
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("Unknown error")
+                .to_string(),
+        )
+    }
+}
+
+/// Reads a preview file from `song_path/file_name` only after confirming
+/// `song_path` is contained within `workspace_root`. Returns:
+/// - `Ok(Some(bytes))` when the file exists and is within the workspace,
+/// - `Ok(None)` when the file is absent (no preview to upload, not an error),
+/// - `Err(message)` when containment fails or the workspace root is missing.
+async fn read_preview_within_workspace(
+    song_path: &str,
+    workspace_root: &str,
+    file_name: &str,
+) -> std::result::Result<Option<Vec<u8>>, String> {
+    if workspace_root.trim().is_empty() {
+        return Err("A workspace root is required to upload previews".to_string());
+    }
+    // Verify root exists with an actionable message before routing the
+    // containment check through canonicalize_within_workspace (which would
+    // surface a generic I/O error otherwise).
+    if fs::canonicalize(workspace_root).await.is_err() {
+        return Err(format!("Workspace root not found: {workspace_root}"));
+    }
+    // Route the song-folder containment check through the canonical primitive
+    // so the symlink-safe invariant lives in one tested place.
+    let canonical_song =
+        match crate::filesystem::canonicalize_within_workspace(song_path, Some(workspace_root))
+            .await
+        {
+            Ok(path) => path,
+            Err(DesktopError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(format!("Song folder not found: {song_path}"));
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+    // Canonicalize the preview file through the same primitive so a symlinked
+    // preview.jpg/mp3 cannot exfiltrate bytes from outside the workspace. A
+    // missing preview is not an error — map NotFound to Ok(None).
+    let preview_path = canonical_song.join(file_name);
+    let preview_path_str = preview_path
+        .to_str()
+        .ok_or_else(|| "Preview path is not valid UTF-8".to_string())?;
+    let canonical_preview = match crate::filesystem::canonicalize_within_workspace(
+        preview_path_str,
+        Some(workspace_root),
+    )
+    .await
+    {
+        Ok(path) => path,
+        Err(DesktopError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(error) => return Err(error.to_string()),
+    };
+    match fs::read(&canonical_preview).await {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(_) => Ok(None),
+    }
+}
+
+pub(crate) async fn fetch_user_simfiles_impl(
+    base_url: &str,
+    token: &str,
+) -> Result<FetchUserSimfilesResult> {
+    let mut all_data: Vec<NativeSimfile> = Vec::new();
+    let page_size = 100;
+    let mut page = 1;
+
+    loop {
+        let result = graphql_result_with_url(
+            base_url,
+            token,
+            &graphql_document(LIST_SIMFILES_QUERY),
+            json!({ "scope": "MINE", "page": page, "pageSize": page_size }),
+        )
+        .await;
+
+        let data = match result {
+            Ok(ApiResultValue::Success { data }) => data,
+            Ok(ApiResultValue::Failure { error, .. }) => {
+                return Ok(FetchUserSimfilesResult {
+                    success: false,
+                    data: all_data,
+                    from_cache: false,
+                    error: Some(error),
+                });
+            }
+            Err(error) => {
+                return Ok(FetchUserSimfilesResult {
+                    success: false,
+                    data: all_data,
+                    from_cache: false,
+                    error: Some(error.to_string()),
+                });
+            }
+        };
+
+        let simfiles = &data["simfiles"];
+        let page_data = simfiles
+            .get("data")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for simfile in page_data {
+            all_data.push(native_simfile_from_graphql(&simfile)?);
+        }
+
+        let count = simfiles.get("count").and_then(Value::as_i64).unwrap_or(0);
+        let total_pages = ((count + page_size - 1) / page_size).max(1);
+        if page >= total_pages {
+            break;
+        }
+        page += 1;
+    }
+
+    Ok(FetchUserSimfilesResult {
+        success: true,
+        data: all_data,
+        from_cache: false,
+        error: None,
+    })
+}
+
+#[tauri::command]
+pub async fn fetch_user_simfiles(app: AppHandle) -> Result<FetchUserSimfilesResult> {
+    let base_url = api_base_url_from_env()?;
+    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
+    fetch_user_simfiles_impl(&base_url, &token).await
+}
+
+pub(crate) async fn get_next_display_id_impl(base_url: &str, token: &str) -> Result<i64> {
+    let data = graphql_data_with_url(base_url, token, NEXT_DISPLAY_ID_QUERY, json!({})).await?;
+    data.get("nextDisplayId")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| DesktopError::Message("Invalid nextDisplayId in API response".to_string()))
+}
+
+#[tauri::command]
+pub async fn get_next_display_id(app: AppHandle) -> Result<i64> {
+    let base_url = api_base_url_from_env()?;
+    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
+    get_next_display_id_impl(&base_url, &token).await
+}
+
+pub(crate) async fn fetch_cloud_song_impl(
+    base_url: &str,
+    token: &str,
+    cloud_song_id: String,
+) -> Result<FetchCloudSongResult> {
+    let result = graphql_result_with_url(
+        base_url,
+        token,
+        &graphql_document(GET_SIMFILE_QUERY),
+        json!({ "id": cloud_song_id }),
+    )
+    .await?;
+    let data = match result.success_data() {
+        Ok(data) => data,
+        Err((error, _)) => {
+            return Ok(FetchCloudSongResult {
+                success: false,
+                cloud_song_data: None,
+                error: Some(error),
+            });
+        }
+    };
+    let Some(simfile) = data.get("simfile").filter(|simfile| !simfile.is_null()) else {
+        return Ok(FetchCloudSongResult {
+            success: false,
+            cloud_song_data: None,
+            error: Some("Simfile not found".to_string()),
+        });
+    };
+
+    Ok(FetchCloudSongResult {
+        success: true,
+        cloud_song_data: Some(native_simfile_from_graphql(simfile)?),
+        error: None,
+    })
+}
+
+#[tauri::command]
+pub async fn fetch_cloud_song(
+    app: AppHandle,
+    cloud_song_id: String,
+) -> Result<FetchCloudSongResult> {
+    let base_url = api_base_url_from_env()?;
+    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
+    fetch_cloud_song_impl(&base_url, &token, cloud_song_id).await
+}
+
+pub(crate) async fn update_simfile_record_impl(
+    base_url: &str,
+    token: &str,
+    simfile_id: String,
+    update_data: UpdateSimfileRecordInput,
+) -> Result<UpdateSimfileRecordResult> {
+    let input = serde_json::to_value(&update_data)?;
+    let result = graphql_result_with_url(
+        base_url,
+        token,
+        &graphql_document(UPDATE_SIMFILE_MUTATION),
+        json!({
+            "id": simfile_id,
+            "input": input,
+        }),
+    )
+    .await?;
+    let data = match result.success_data() {
+        Ok(data) => data,
+        Err((error, _)) => {
+            return Ok(UpdateSimfileRecordResult {
+                success: false,
+                data: None,
+                error: Some(error),
+            });
+        }
+    };
+
+    Ok(UpdateSimfileRecordResult {
+        success: true,
+        data: Some(native_simfile_from_graphql(&data["updateSimfile"])?),
+        error: None,
+    })
+}
+
+#[tauri::command]
+pub async fn update_simfile_record(
+    app: AppHandle,
+    simfile_id: String,
+    update_data: UpdateSimfileRecordInput,
+) -> Result<UpdateSimfileRecordResult> {
+    let base_url = api_base_url_from_env()?;
+    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
+    update_simfile_record_impl(&base_url, &token, simfile_id, update_data).await
+}
+
+pub(crate) async fn create_simfile_record_impl(
+    base_url: &str,
+    token: &str,
+    simfile_data: CreateSimfileRecordInput,
+    workspace_root: &Path,
+) -> Result<CreateSimfileRecordResult> {
+    let mut input = serde_json::to_value(&simfile_data)?;
+    if let Value::Object(input) = &mut input {
+        input.remove("songPath");
+        if let Some(levels) = input.remove("levels") {
+            input.insert("dtxFiles".to_string(), levels);
+        }
+    }
+    let result = run_graphql_value(
+        base_url,
+        token,
+        &graphql_document(CREATE_SIMFILE_MUTATION),
+        json!({ "input": input }),
+    )
+    .await;
+    let data = match result.success_data() {
+        Ok(data) => data,
+        Err((error, _)) => {
+            return Ok(CreateSimfileRecordResult {
+                success: false,
+                simfile_id: None,
+                data: None,
+                error: Some(error),
+                warnings: None,
+            });
+        }
+    };
+
+    let simfile = &data["createSimfile"];
+    let simfile_id = number_id(&simfile["id"])?.to_string();
+    let mut warnings = Vec::new();
+
+    let workspace_root = workspace_root.to_string_lossy();
+    if !simfile_data.song_path.is_empty() {
+        if let Some(error) = upload_preview_if_present(
+            base_url,
+            token,
+            &simfile_data.song_path,
+            &workspace_root,
+            &simfile_id,
+            "preview.jpg",
+            "image/jpeg",
+        )
+        .await
+        {
+            warnings.push(format!("Preview image: {error}"));
+        }
+        if let Some(error) = upload_preview_if_present(
+            base_url,
+            token,
+            &simfile_data.song_path,
+            &workspace_root,
+            &simfile_id,
+            "preview.mp3",
+            "audio/mpeg",
+        )
+        .await
+        {
+            warnings.push(format!("Sound preview: {error}"));
+        }
+    }
+
+    Ok(CreateSimfileRecordResult {
+        success: true,
+        simfile_id: Some(simfile_id),
+        data: Some(native_simfile_from_graphql(simfile)?),
+        error: None,
+        warnings: (!warnings.is_empty()).then_some(warnings),
+    })
+}
+
+#[tauri::command]
+pub async fn create_simfile_record(
+    app: AppHandle,
+    simfile_data: CreateSimfileRecordInput,
+    state: State<'_, WorkspaceRootState>,
+) -> Result<CreateSimfileRecordResult> {
+    let workspace_root = state.current()?;
+    let base_url = api_base_url_from_env()?;
+    let token = access_token_from_auth_state(&app.state::<AuthState>(), Some(&app)).await?;
+    create_simfile_record_impl(&base_url, &token, simfile_data, &workspace_root).await
+}
+
+#[cfg(test)]
+pub(crate) async fn create_simfile_record_with_workspace_state(
+    base_url: &str,
+    token: &str,
+    simfile_data: CreateSimfileRecordInput,
+    state: &WorkspaceRootState,
+) -> Result<CreateSimfileRecordResult> {
+    let workspace_root = state.current()?;
+    create_simfile_record_impl(base_url, token, simfile_data, &workspace_root).await
+}
+
+#[cfg(test)]
+#[path = "tests/simfile_tests.rs"]
+mod tests;

--- a/packages/dtx-desktop/src-tauri/src/simfile.rs
+++ b/packages/dtx-desktop/src-tauri/src/simfile.rs
@@ -161,7 +161,8 @@ async fn upload_preview_if_present(
 /// `song_path` is contained within `workspace_root`. Returns:
 /// - `Ok(Some(bytes))` when the file exists and is within the workspace,
 /// - `Ok(None)` when the file is absent (no preview to upload, not an error),
-/// - `Err(message)` when containment fails or the workspace root is missing.
+/// - `Err(message)` when containment fails, the workspace root is missing,
+///   or reading the preview file fails.
 async fn read_preview_within_workspace(
     song_path: &str,
     workspace_root: &str,
@@ -209,7 +210,7 @@ async fn read_preview_within_workspace(
     };
     match fs::read(&canonical_preview).await {
         Ok(bytes) => Ok(Some(bytes)),
-        Err(_) => Ok(None),
+        Err(error) => Err(error.to_string()),
     }
 }
 

--- a/packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
+++ b/packages/dtx-desktop/src-tauri/src/tests/api_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::api_contracts::CreateSimfileLevelInput;
 use crate::google_drive::{ApiDriveMetadataClient, DriveMetadataClient};
 use crate::workspace::{test_support::managed_workspace_state, WorkspaceRootState};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -7,7 +6,6 @@ use std::fs;
 use std::sync::{mpsc, Mutex, OnceLock};
 use std::time::Duration as StdDuration;
 use tauri::Listener;
-use ts_rs::TS;
 use wiremock::matchers::{body_partial_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -50,32 +48,6 @@ fn jwt_with_exp(exp: i64) -> String {
     )
 }
 
-fn gql_simfile() -> Value {
-    json!({
-        "id": "42",
-        "displayId": 7,
-        "title": "Song",
-        "artist": "Artist",
-        "bpm": 180.5,
-        "userId": "user-1",
-        "googleDriveFileId": "drive-file-42",
-        "isPublished": true,
-        "downloadUrl": "https://files/song.zip",
-        "previewUrl": "https://files/preview.jpg",
-        "videoPreviewUrl": null,
-        "publishDate": "2024-01-01",
-        "createdAt": "2024-01-02",
-        "updatedAt": "2024-01-03",
-        "dtxFiles": [{ "id": "101", "level": 9.2, "label": "EXT" }]
-    })
-}
-
-fn gql_simfile_with_id(id: i64) -> Value {
-    let mut simfile = gql_simfile();
-    simfile["id"] = json!(id.to_string());
-    simfile
-}
-
 fn owner_drive_simfile() -> Value {
     json!({
         "id": "42",
@@ -84,24 +56,6 @@ fn owner_drive_simfile() -> Value {
         "googleDriveFileId": "drive-file-42",
         "downloadUrl": "https://drive.google.com/uc?id=drive-file-42"
     })
-}
-
-fn create_input_fixture_with_display_id(display_id: Option<i64>) -> CreateSimfileRecordInput {
-    CreateSimfileRecordInput {
-        title: "Song".to_string(),
-        artist: "Artist".to_string(),
-        bpm: 180.0,
-        display_id,
-        is_published: true,
-        publish_date: "2024-01-01".to_string(),
-        download_url: "https://files/song.zip".to_string(),
-        video_preview_url: "https://video".to_string(),
-        levels: vec![CreateSimfileLevelInput {
-            label: "EXT".to_string(),
-            level: 9.2,
-        }],
-        song_path: String::new(),
-    }
 }
 
 #[test]
@@ -119,263 +73,8 @@ fn api_base_url_rejects_empty_value() {
 }
 
 #[test]
-fn native_simfile_from_graphql_matches_renderer_fixture() {
-    let expected: Value =
-        serde_json::from_str(include_str!("../../tests/fixtures/simfile_model.json"))
-            .expect("fixture parses");
-    let graphql_value = json!({
-        "id": "42",
-        "displayId": 7,
-        "title": "Fixture Song",
-        "artist": "Fixture Artist",
-        "bpm": 123.5,
-        "userId": "user-1",
-        "googleDriveFileId": null,
-        "isPublished": true,
-        "downloadUrl": "https://example.test/chart.zip",
-        "previewUrl": null,
-        "videoPreviewUrl": null,
-        "publishDate": "2026-08-15",
-        "createdAt": "2026-08-15T00:00:00Z",
-        "updatedAt": "2026-08-15T00:00:01Z",
-        "dtxFiles": [{ "id": "99", "label": "EXT", "level": 85.0 }]
-    });
-
-    let native = native_simfile_from_graphql(&graphql_value).expect("mapped");
-    assert_eq!(serde_json::to_value(native).expect("serializes"), expected);
-}
-
-#[test]
-fn native_simfile_from_graphql_rejects_missing_null_and_non_array_dtx_files() {
-    for (case, dtx_files) in [
-        ("missing", None),
-        ("null", Some(Value::Null)),
-        ("non-array", Some(json!({}))),
-    ] {
-        let mut graphql_value = gql_simfile();
-        match dtx_files {
-            Some(dtx_files) => graphql_value["dtxFiles"] = dtx_files,
-            None => {
-                graphql_value
-                    .as_object_mut()
-                    .expect("simfile object")
-                    .remove("dtxFiles");
-            }
-        };
-
-        assert!(
-            native_simfile_from_graphql(&graphql_value).is_err(),
-            "{case} dtxFiles should fail conversion"
-        );
-    }
-}
-
-#[test]
-fn native_simfile_from_graphql_rejects_missing_null_and_invalid_dtx_ids() {
-    for (case, dtx_file) in [
-        ("absent", json!({ "label": "EXT", "level": 9.2 })),
-        ("null", json!({ "id": null, "label": "EXT", "level": 9.2 })),
-        (
-            "invalid",
-            json!({ "id": "abc", "label": "EXT", "level": 9.2 }),
-        ),
-    ] {
-        let mut graphql_value = gql_simfile();
-        graphql_value["dtxFiles"] = json!([dtx_file]);
-
-        assert!(
-            native_simfile_from_graphql(&graphql_value).is_err(),
-            "{case} dtx id should fail conversion"
-        );
-    }
-}
-
-#[test]
-fn native_simfile_from_graphql_rejects_non_string_nullable_fields() {
-    // A nullable string field (e.g. userId) must be null, absent, or a string.
-    // A non-string value (number, bool, array) is malformed and must error
-    // rather than silently coercing — covering the nullable_string error branch.
-    for field in [
-        "userId",
-        "googleDriveFileId",
-        "downloadUrl",
-        "previewUrl",
-        "videoPreviewUrl",
-    ] {
-        let mut graphql_value = gql_simfile();
-        graphql_value[field] = json!(42);
-
-        assert!(
-            native_simfile_from_graphql(&graphql_value).is_err(),
-            "{field} as a number should fail conversion"
-        );
-    }
-}
-
-#[test]
-fn native_simfile_typescript_keeps_nullable_fields_required() {
-    let decl = NativeSimfile::decl(&Default::default());
-    assert!(decl.contains("displayId: number | null"));
-    assert!(decl.contains("googleDriveFileId: string | null"));
-    assert!(!decl.contains("displayId?:"));
-    assert!(!decl.contains("googleDriveFileId?:"));
-}
-
-#[test]
-fn list_simfiles_query_reuses_full_simfile_fragment() {
-    assert!(LIST_SIMFILES_QUERY.contains("...DesktopSimfileFull"));
-    let document = graphql_document(LIST_SIMFILES_QUERY);
-    assert!(document.contains("fragment DesktopSimfileFull on Simfile"));
-    assert!(document.contains("googleDriveFileId"));
-    assert!(document.contains("createdAt"));
-    assert!(document.contains("updatedAt"));
-    assert!(document.contains("dtxFiles"));
-}
-
-#[test]
 fn asset_file_query_uses_moved_full_simfile_fragment_name() {
     assert!(GET_SIMFILE_WITH_FILES_QUERY.contains("...DesktopSimfileFull"));
-}
-
-#[tokio::test]
-async fn update_simfile_record_impl_sends_typed_input() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({
-            "variables": {
-                "id": "42",
-                "input": { "title": "Updated" }
-            }
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "updateSimfile": gql_simfile() }
-        })))
-        .mount(&server)
-        .await;
-
-    let input = UpdateSimfileRecordInput {
-        title: Some("Updated".to_string()),
-        ..Default::default()
-    };
-
-    let result = update_simfile_record_impl(&server.uri(), "token-1", "42".to_string(), input)
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    assert_eq!(result["data"]["title"], "Song");
-}
-
-#[test]
-fn update_simfile_input_omits_absent_fields() {
-    let input = UpdateSimfileRecordInput {
-        title: Some("Updated".to_string()),
-        ..Default::default()
-    };
-    assert_eq!(
-        serde_json::to_value(input).expect("serializes"),
-        json!({ "title": "Updated" })
-    );
-}
-
-#[test]
-fn update_simfile_input_serializes_explicit_null_as_null() {
-    // Tri-state: Some(None) is an explicit request to clear the stored
-    // value and must reach GraphQL as `null`, distinct from an omitted
-    // field (None) which means "leave unchanged". The GraphQL
-    // `updateSimfile` resolver applies displayId/downloadUrl/videoPreviewUrl
-    // only when the input property is `!== undefined`.
-    let input = UpdateSimfileRecordInput {
-        display_id: Some(None),
-        download_url: Some(None),
-        video_preview_url: Some(None),
-        ..Default::default()
-    };
-    assert_eq!(
-        serde_json::to_value(input).expect("serializes"),
-        json!({
-            "displayId": null,
-            "downloadUrl": null,
-            "videoPreviewUrl": null
-        })
-    );
-}
-
-#[tokio::test]
-async fn update_simfile_record_impl_sends_explicit_null_to_graphql() {
-    // Wire-level proof that an explicit clear request ({ displayId: null })
-    // reaches the GraphQL mutation input as `"displayId": null` rather than
-    // being silently omitted. The API intentionally distinguishes null
-    // (clear) from undefined (omit) for displayId/downloadUrl/videoPreviewUrl.
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "updateSimfile": gql_simfile() }
-        })))
-        .mount(&server)
-        .await;
-
-    let input = UpdateSimfileRecordInput {
-        display_id: Some(None),
-        ..Default::default()
-    };
-
-    update_simfile_record_impl(&server.uri(), "token-1", "42".to_string(), input)
-        .await
-        .expect("result");
-
-    let requests = server.received_requests().await.expect("received request");
-    assert_eq!(requests.len(), 1);
-    let body: Value = serde_json::from_slice(&requests[0].body).expect("GraphQL JSON body");
-    assert_eq!(body["variables"]["id"], "42");
-    assert!(
-        body["variables"]["input"]["displayId"].is_null(),
-        "explicit null displayId must reach GraphQL as null, not be omitted"
-    );
-    assert!(
-        body["variables"]["input"]
-            .as_object()
-            .unwrap()
-            .contains_key("displayId"),
-        "displayId key must be present in the GraphQL input"
-    );
-    assert!(
-        !body["variables"]["input"]
-            .as_object()
-            .unwrap()
-            .contains_key("downloadUrl"),
-        "absent fields must remain omitted from the GraphQL input"
-    );
-}
-
-#[test]
-fn update_simfile_input_deserializes_tri_state() {
-    // Pinning the deserialization side of the tri-state: an explicit null
-    // becomes Some(None) (clear), a missing field becomes None (omit), and a
-    // value becomes Some(Some(_)) (set). Without double_option, serde
-    // collapses both null and missing into None, silently dropping clears.
-    let omitted: UpdateSimfileRecordInput =
-        serde_json::from_str(json!({ "title": "T" }).to_string().as_str()).expect("parses");
-    assert_eq!(omitted.display_id, None);
-
-    let cleared: UpdateSimfileRecordInput =
-        serde_json::from_str(json!({ "displayId": null }).to_string().as_str()).expect("parses");
-    assert_eq!(cleared.display_id, Some(None));
-
-    let set: UpdateSimfileRecordInput =
-        serde_json::from_str(json!({ "displayId": 7 }).to_string().as_str()).expect("parses");
-    assert_eq!(set.display_id, Some(Some(7)));
-}
-
-#[test]
-fn create_simfile_input_preserves_null_display_id() {
-    let input = create_input_fixture_with_display_id(None);
-    let value = serde_json::to_value(input).expect("serializes");
-    assert!(value.get("displayId").is_some());
-    assert!(value["displayId"].is_null());
 }
 
 #[tokio::test]
@@ -929,76 +628,6 @@ async fn upload_file_to_api_rejects_paths_outside_song_folder() {
     assert_eq!(result["error"], "File path is outside song folder");
 }
 
-#[tokio::test]
-async fn read_preview_rejects_song_folder_outside_workspace() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let outside = tempfile::tempdir().expect("outside");
-    fs::write(outside.path().join("preview.jpg"), b"img").expect("preview");
-
-    let result = read_preview_within_workspace(
-        outside.path().to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(matches!(result, Err(ref e) if e.contains("outside the workspace")));
-}
-
-#[tokio::test]
-async fn read_preview_rejects_missing_workspace_root() {
-    let song = tempfile::tempdir().expect("song");
-
-    let result =
-        read_preview_within_workspace(song.path().to_str().unwrap(), "", "preview.jpg").await;
-
-    assert!(matches!(result, Err(ref e) if e.contains("workspace root is required")));
-}
-
-#[tokio::test]
-async fn read_preview_returns_none_when_file_absent() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let song = workspace.path().join("song");
-    fs::create_dir(&song).expect("song dir");
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(matches!(result, Ok(None)));
-}
-
-#[tokio::test]
-async fn read_preview_reads_file_inside_workspace() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let song = workspace.path().join("song");
-    fs::create_dir(&song).expect("song dir");
-    fs::write(song.join("preview.jpg"), b"img").expect("preview");
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(matches!(result, Ok(Some(ref bytes)) if bytes == b"img"));
-}
-
-#[test]
-fn number_id_accepts_i64_and_numeric_strings_but_rejects_overflow_and_invalid_types() {
-    assert_eq!(number_id(&json!(42)).unwrap(), 42);
-    assert_eq!(number_id(&json!(-7)).unwrap(), -7);
-    assert_eq!(number_id(&json!("123")).unwrap(), 123);
-    assert!(number_id(&json!(u64::MAX)).is_err());
-    assert!(number_id(&json!(null)).is_err());
-    assert!(number_id(&json!([1, 2])).is_err());
-    assert!(number_id(&json!("not a number")).is_err());
-}
-
 #[test]
 fn upload_name_from_file_name_strips_only_the_leading_segment() {
     assert_eq!(upload_name_from_file_name("kick.wav"), "kick.wav");
@@ -1350,140 +979,6 @@ async fn access_token_from_auth_state_returns_token_from_session() {
 }
 
 #[tokio::test]
-async fn fetch_user_simfiles_impl_returns_single_page() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(header("authorization", "Bearer token-1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": {
-                "simfiles": {
-                    "data": [gql_simfile()],
-                    "count": 1
-                }
-            }
-        })))
-        .mount(&server)
-        .await;
-
-    let result = fetch_user_simfiles_impl(&server.uri(), "token-1")
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    assert_eq!(result["data"].as_array().unwrap().len(), 1);
-    assert_eq!(result["fromCache"], false);
-}
-
-#[tokio::test]
-async fn fetch_user_simfiles_impl_paginates_across_multiple_pages() {
-    let server = MockServer::start().await;
-
-    let page1_data = (0..100).map(gql_simfile_with_id).collect::<Vec<_>>();
-    let page2_data = (100..200).map(gql_simfile_with_id).collect::<Vec<_>>();
-    let page3_data = (200..250).map(gql_simfile_with_id).collect::<Vec<_>>();
-
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({ "variables": { "page": 1 } })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "simfiles": { "data": page1_data, "count": 250 } }
-        })))
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({ "variables": { "page": 2 } })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "simfiles": { "data": page2_data, "count": 250 } }
-        })))
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({ "variables": { "page": 3 } })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "simfiles": { "data": page3_data, "count": 250 } }
-        })))
-        .mount(&server)
-        .await;
-
-    let result = fetch_user_simfiles_impl(&server.uri(), "token-1")
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    assert_eq!(result["data"].as_array().unwrap().len(), 250);
-}
-
-#[tokio::test]
-async fn fetch_user_simfiles_impl_returns_partial_data_on_mid_pagination_failure() {
-    let server = MockServer::start().await;
-
-    let page1_data = (0..100).map(gql_simfile_with_id).collect::<Vec<_>>();
-
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({ "variables": { "page": 1 } })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "simfiles": { "data": page1_data, "count": 200 } }
-        })))
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({ "variables": { "page": 2 } })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "errors": [{ "message": "boom", "extensions": { "code": "INTERNAL" } }]
-        })))
-        .mount(&server)
-        .await;
-
-    let result = fetch_user_simfiles_impl(&server.uri(), "token-1")
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], false);
-    assert_eq!(result["data"].as_array().unwrap().len(), 100);
-    assert_eq!(result["fromCache"], false);
-}
-
-#[tokio::test]
-async fn get_next_display_id_impl_returns_id() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({ "data": { "nextDisplayId": 42 } })),
-        )
-        .mount(&server)
-        .await;
-
-    let id = get_next_display_id_impl(&server.uri(), "token-1")
-        .await
-        .expect("id");
-
-    assert_eq!(id, 42);
-}
-
-#[tokio::test]
-async fn get_next_display_id_impl_errors_when_missing() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": {} })))
-        .mount(&server)
-        .await;
-
-    assert!(get_next_display_id_impl(&server.uri(), "token-1")
-        .await
-        .is_err());
-}
-
-#[tokio::test]
 async fn search_cloud_songs_impl_returns_mapped_rows() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
@@ -1549,104 +1044,6 @@ async fn search_cloud_songs_impl_returns_failure_on_graphql_error() {
     let result = search_cloud_songs_impl(&server.uri(), "token-1", "Song".to_string(), None, None)
         .await
         .expect("result");
-
-    assert_eq!(result["success"], false);
-}
-
-#[tokio::test]
-async fn fetch_cloud_song_impl_returns_cloud_song_data_when_found() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({ "data": { "simfile": gql_simfile() } })),
-        )
-        .mount(&server)
-        .await;
-
-    let result = fetch_cloud_song_impl(&server.uri(), "token-1", "42".to_string())
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    assert_eq!(result["cloudSongData"]["id"], 42);
-    assert_eq!(result["cloudSongData"]["title"], "Song");
-    assert_eq!(result["cloudSongData"]["isPublished"], true);
-    assert_eq!(result["cloudSongData"]["createdAt"], "2024-01-02");
-}
-
-#[tokio::test]
-async fn fetch_cloud_song_impl_returns_failure_when_simfile_null() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({ "data": { "simfile": null } })),
-        )
-        .mount(&server)
-        .await;
-
-    let result = fetch_cloud_song_impl(&server.uri(), "token-1", "42".to_string())
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], false);
-    assert_eq!(result["error"], "Simfile not found");
-}
-
-#[tokio::test]
-async fn update_simfile_record_impl_returns_updated_simfile() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "updateSimfile": gql_simfile() }
-        })))
-        .mount(&server)
-        .await;
-
-    let result = update_simfile_record_impl(
-        &server.uri(),
-        "token-1",
-        "42".to_string(),
-        UpdateSimfileRecordInput {
-            title: Some("Updated".to_string()),
-            ..Default::default()
-        },
-    )
-    .await
-    .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    assert_eq!(result["data"]["id"], 42);
-    assert_eq!(result["data"]["title"], "Song");
-    assert_eq!(result["data"]["isPublished"], true);
-}
-
-#[tokio::test]
-async fn update_simfile_record_impl_returns_failure_on_graphql_error() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "errors": [{ "message": "forbidden" }]
-        })))
-        .mount(&server)
-        .await;
-
-    let result = update_simfile_record_impl(
-        &server.uri(),
-        "token-1",
-        "42".to_string(),
-        UpdateSimfileRecordInput::default(),
-    )
-    .await
-    .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
 
     assert_eq!(result["success"], false);
 }
@@ -1738,85 +1135,6 @@ async fn load_asset_files_impl_returns_empty_when_no_files_array() {
 }
 
 #[tokio::test]
-async fn create_simfile_record_impl_creates_without_previews_when_no_song_path() {
-    let server = MockServer::start().await;
-    let workspace = tempfile::tempdir().expect("workspace");
-    let expected_variables = json!({
-        "input": {
-            "title": "Song",
-            "artist": "Artist",
-            "bpm": 180.0,
-            "displayId": null,
-            "isPublished": true,
-            "publishDate": "2024-01-01",
-            "downloadUrl": "https://files/song.zip",
-            "videoPreviewUrl": "https://video",
-            "dtxFiles": [{ "label": "EXT", "level": 9.2 }]
-        }
-    });
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .and(body_partial_json(json!({
-            "variables": expected_variables.clone()
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "createSimfile": gql_simfile() }
-        })))
-        .mount(&server)
-        .await;
-
-    let state = managed_workspace_state(workspace.path());
-    let result = create_simfile_record_with_workspace_state(
-        &server.uri(),
-        "token-1",
-        create_input_fixture_with_display_id(None),
-        &state,
-    )
-    .await
-    .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-    let requests = server.received_requests().await.expect("received requests");
-    assert_eq!(requests.len(), 1);
-    let body: Value = serde_json::from_slice(&requests[0].body).expect("GraphQL JSON body");
-    assert_eq!(body["variables"], expected_variables);
-    assert!(body["variables"]["input"].get("levels").is_none());
-    assert!(body["variables"]["input"].get("songPath").is_none());
-
-    assert_eq!(result["success"], true);
-    assert_eq!(result["simfileId"], "42");
-    assert_eq!(result["data"]["id"], 42);
-    assert_eq!(result["data"]["isPublished"], true);
-    assert!(result.get("warnings").is_none());
-}
-
-#[tokio::test]
-async fn create_simfile_record_impl_skips_previews_when_files_absent() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "createSimfile": gql_simfile() }
-        })))
-        .mount(&server)
-        .await;
-
-    let workspace = tempfile::tempdir().expect("workspace");
-    let song = workspace.path().join("song");
-    fs::create_dir(&song).expect("song dir");
-
-    let mut simfile_data = create_input_fixture_with_display_id(None);
-    simfile_data.song_path = song.to_str().unwrap().to_string();
-    let result =
-        create_simfile_record_impl(&server.uri(), "token-1", simfile_data, workspace.path())
-            .await
-            .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    assert!(result.get("warnings").is_none());
-}
-
-#[tokio::test]
 async fn get_sound_preview_url_rejects_non_positive_ids() {
     // Symmetric with get_preview_url: an invalid id must surface as an error
     // rather than producing a malformed bucket URL.
@@ -1886,24 +1204,6 @@ fn graphql_document_prefixes_operation_with_desktop_simfile_full_fragment() {
 }
 
 #[test]
-fn number_id_rejects_object_and_array_input() {
-    // Defensive: a malformed renderer payload must surface as an error rather
-    // than panicking inside number_id.
-    assert!(number_id(&json!({ "id": "x" })).is_err());
-    assert!(number_id(&json!([1, 2, 3])).is_err());
-    assert!(number_id(&Value::Null).is_err());
-}
-
-#[test]
-fn number_id_accepts_u64_that_fits_in_i64() {
-    // IDs coming from JSON could deserialize as u64; values within i64 range
-    // must convert cleanly. (Anything outside i64 range must error — covered
-    // by number_id_accepts_i64_and_numeric_strings_but_rejects_overflow_and_invalid_types.)
-    let value: u64 = 123_456;
-    assert_eq!(number_id(&json!(value)).unwrap(), 123_456);
-}
-
-#[test]
 fn reqwest_client_builder_produces_usable_client() {
     // Sanity: the helper must succeed in constructing a client — failures
     // here would indicate a TLS/build configuration issue.
@@ -1935,7 +1235,6 @@ fn api_result_value_success_data_returns_error_tuple_for_failure() {
 // ---------------------------------------------------------------------------
 // upload_name_from_file_name
 // ---------------------------------------------------------------------------
-
 #[test]
 fn upload_name_from_file_name_strips_leading_slash_prefix() {
     let name = upload_name_from_file_name("subfolder/song.dtx");
@@ -1961,7 +1260,6 @@ fn upload_name_from_file_name_falls_back_when_only_slash() {
 // ---------------------------------------------------------------------------
 // upload_file_to_api error paths (temp-file based, no wiremock needed)
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn upload_file_to_api_fails_when_song_folder_missing() {
     let workspace = tempfile::tempdir().unwrap();
@@ -2051,111 +1349,8 @@ async fn upload_file_to_api_rejects_song_folder_outside_workspace() {
 }
 
 // ---------------------------------------------------------------------------
-// read_preview_within_workspace (temp-file based)
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn read_preview_within_workspace_rejects_empty_workspace_root() {
-    let result = read_preview_within_workspace("/some/song", "", "preview.jpg").await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("workspace root"));
-}
-
-#[tokio::test]
-async fn read_preview_within_workspace_rejects_nonexistent_workspace_root() {
-    let result = read_preview_within_workspace(
-        "/some/song",
-        "/nonexistent-workspace-root-12345",
-        "preview.jpg",
-    )
-    .await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Workspace root not found"));
-}
-
-#[tokio::test]
-async fn read_preview_within_workspace_rejects_song_outside_workspace() {
-    let workspace = tempfile::tempdir().unwrap();
-    let outside = tempfile::tempdir().unwrap();
-
-    let result = read_preview_within_workspace(
-        outside.path().to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("outside the workspace"));
-}
-
-#[tokio::test]
-async fn read_preview_within_workspace_returns_none_when_preview_absent() {
-    let workspace = tempfile::tempdir().unwrap();
-    let song = workspace.path().join("mysong");
-    fs::create_dir(&song).unwrap();
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), None);
-}
-
-#[tokio::test]
-async fn read_preview_within_workspace_returns_bytes_when_preview_present() {
-    let workspace = tempfile::tempdir().unwrap();
-    let song = workspace.path().join("mysong");
-    fs::create_dir(&song).unwrap();
-    fs::write(song.join("preview.jpg"), b"image-bytes").unwrap();
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), Some(b"image-bytes".to_vec()));
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn read_preview_rejects_symlink_pointing_outside_workspace() {
-    use std::os::unix::fs::symlink;
-
-    let workspace = tempfile::tempdir().unwrap();
-    let outside = tempfile::tempdir().unwrap();
-    let song = workspace.path().join("song");
-    fs::create_dir(&song).unwrap();
-
-    // File outside the workspace that the symlink will target.
-    let secret = outside.path().join("secret.jpg");
-    fs::write(&secret, b"secret-bytes").unwrap();
-
-    // Symlink inside the song folder pointing outside the workspace.
-    symlink(&secret, song.join("preview.jpg")).unwrap();
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("outside the workspace"));
-}
-
-// ---------------------------------------------------------------------------
 // Wiremock-based: timeouts and NOT_FOUND paths
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn run_graphql_value_times_out_on_slow_server() {
     let server = MockServer::start().await;
@@ -2258,93 +1453,6 @@ async fn load_asset_files_impl_returns_failure_for_general_graphql_error() {
 
     assert_eq!(result["success"], false);
     assert_eq!(result["error"], "INTERNAL: Internal server error");
-}
-
-#[tokio::test]
-async fn create_simfile_record_impl_surfaces_preview_upload_warnings() {
-    let server = MockServer::start().await;
-    // Create mutation succeeds
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": {
-                "createSimfile": {
-                    "id": 42,
-                    "title": "Song",
-                    "artist": "Artist",
-                    "bpm": 120.0,
-                    "userId": "u1",
-                    "isPublished": false,
-                    "displayId": null,
-                    "downloadUrl": null,
-                    "previewUrl": null,
-                    "videoPreviewUrl": null,
-                    "publishDate": "2026-08-15",
-                    "createdAt": "2026-08-15T00:00:00Z",
-                    "updatedAt": "2026-08-15T00:00:01Z",
-                    "dtxFiles": [],
-                }
-            }
-        })))
-        .mount(&server)
-        .await;
-    // Upload endpoint fails
-    Mock::given(method("POST"))
-        .and(path("/upload"))
-        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
-            "error": "Storage error"
-        })))
-        .mount(&server)
-        .await;
-
-    let workspace = tempfile::tempdir().unwrap();
-    let song = workspace.path().join("mysong");
-    fs::create_dir(&song).unwrap();
-    fs::write(song.join("preview.jpg"), b"image").unwrap();
-    fs::write(song.join("preview.mp3"), b"audio").unwrap();
-
-    let mut simfile_data = create_input_fixture_with_display_id(None);
-    simfile_data.song_path = song.to_str().unwrap().to_string();
-
-    let result = create_simfile_record_impl(&server.uri(), "tok", simfile_data, workspace.path())
-        .await
-        .unwrap();
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], true);
-    let warnings = result["warnings"].as_array().expect("warnings array");
-    assert!(warnings.len() >= 2, "should have preview + sound warnings");
-    assert!(warnings
-        .iter()
-        .any(|w| w.as_str().unwrap().contains("Preview image")));
-    assert!(warnings
-        .iter()
-        .any(|w| w.as_str().unwrap().contains("Sound preview")));
-}
-
-#[tokio::test]
-async fn create_simfile_record_rejects_when_managed_workspace_is_unset_before_request() {
-    // Moving the root lookup below the GraphQL mutation would create a remote
-    // simfile even though preview file access is not authorized.
-    let server = MockServer::start().await;
-    let state = WorkspaceRootState::default();
-
-    let mut simfile_data = create_input_fixture_with_display_id(None);
-    simfile_data.song_path = "/untrusted/song".to_string();
-    let result =
-        create_simfile_record_with_workspace_state(&server.uri(), "token-1", simfile_data, &state)
-            .await;
-
-    assert!(result.is_err());
-    assert!(result
-        .expect_err("managed workspace is required")
-        .to_string()
-        .contains("workspace root is required"));
-    assert!(server
-        .received_requests()
-        .await
-        .expect("received requests")
-        .is_empty());
 }
 
 #[tokio::test]
@@ -2719,7 +1827,6 @@ async fn fetch_cloud_song_charts_returns_empty_when_dtx_files_absent() {
 // classify_metadata_auth_error — maps DesktopError messages to the
 // coarse-grained DriveMetadataError categories reconciliation acts on.
 // ---------------------------------------------------------------------------
-
 #[test]
 fn classify_metadata_auth_error_maps_network_messages_to_network() {
     for message in [
@@ -2749,7 +1856,6 @@ fn classify_metadata_auth_error_maps_other_messages_to_authentication() {
 // ---------------------------------------------------------------------------
 // search_cloud_songs_impl — exclude_ids coercion of non-string values.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn search_cloud_songs_impl_coerces_numeric_exclude_ids_to_strings() {
     // The renderer may send exclude ids as numbers; the GraphQL variable is
@@ -2786,7 +1892,6 @@ async fn search_cloud_songs_impl_coerces_numeric_exclude_ids_to_strings() {
 // ---------------------------------------------------------------------------
 // update_drive_file_impl — null mutation response.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn update_drive_file_impl_returns_definitive_unavailable_for_null_response() {
     let server = MockServer::start().await;
@@ -2817,29 +1922,8 @@ async fn update_drive_file_impl_returns_definitive_unavailable_for_null_response
 }
 
 // ---------------------------------------------------------------------------
-// fetch_cloud_song_impl / fetch_cloud_song_charts_impl — GraphQL error branch.
+// fetch_cloud_song_charts_impl — GraphQL error branch.
 // ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn fetch_cloud_song_impl_returns_failure_on_graphql_error() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "errors": [{ "message": "forbidden", "extensions": { "code": "FORBIDDEN" } }]
-        })))
-        .mount(&server)
-        .await;
-
-    let result = fetch_cloud_song_impl(&server.uri(), "token-1", "42".to_string())
-        .await
-        .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], serde_json::json!(false));
-    assert!(result["error"].as_str().unwrap().contains("forbidden"));
-}
-
 #[tokio::test]
 async fn fetch_cloud_song_charts_impl_returns_failure_on_graphql_error() {
     let server = MockServer::start().await;
@@ -2865,7 +1949,6 @@ async fn fetch_cloud_song_charts_impl_returns_failure_on_graphql_error() {
 // coarse-grained category so reconciliation never deletes a recoverable
 // Drive object.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn drive_metadata_classifies_not_found_code_as_definitive_unavailable() {
     let server = MockServer::start().await;
@@ -3055,7 +2138,6 @@ async fn drive_metadata_classifies_403_status_as_authentication() {
 // ---------------------------------------------------------------------------
 // upload_bytes_to_api — invalid content-type short-circuits before the POST.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn upload_bytes_to_api_returns_failure_for_invalid_content_type() {
     // A malformed MIME string (containing a space) is rejected by
@@ -3077,7 +2159,6 @@ async fn upload_bytes_to_api_returns_failure_for_invalid_content_type() {
 // ---------------------------------------------------------------------------
 // upload_name_from_file_name — trailing-slash fallback.
 // ---------------------------------------------------------------------------
-
 #[test]
 fn upload_name_from_file_name_falls_back_when_stripped_segment_is_empty() {
     // "song/" splits to ["song", ""] → stripped is "" → fall back to the
@@ -3086,41 +2167,10 @@ fn upload_name_from_file_name_falls_back_when_stripped_segment_is_empty() {
 }
 
 // ---------------------------------------------------------------------------
-// create_simfile_record_impl — GraphQL error branch.
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn create_simfile_record_impl_returns_failure_on_graphql_error() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "errors": [{ "message": "forbidden", "extensions": { "code": "FORBIDDEN" } }]
-        })))
-        .mount(&server)
-        .await;
-
-    let workspace = tempfile::tempdir().expect("workspace");
-    let result = create_simfile_record_impl(
-        &server.uri(),
-        "token-1",
-        create_input_fixture_with_display_id(None),
-        workspace.path(),
-    )
-    .await
-    .expect("result");
-    let result = serde_json::to_value(result).expect("serializes");
-
-    assert_eq!(result["success"], serde_json::json!(false));
-    assert!(result["error"].as_str().unwrap().contains("forbidden"));
-}
-
-// ---------------------------------------------------------------------------
 // update_drive_file_impl — ExpectedPreviousDriveFile variants (patch lines
 // 529-533). Each variant must serialize the correct optimistic-concurrency
 // variables so the server can reject stale cross-device overwrites.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn update_drive_file_impl_sends_expect_no_existing_drive_file_for_none_variant() {
     // ExpectedPreviousDriveFile::None → expectNoExistingDriveFile: true,
@@ -3209,40 +2259,11 @@ async fn update_drive_file_impl_sends_expected_previous_drive_file_id_for_drive_
 }
 
 // ---------------------------------------------------------------------------
-// read_preview_within_workspace — "Song folder not found" error path (patch
-// line 934). When the workspace root exists but the song folder does not,
-// the refactored containment check surfaces a clear NotFound message rather
-// than a generic I/O error.
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn read_preview_within_workspace_rejects_nonexistent_song_folder() {
-    let workspace = tempfile::tempdir().expect("workspace");
-
-    // The nonexistent song folder must have an existing ancestor inside the
-    // workspace so the containment check passes and surfaces NotFound for the
-    // missing target itself (rather than rejecting it as outside the workspace).
-    let result = read_preview_within_workspace(
-        &format!(
-            "{}/nonexistent-song-folder-12345",
-            workspace.path().to_str().unwrap()
-        ),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Song folder not found"));
-}
-
-// ---------------------------------------------------------------------------
 // drive_metadata_graphql_data — HTTP status classification branches.
 // `fetch_owner_drive_simfile_impl` routes through `drive_metadata_graphql_data`,
 // so these tests exercise the status-code branches indirectly (as the
 // production callers do) rather than touching the private helper directly.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn drive_metadata_classifies_429_status_as_service_unavailable() {
     let server = MockServer::start().await;
@@ -3346,7 +2367,6 @@ async fn drive_metadata_classifies_422_status_as_invalid_response() {
 // session is missing, lacks a user id, or carries a blank id, so that Drive
 // commands never operate on an unauthenticated identity.
 // ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn authenticated_user_id_errors_when_session_is_absent() {
     let state = AuthState::default();

--- a/packages/dtx-desktop/src-tauri/src/tests/simfile_tests.rs
+++ b/packages/dtx-desktop/src-tauri/src/tests/simfile_tests.rs
@@ -305,65 +305,6 @@ fn create_simfile_input_preserves_null_display_id() {
     assert!(value["displayId"].is_null());
 }
 
-#[tokio::test]
-async fn read_preview_rejects_song_folder_outside_workspace() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let outside = tempfile::tempdir().expect("outside");
-    fs::write(outside.path().join("preview.jpg"), b"img").expect("preview");
-
-    let result = read_preview_within_workspace(
-        outside.path().to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(matches!(result, Err(ref e) if e.contains("outside the workspace")));
-}
-
-#[tokio::test]
-async fn read_preview_rejects_missing_workspace_root() {
-    let song = tempfile::tempdir().expect("song");
-
-    let result =
-        read_preview_within_workspace(song.path().to_str().unwrap(), "", "preview.jpg").await;
-
-    assert!(matches!(result, Err(ref e) if e.contains("workspace root is required")));
-}
-
-#[tokio::test]
-async fn read_preview_returns_none_when_file_absent() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let song = workspace.path().join("song");
-    fs::create_dir(&song).expect("song dir");
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(matches!(result, Ok(None)));
-}
-
-#[tokio::test]
-async fn read_preview_reads_file_inside_workspace() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let song = workspace.path().join("song");
-    fs::create_dir(&song).expect("song dir");
-    fs::write(song.join("preview.jpg"), b"img").expect("preview");
-
-    let result = read_preview_within_workspace(
-        song.to_str().unwrap(),
-        workspace.path().to_str().unwrap(),
-        "preview.jpg",
-    )
-    .await;
-
-    assert!(matches!(result, Ok(Some(ref bytes)) if bytes == b"img"));
-}
-
 #[test]
 fn number_id_accepts_i64_and_numeric_strings_but_rejects_overflow_and_invalid_types() {
     assert_eq!(number_id(&json!(42)).unwrap(), 42);

--- a/packages/dtx-desktop/src-tauri/src/tests/simfile_tests.rs
+++ b/packages/dtx-desktop/src-tauri/src/tests/simfile_tests.rs
@@ -1,0 +1,972 @@
+use super::*;
+use crate::api_contracts::CreateSimfileLevelInput;
+use crate::workspace::{test_support::managed_workspace_state, WorkspaceRootState};
+use std::fs;
+use ts_rs::TS;
+use wiremock::matchers::{body_partial_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn gql_simfile() -> Value {
+    json!({
+        "id": "42",
+        "displayId": 7,
+        "title": "Song",
+        "artist": "Artist",
+        "bpm": 180.5,
+        "userId": "user-1",
+        "googleDriveFileId": "drive-file-42",
+        "isPublished": true,
+        "downloadUrl": "https://files/song.zip",
+        "previewUrl": "https://files/preview.jpg",
+        "videoPreviewUrl": null,
+        "publishDate": "2024-01-01",
+        "createdAt": "2024-01-02",
+        "updatedAt": "2024-01-03",
+        "dtxFiles": [{ "id": "101", "level": 9.2, "label": "EXT" }]
+    })
+}
+
+fn gql_simfile_with_id(id: i64) -> Value {
+    let mut simfile = gql_simfile();
+    simfile["id"] = json!(id.to_string());
+    simfile
+}
+
+fn create_input_fixture_with_display_id(display_id: Option<i64>) -> CreateSimfileRecordInput {
+    CreateSimfileRecordInput {
+        title: "Song".to_string(),
+        artist: "Artist".to_string(),
+        bpm: 180.0,
+        display_id,
+        is_published: true,
+        publish_date: "2024-01-01".to_string(),
+        download_url: "https://files/song.zip".to_string(),
+        video_preview_url: "https://video".to_string(),
+        levels: vec![CreateSimfileLevelInput {
+            label: "EXT".to_string(),
+            level: 9.2,
+        }],
+        song_path: String::new(),
+    }
+}
+
+#[test]
+fn native_simfile_from_graphql_matches_renderer_fixture() {
+    let expected: Value =
+        serde_json::from_str(include_str!("../../tests/fixtures/simfile_model.json"))
+            .expect("fixture parses");
+    let graphql_value = json!({
+        "id": "42",
+        "displayId": 7,
+        "title": "Fixture Song",
+        "artist": "Fixture Artist",
+        "bpm": 123.5,
+        "userId": "user-1",
+        "googleDriveFileId": null,
+        "isPublished": true,
+        "downloadUrl": "https://example.test/chart.zip",
+        "previewUrl": null,
+        "videoPreviewUrl": null,
+        "publishDate": "2026-08-15",
+        "createdAt": "2026-08-15T00:00:00Z",
+        "updatedAt": "2026-08-15T00:00:01Z",
+        "dtxFiles": [{ "id": "99", "label": "EXT", "level": 85.0 }]
+    });
+
+    let native = native_simfile_from_graphql(&graphql_value).expect("mapped");
+    assert_eq!(serde_json::to_value(native).expect("serializes"), expected);
+}
+
+#[test]
+fn native_simfile_from_graphql_rejects_missing_null_and_non_array_dtx_files() {
+    for (case, dtx_files) in [
+        ("missing", None),
+        ("null", Some(Value::Null)),
+        ("non-array", Some(json!({}))),
+    ] {
+        let mut graphql_value = gql_simfile();
+        match dtx_files {
+            Some(dtx_files) => graphql_value["dtxFiles"] = dtx_files,
+            None => {
+                graphql_value
+                    .as_object_mut()
+                    .expect("simfile object")
+                    .remove("dtxFiles");
+            }
+        };
+
+        assert!(
+            native_simfile_from_graphql(&graphql_value).is_err(),
+            "{case} dtxFiles should fail conversion"
+        );
+    }
+}
+
+#[test]
+fn native_simfile_from_graphql_rejects_missing_null_and_invalid_dtx_ids() {
+    for (case, dtx_file) in [
+        ("absent", json!({ "label": "EXT", "level": 9.2 })),
+        ("null", json!({ "id": null, "label": "EXT", "level": 9.2 })),
+        (
+            "invalid",
+            json!({ "id": "abc", "label": "EXT", "level": 9.2 }),
+        ),
+    ] {
+        let mut graphql_value = gql_simfile();
+        graphql_value["dtxFiles"] = json!([dtx_file]);
+
+        assert!(
+            native_simfile_from_graphql(&graphql_value).is_err(),
+            "{case} dtx id should fail conversion"
+        );
+    }
+}
+
+#[test]
+fn native_simfile_from_graphql_rejects_non_string_nullable_fields() {
+    // A nullable string field (e.g. userId) must be null, absent, or a string.
+    // A non-string value (number, bool, array) is malformed and must error
+    // rather than silently coercing — covering the nullable_string error branch.
+    for field in [
+        "userId",
+        "googleDriveFileId",
+        "downloadUrl",
+        "previewUrl",
+        "videoPreviewUrl",
+    ] {
+        let mut graphql_value = gql_simfile();
+        graphql_value[field] = json!(42);
+
+        assert!(
+            native_simfile_from_graphql(&graphql_value).is_err(),
+            "{field} as a number should fail conversion"
+        );
+    }
+}
+
+#[test]
+fn native_simfile_typescript_keeps_nullable_fields_required() {
+    let decl = NativeSimfile::decl(&Default::default());
+    assert!(decl.contains("displayId: number | null"));
+    assert!(decl.contains("googleDriveFileId: string | null"));
+    assert!(!decl.contains("displayId?:"));
+    assert!(!decl.contains("googleDriveFileId?:"));
+}
+
+#[test]
+fn list_simfiles_query_reuses_full_simfile_fragment() {
+    assert!(LIST_SIMFILES_QUERY.contains("...DesktopSimfileFull"));
+    let document = graphql_document(LIST_SIMFILES_QUERY);
+    assert!(document.contains("fragment DesktopSimfileFull on Simfile"));
+    assert!(document.contains("googleDriveFileId"));
+    assert!(document.contains("createdAt"));
+    assert!(document.contains("updatedAt"));
+    assert!(document.contains("dtxFiles"));
+}
+
+#[tokio::test]
+async fn update_simfile_record_impl_sends_typed_input() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({
+            "variables": {
+                "id": "42",
+                "input": { "title": "Updated" }
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "updateSimfile": gql_simfile() }
+        })))
+        .mount(&server)
+        .await;
+
+    let input = UpdateSimfileRecordInput {
+        title: Some("Updated".to_string()),
+        ..Default::default()
+    };
+
+    let result = update_simfile_record_impl(&server.uri(), "token-1", "42".to_string(), input)
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["data"]["title"], "Song");
+}
+
+#[test]
+fn update_simfile_input_omits_absent_fields() {
+    let input = UpdateSimfileRecordInput {
+        title: Some("Updated".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(input).expect("serializes"),
+        json!({ "title": "Updated" })
+    );
+}
+
+#[test]
+fn update_simfile_input_serializes_explicit_null_as_null() {
+    // Tri-state: Some(None) is an explicit request to clear the stored
+    // value and must reach GraphQL as `null`, distinct from an omitted
+    // field (None) which means "leave unchanged". The GraphQL
+    // `updateSimfile` resolver applies displayId/downloadUrl/videoPreviewUrl
+    // only when the input property is `!== undefined`.
+    let input = UpdateSimfileRecordInput {
+        display_id: Some(None),
+        download_url: Some(None),
+        video_preview_url: Some(None),
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(input).expect("serializes"),
+        json!({
+            "displayId": null,
+            "downloadUrl": null,
+            "videoPreviewUrl": null
+        })
+    );
+}
+
+#[tokio::test]
+async fn update_simfile_record_impl_sends_explicit_null_to_graphql() {
+    // Wire-level proof that an explicit clear request ({ displayId: null })
+    // reaches the GraphQL mutation input as `"displayId": null` rather than
+    // being silently omitted. The API intentionally distinguishes null
+    // (clear) from undefined (omit) for displayId/downloadUrl/videoPreviewUrl.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "updateSimfile": gql_simfile() }
+        })))
+        .mount(&server)
+        .await;
+
+    let input = UpdateSimfileRecordInput {
+        display_id: Some(None),
+        ..Default::default()
+    };
+
+    update_simfile_record_impl(&server.uri(), "token-1", "42".to_string(), input)
+        .await
+        .expect("result");
+
+    let requests = server.received_requests().await.expect("received request");
+    assert_eq!(requests.len(), 1);
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("GraphQL JSON body");
+    assert_eq!(body["variables"]["id"], "42");
+    assert!(
+        body["variables"]["input"]["displayId"].is_null(),
+        "explicit null displayId must reach GraphQL as null, not be omitted"
+    );
+    assert!(
+        body["variables"]["input"]
+            .as_object()
+            .unwrap()
+            .contains_key("displayId"),
+        "displayId key must be present in the GraphQL input"
+    );
+    assert!(
+        !body["variables"]["input"]
+            .as_object()
+            .unwrap()
+            .contains_key("downloadUrl"),
+        "absent fields must remain omitted from the GraphQL input"
+    );
+}
+
+#[test]
+fn update_simfile_input_deserializes_tri_state() {
+    // Pinning the deserialization side of the tri-state: an explicit null
+    // becomes Some(None) (clear), a missing field becomes None (omit), and a
+    // value becomes Some(Some(_)) (set). Without double_option, serde
+    // collapses both null and missing into None, silently dropping clears.
+    let omitted: UpdateSimfileRecordInput =
+        serde_json::from_str(json!({ "title": "T" }).to_string().as_str()).expect("parses");
+    assert_eq!(omitted.display_id, None);
+
+    let cleared: UpdateSimfileRecordInput =
+        serde_json::from_str(json!({ "displayId": null }).to_string().as_str()).expect("parses");
+    assert_eq!(cleared.display_id, Some(None));
+
+    let set: UpdateSimfileRecordInput =
+        serde_json::from_str(json!({ "displayId": 7 }).to_string().as_str()).expect("parses");
+    assert_eq!(set.display_id, Some(Some(7)));
+}
+
+#[test]
+fn create_simfile_input_preserves_null_display_id() {
+    let input = create_input_fixture_with_display_id(None);
+    let value = serde_json::to_value(input).expect("serializes");
+    assert!(value.get("displayId").is_some());
+    assert!(value["displayId"].is_null());
+}
+
+#[tokio::test]
+async fn read_preview_rejects_song_folder_outside_workspace() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let outside = tempfile::tempdir().expect("outside");
+    fs::write(outside.path().join("preview.jpg"), b"img").expect("preview");
+
+    let result = read_preview_within_workspace(
+        outside.path().to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(matches!(result, Err(ref e) if e.contains("outside the workspace")));
+}
+
+#[tokio::test]
+async fn read_preview_rejects_missing_workspace_root() {
+    let song = tempfile::tempdir().expect("song");
+
+    let result =
+        read_preview_within_workspace(song.path().to_str().unwrap(), "", "preview.jpg").await;
+
+    assert!(matches!(result, Err(ref e) if e.contains("workspace root is required")));
+}
+
+#[tokio::test]
+async fn read_preview_returns_none_when_file_absent() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let song = workspace.path().join("song");
+    fs::create_dir(&song).expect("song dir");
+
+    let result = read_preview_within_workspace(
+        song.to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(matches!(result, Ok(None)));
+}
+
+#[tokio::test]
+async fn read_preview_reads_file_inside_workspace() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let song = workspace.path().join("song");
+    fs::create_dir(&song).expect("song dir");
+    fs::write(song.join("preview.jpg"), b"img").expect("preview");
+
+    let result = read_preview_within_workspace(
+        song.to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Some(ref bytes)) if bytes == b"img"));
+}
+
+#[test]
+fn number_id_accepts_i64_and_numeric_strings_but_rejects_overflow_and_invalid_types() {
+    assert_eq!(number_id(&json!(42)).unwrap(), 42);
+    assert_eq!(number_id(&json!(-7)).unwrap(), -7);
+    assert_eq!(number_id(&json!("123")).unwrap(), 123);
+    assert!(number_id(&json!(u64::MAX)).is_err());
+    assert!(number_id(&json!(null)).is_err());
+    assert!(number_id(&json!([1, 2])).is_err());
+    assert!(number_id(&json!("not a number")).is_err());
+}
+
+#[tokio::test]
+async fn fetch_user_simfiles_impl_returns_single_page() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(header("authorization", "Bearer token-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "simfiles": {
+                    "data": [gql_simfile()],
+                    "count": 1
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let result = fetch_user_simfiles_impl(&server.uri(), "token-1")
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["data"].as_array().unwrap().len(), 1);
+    assert_eq!(result["fromCache"], false);
+}
+
+#[tokio::test]
+async fn fetch_user_simfiles_impl_paginates_across_multiple_pages() {
+    let server = MockServer::start().await;
+
+    let page1_data = (0..100).map(gql_simfile_with_id).collect::<Vec<_>>();
+    let page2_data = (100..200).map(gql_simfile_with_id).collect::<Vec<_>>();
+    let page3_data = (200..250).map(gql_simfile_with_id).collect::<Vec<_>>();
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({ "variables": { "page": 1 } })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "simfiles": { "data": page1_data, "count": 250 } }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({ "variables": { "page": 2 } })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "simfiles": { "data": page2_data, "count": 250 } }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({ "variables": { "page": 3 } })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "simfiles": { "data": page3_data, "count": 250 } }
+        })))
+        .mount(&server)
+        .await;
+
+    let result = fetch_user_simfiles_impl(&server.uri(), "token-1")
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["data"].as_array().unwrap().len(), 250);
+}
+
+#[tokio::test]
+async fn fetch_user_simfiles_impl_returns_partial_data_on_mid_pagination_failure() {
+    let server = MockServer::start().await;
+
+    let page1_data = (0..100).map(gql_simfile_with_id).collect::<Vec<_>>();
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({ "variables": { "page": 1 } })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "simfiles": { "data": page1_data, "count": 200 } }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({ "variables": { "page": 2 } })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "errors": [{ "message": "boom", "extensions": { "code": "INTERNAL" } }]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = fetch_user_simfiles_impl(&server.uri(), "token-1")
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], false);
+    assert_eq!(result["data"].as_array().unwrap().len(), 100);
+    assert_eq!(result["fromCache"], false);
+}
+
+#[tokio::test]
+async fn get_next_display_id_impl_returns_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "data": { "nextDisplayId": 42 } })),
+        )
+        .mount(&server)
+        .await;
+
+    let id = get_next_display_id_impl(&server.uri(), "token-1")
+        .await
+        .expect("id");
+
+    assert_eq!(id, 42);
+}
+
+#[tokio::test]
+async fn get_next_display_id_impl_errors_when_missing() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": {} })))
+        .mount(&server)
+        .await;
+
+    assert!(get_next_display_id_impl(&server.uri(), "token-1")
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn fetch_cloud_song_impl_returns_cloud_song_data_when_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "data": { "simfile": gql_simfile() } })),
+        )
+        .mount(&server)
+        .await;
+
+    let result = fetch_cloud_song_impl(&server.uri(), "token-1", "42".to_string())
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["cloudSongData"]["id"], 42);
+    assert_eq!(result["cloudSongData"]["title"], "Song");
+    assert_eq!(result["cloudSongData"]["isPublished"], true);
+    assert_eq!(result["cloudSongData"]["createdAt"], "2024-01-02");
+}
+
+#[tokio::test]
+async fn fetch_cloud_song_impl_returns_failure_when_simfile_null() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "data": { "simfile": null } })),
+        )
+        .mount(&server)
+        .await;
+
+    let result = fetch_cloud_song_impl(&server.uri(), "token-1", "42".to_string())
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], false);
+    assert_eq!(result["error"], "Simfile not found");
+}
+
+#[tokio::test]
+async fn update_simfile_record_impl_returns_updated_simfile() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "updateSimfile": gql_simfile() }
+        })))
+        .mount(&server)
+        .await;
+
+    let result = update_simfile_record_impl(
+        &server.uri(),
+        "token-1",
+        "42".to_string(),
+        UpdateSimfileRecordInput {
+            title: Some("Updated".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["data"]["id"], 42);
+    assert_eq!(result["data"]["title"], "Song");
+    assert_eq!(result["data"]["isPublished"], true);
+}
+
+#[tokio::test]
+async fn update_simfile_record_impl_returns_failure_on_graphql_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "errors": [{ "message": "forbidden" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = update_simfile_record_impl(
+        &server.uri(),
+        "token-1",
+        "42".to_string(),
+        UpdateSimfileRecordInput::default(),
+    )
+    .await
+    .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], false);
+}
+
+#[tokio::test]
+async fn create_simfile_record_impl_creates_without_previews_when_no_song_path() {
+    let server = MockServer::start().await;
+    let workspace = tempfile::tempdir().expect("workspace");
+    let expected_variables = json!({
+        "input": {
+            "title": "Song",
+            "artist": "Artist",
+            "bpm": 180.0,
+            "displayId": null,
+            "isPublished": true,
+            "publishDate": "2024-01-01",
+            "downloadUrl": "https://files/song.zip",
+            "videoPreviewUrl": "https://video",
+            "dtxFiles": [{ "label": "EXT", "level": 9.2 }]
+        }
+    });
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_partial_json(json!({
+            "variables": expected_variables.clone()
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "createSimfile": gql_simfile() }
+        })))
+        .mount(&server)
+        .await;
+
+    let state = managed_workspace_state(workspace.path());
+    let result = create_simfile_record_with_workspace_state(
+        &server.uri(),
+        "token-1",
+        create_input_fixture_with_display_id(None),
+        &state,
+    )
+    .await
+    .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+    let requests = server.received_requests().await.expect("received requests");
+    assert_eq!(requests.len(), 1);
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("GraphQL JSON body");
+    assert_eq!(body["variables"], expected_variables);
+    assert!(body["variables"]["input"].get("levels").is_none());
+    assert!(body["variables"]["input"].get("songPath").is_none());
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["simfileId"], "42");
+    assert_eq!(result["data"]["id"], 42);
+    assert_eq!(result["data"]["isPublished"], true);
+    assert!(result.get("warnings").is_none());
+}
+
+#[tokio::test]
+async fn create_simfile_record_impl_skips_previews_when_files_absent() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "createSimfile": gql_simfile() }
+        })))
+        .mount(&server)
+        .await;
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let song = workspace.path().join("song");
+    fs::create_dir(&song).expect("song dir");
+
+    let mut simfile_data = create_input_fixture_with_display_id(None);
+    simfile_data.song_path = song.to_str().unwrap().to_string();
+    let result =
+        create_simfile_record_impl(&server.uri(), "token-1", simfile_data, workspace.path())
+            .await
+            .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    assert!(result.get("warnings").is_none());
+}
+
+#[test]
+fn number_id_rejects_object_and_array_input() {
+    // Defensive: a malformed renderer payload must surface as an error rather
+    // than panicking inside number_id.
+    assert!(number_id(&json!({ "id": "x" })).is_err());
+    assert!(number_id(&json!([1, 2, 3])).is_err());
+    assert!(number_id(&Value::Null).is_err());
+}
+
+#[test]
+fn number_id_accepts_u64_that_fits_in_i64() {
+    // IDs coming from JSON could deserialize as u64; values within i64 range
+    // must convert cleanly. (Anything outside i64 range must error — covered
+    // by number_id_accepts_i64_and_numeric_strings_but_rejects_overflow_and_invalid_types.)
+    let value: u64 = 123_456;
+    assert_eq!(number_id(&json!(value)).unwrap(), 123_456);
+}
+
+// ---------------------------------------------------------------------------
+// read_preview_within_workspace (temp-file based)
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn read_preview_within_workspace_rejects_empty_workspace_root() {
+    let result = read_preview_within_workspace("/some/song", "", "preview.jpg").await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("workspace root"));
+}
+
+#[tokio::test]
+async fn read_preview_within_workspace_rejects_nonexistent_workspace_root() {
+    let result = read_preview_within_workspace(
+        "/some/song",
+        "/nonexistent-workspace-root-12345",
+        "preview.jpg",
+    )
+    .await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Workspace root not found"));
+}
+
+#[tokio::test]
+async fn read_preview_within_workspace_rejects_song_outside_workspace() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+
+    let result = read_preview_within_workspace(
+        outside.path().to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("outside the workspace"));
+}
+
+#[tokio::test]
+async fn read_preview_within_workspace_returns_none_when_preview_absent() {
+    let workspace = tempfile::tempdir().unwrap();
+    let song = workspace.path().join("mysong");
+    fs::create_dir(&song).unwrap();
+
+    let result = read_preview_within_workspace(
+        song.to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), None);
+}
+
+#[tokio::test]
+async fn read_preview_within_workspace_returns_bytes_when_preview_present() {
+    let workspace = tempfile::tempdir().unwrap();
+    let song = workspace.path().join("mysong");
+    fs::create_dir(&song).unwrap();
+    fs::write(song.join("preview.jpg"), b"image-bytes").unwrap();
+
+    let result = read_preview_within_workspace(
+        song.to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Some(b"image-bytes".to_vec()));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn read_preview_rejects_symlink_pointing_outside_workspace() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let song = workspace.path().join("song");
+    fs::create_dir(&song).unwrap();
+
+    // File outside the workspace that the symlink will target.
+    let secret = outside.path().join("secret.jpg");
+    fs::write(&secret, b"secret-bytes").unwrap();
+
+    // Symlink inside the song folder pointing outside the workspace.
+    symlink(&secret, song.join("preview.jpg")).unwrap();
+
+    let result = read_preview_within_workspace(
+        song.to_str().unwrap(),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("outside the workspace"));
+}
+
+#[tokio::test]
+async fn create_simfile_record_impl_surfaces_preview_upload_warnings() {
+    let server = MockServer::start().await;
+    // Create mutation succeeds
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "createSimfile": {
+                    "id": 42,
+                    "title": "Song",
+                    "artist": "Artist",
+                    "bpm": 120.0,
+                    "userId": "u1",
+                    "isPublished": false,
+                    "displayId": null,
+                    "downloadUrl": null,
+                    "previewUrl": null,
+                    "videoPreviewUrl": null,
+                    "publishDate": "2026-08-15",
+                    "createdAt": "2026-08-15T00:00:00Z",
+                    "updatedAt": "2026-08-15T00:00:01Z",
+                    "dtxFiles": [],
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+    // Upload endpoint fails
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": "Storage error"
+        })))
+        .mount(&server)
+        .await;
+
+    let workspace = tempfile::tempdir().unwrap();
+    let song = workspace.path().join("mysong");
+    fs::create_dir(&song).unwrap();
+    fs::write(song.join("preview.jpg"), b"image").unwrap();
+    fs::write(song.join("preview.mp3"), b"audio").unwrap();
+
+    let mut simfile_data = create_input_fixture_with_display_id(None);
+    simfile_data.song_path = song.to_str().unwrap().to_string();
+
+    let result = create_simfile_record_impl(&server.uri(), "tok", simfile_data, workspace.path())
+        .await
+        .unwrap();
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], true);
+    let warnings = result["warnings"].as_array().expect("warnings array");
+    assert!(warnings.len() >= 2, "should have preview + sound warnings");
+    assert!(warnings
+        .iter()
+        .any(|w| w.as_str().unwrap().contains("Preview image")));
+    assert!(warnings
+        .iter()
+        .any(|w| w.as_str().unwrap().contains("Sound preview")));
+}
+
+#[tokio::test]
+async fn create_simfile_record_rejects_when_managed_workspace_is_unset_before_request() {
+    // Moving the root lookup below the GraphQL mutation would create a remote
+    // simfile even though preview file access is not authorized.
+    let server = MockServer::start().await;
+    let state = WorkspaceRootState::default();
+
+    let mut simfile_data = create_input_fixture_with_display_id(None);
+    simfile_data.song_path = "/untrusted/song".to_string();
+    let result =
+        create_simfile_record_with_workspace_state(&server.uri(), "token-1", simfile_data, &state)
+            .await;
+
+    assert!(result.is_err());
+    assert!(result
+        .expect_err("managed workspace is required")
+        .to_string()
+        .contains("workspace root is required"));
+    assert!(server
+        .received_requests()
+        .await
+        .expect("received requests")
+        .is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// fetch_cloud_song_impl — GraphQL error branch.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn fetch_cloud_song_impl_returns_failure_on_graphql_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "errors": [{ "message": "forbidden", "extensions": { "code": "FORBIDDEN" } }]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = fetch_cloud_song_impl(&server.uri(), "token-1", "42".to_string())
+        .await
+        .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], serde_json::json!(false));
+    assert!(result["error"].as_str().unwrap().contains("forbidden"));
+}
+
+// ---------------------------------------------------------------------------
+// create_simfile_record_impl — GraphQL error branch.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn create_simfile_record_impl_returns_failure_on_graphql_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "errors": [{ "message": "forbidden", "extensions": { "code": "FORBIDDEN" } }]
+        })))
+        .mount(&server)
+        .await;
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let result = create_simfile_record_impl(
+        &server.uri(),
+        "token-1",
+        create_input_fixture_with_display_id(None),
+        workspace.path(),
+    )
+    .await
+    .expect("result");
+    let result = serde_json::to_value(result).expect("serializes");
+
+    assert_eq!(result["success"], serde_json::json!(false));
+    assert!(result["error"].as_str().unwrap().contains("forbidden"));
+}
+
+// ---------------------------------------------------------------------------
+// read_preview_within_workspace — "Song folder not found" error path (patch
+// line 934). When the workspace root exists but the song folder does not,
+// the refactored containment check surfaces a clear NotFound message rather
+// than a generic I/O error.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn read_preview_within_workspace_rejects_nonexistent_song_folder() {
+    let workspace = tempfile::tempdir().expect("workspace");
+
+    // The nonexistent song folder must have an existing ancestor inside the
+    // workspace so the containment check passes and surfaces NotFound for the
+    // missing target itself (rather than rejecting it as outside the workspace).
+    let result = read_preview_within_workspace(
+        &format!(
+            "{}/nonexistent-song-folder-12345",
+            workspace.path().to_str().unwrap()
+        ),
+        workspace.path().to_str().unwrap(),
+        "preview.jpg",
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Song folder not found"));
+}

--- a/packages/dtx-desktop/src/renderer/src/components/LocalAssetFilesSection.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/LocalAssetFilesSection.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { UploadedAssetFiles } from '@dtx/common/components';
+
+	type AssetFile = {
+		fileName: string;
+		size: number;
+		lastModified: string;
+		key: string;
+	};
+
+	interface Props {
+		isLoadingFiles: boolean;
+		fileLoadError: string | null;
+		onRetry: () => void;
+		simfileId: string;
+		userFiles: File[];
+		loadAssetFiles: (simfileId: string) => Promise<AssetFile[]>;
+		uploadFile: (
+			fileName: string,
+			songFolderPath: string,
+			simfileId: string
+		) => Promise<{ success: boolean; error?: string }>;
+		songFolderPath: string;
+		disableUploads: boolean;
+	}
+
+	let {
+		isLoadingFiles,
+		fileLoadError,
+		onRetry,
+		simfileId,
+		userFiles,
+		loadAssetFiles,
+		uploadFile,
+		songFolderPath,
+		disableUploads
+	}: Props = $props();
+</script>
+
+<!-- Local Asset Files Section -->
+<div class="bg-surface-2 rounded-lg">
+	{#if isLoadingFiles}
+		<div class="flex justify-center p-4">
+			<p class="text-dim">Loading files...</p>
+		</div>
+	{:else if fileLoadError}
+		<div class="text-red p-4">
+			<p>{fileLoadError}</p>
+			<button
+				class="bg-magenta mt-2 rounded-sm px-3 py-1 text-sm text-[#16001a] hover:opacity-90"
+				onclick={onRetry}
+			>
+				Retry
+			</button>
+		</div>
+	{:else}
+		<!-- Use UploadedAssetFiles component for local files display -->
+		<UploadedAssetFiles
+			{simfileId}
+			{userFiles}
+			simfileBucketUrl=""
+			{loadAssetFiles}
+			{uploadFile}
+			isDesktop={true}
+			{songFolderPath}
+			{disableUploads}
+		/>
+	{/if}
+</div>

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -5,7 +5,7 @@
 	import { settingsStore } from '$lib/stores/settingsStore';
 	import { editorMappingStore } from '$lib/stores/editorMappingStore';
 	import { authStore } from '$lib/stores/authStore';
-	import { UploadedAssetFiles, ChartDetail } from '@dtx/common/components';
+	import { ChartDetail } from '@dtx/common/components';
 	import { isValidDtxFile } from '@dtx/common';
 	import type { SimfileModel, SimfileDtxFile } from '@dtx/common';
 	import { onMount } from 'svelte';
@@ -22,6 +22,7 @@
 		googleDriveStore
 	} from '$lib/stores/googleDriveStore';
 	import GoogleDriveUploadStatus from '$lib/components/GoogleDriveUploadStatus.svelte';
+	import LocalAssetFilesSection from '$lib/components/LocalAssetFilesSection.svelte';
 	import {
 		getPrimaryOutcomeKey,
 		getLocalSongActionKey,
@@ -1243,37 +1244,18 @@
 			{/snippet}
 
 			{#snippet local_files()}
-				<!-- Local Asset Files Section -->
-				<div class="bg-surface-2 rounded-lg">
-					{#if isLoadingFiles}
-						<div class="flex justify-center p-4">
-							<p class="text-dim">Loading files...</p>
-						</div>
-					{:else if fileLoadError}
-						<div class="text-red p-4">
-							<p>{fileLoadError}</p>
-							<button
-								class="bg-magenta mt-2 rounded-sm px-3 py-1 text-sm text-[#16001a] hover:opacity-90"
-								onclick={loadLocalFiles}
-							>
-								Retry
-							</button>
-						</div>
-					{:else}
-						<!-- Use UploadedAssetFiles component for local files display -->
-						<UploadedAssetFiles
-							simfileId={song.linkedSimFileId?.toString() || ''}
-							userFiles={localFiles}
-							simfileBucketUrl=""
-							loadAssetFiles={loadAssetFilesForDesktop}
-							uploadFile={(fileName, songFolderPath, simfileId) =>
-								desktopHost.uploadFile(fileName, songFolderPath, simfileId)}
-							isDesktop={true}
-							songFolderPath={song.path || ''}
-							disableUploads={!$authStore.isAuthenticated}
-						/>
-					{/if}
-				</div>
+				<LocalAssetFilesSection
+					{isLoadingFiles}
+					{fileLoadError}
+					onRetry={loadLocalFiles}
+					simfileId={song.linkedSimFileId?.toString() || ''}
+					userFiles={localFiles}
+					loadAssetFiles={loadAssetFilesForDesktop}
+					uploadFile={(fileName, songFolderPath, simfileId) =>
+						desktopHost.uploadFile(fileName, songFolderPath, simfileId)}
+					songFolderPath={song.path || ''}
+					disableUploads={!$authStore.isAuthenticated}
+				/>
 			{/snippet}
 		</ChartDetail>
 	</div>
@@ -1498,37 +1480,18 @@
 			{/snippet}
 
 			{#snippet local_files()}
-				<!-- Local Asset Files Section -->
-				<div class="bg-surface-2 rounded-lg">
-					{#if isLoadingFiles}
-						<div class="flex justify-center p-4">
-							<p class="text-dim">Loading files...</p>
-						</div>
-					{:else if fileLoadError}
-						<div class="text-red p-4">
-							<p>{fileLoadError}</p>
-							<button
-								class="bg-magenta mt-2 rounded-sm px-3 py-1 text-sm text-[#16001a] hover:opacity-90"
-								onclick={loadLocalFiles}
-							>
-								Retry
-							</button>
-						</div>
-					{:else}
-						<!-- Use UploadedAssetFiles component for local files display -->
-						<UploadedAssetFiles
-							simfileId={song.linkedSimFileId?.toString() || ''}
-							userFiles={localFiles}
-							simfileBucketUrl=""
-							loadAssetFiles={loadAssetFilesForDesktop}
-							uploadFile={(fileName, songFolderPath, simfileId) =>
-								desktopHost.uploadFile(fileName, songFolderPath, simfileId)}
-							isDesktop={true}
-							songFolderPath={song.path || ''}
-							disableUploads={!$authStore.isAuthenticated}
-						/>
-					{/if}
-				</div>
+				<LocalAssetFilesSection
+					{isLoadingFiles}
+					{fileLoadError}
+					onRetry={loadLocalFiles}
+					simfileId={song.linkedSimFileId?.toString() || ''}
+					userFiles={localFiles}
+					loadAssetFiles={loadAssetFilesForDesktop}
+					uploadFile={(fileName, songFolderPath, simfileId) =>
+						desktopHost.uploadFile(fileName, songFolderPath, simfileId)}
+					songFolderPath={song.path || ''}
+					disableUploads={!$authStore.isAuthenticated}
+				/>
 			{/snippet}
 
 			{#snippet save()}

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -29,6 +29,9 @@
 		beginLocalSongAction as beginLocalSongActionInMap,
 		finishLocalSongAction as finishLocalSongActionInMap,
 		isSelectionCurrent,
+		computeDriveFieldMerge,
+		getCachedDisplayId,
+		shouldSkipAutoPopulate,
 		type LocalSongAction
 	} from '$lib/services/songDetailsActions';
 
@@ -307,19 +310,13 @@
 		simfileId: string,
 		outcome: SongSaveOutcome['driveUpload']
 	): void => {
-		if (outcome.status !== 'success') return;
-
-		const fields = {
-			...(outcome.fileId === undefined ? {} : { googleDriveFileId: outcome.fileId }),
-			...(outcome.downloadUrl === undefined ? {} : { downloadUrl: outcome.downloadUrl })
-		};
-		if (Object.keys(fields).length === 0) return;
+		const fields = computeDriveFieldMerge(outcome);
+		if (!fields) return;
 
 		if (targetSong.linkedSimFile && targetSong.linkedSimFileId === simfileId) {
 			targetSong.linkedSimFile = {
 				...targetSong.linkedSimFile,
-				...(outcome.fileId === undefined ? {} : { googleDriveFileId: outcome.fileId }),
-				...(outcome.downloadUrl === undefined ? {} : { downloadUrl: outcome.downloadUrl })
+				...fields
 			};
 		}
 		workspaceStore.mergeGoogleDriveFields(targetPath, simfileId, fields);
@@ -567,12 +564,12 @@
 	};
 
 	const populateNextDisplayId = async (currentPath: string) => {
-		if (autoPopulateInFlightPaths.has(currentPath)) {
+		if (shouldSkipAutoPopulate(autoPopulateInFlightPaths, currentPath)) {
 			return;
 		}
 
 		// Restore cached value on revisit without re-fetching
-		const cachedId = autoPopulatedForPaths.get(currentPath);
+		const cachedId = getCachedDisplayId(autoPopulatedForPaths, currentPath);
 		if (cachedId !== undefined) {
 			if (displayId === 0) {
 				displayId = cachedId;

--- a/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
+++ b/packages/dtx-desktop/src/renderer/src/components/SongDetails.svelte
@@ -22,6 +22,15 @@
 		googleDriveStore
 	} from '$lib/stores/googleDriveStore';
 	import GoogleDriveUploadStatus from '$lib/components/GoogleDriveUploadStatus.svelte';
+	import {
+		getPrimaryOutcomeKey,
+		getLocalSongActionKey,
+		withoutMapKey,
+		beginLocalSongAction as beginLocalSongActionInMap,
+		finishLocalSongAction as finishLocalSongActionInMap,
+		isSelectionCurrent,
+		type LocalSongAction
+	} from '$lib/services/songDetailsActions';
 
 	interface Props {
 		song: TreeNode;
@@ -62,10 +71,6 @@
 	type PrimarySaveSuccess = {
 		simfileId: string;
 		messageKey: 'googleDrive.songDetails.draftSaved' | 'googleDrive.songDetails.published';
-	};
-
-	type LocalSongAction = {
-		kind: 'create' | 'update' | 'drive';
 	};
 
 	type TimedPrimaryError = {
@@ -259,12 +264,6 @@
 	let selectionGeneration = 0;
 	let primaryOutcomeSequence = 0;
 	const currentSimfileId = $derived(song.linkedSimFileId || undefined);
-	const getPrimaryOutcomeKey = (targetSong: TreeNode, workspacePath: string): string =>
-		`workspace:${workspacePath}\u0000song:${targetSong.path || targetSong.name}`;
-	const getLocalSongActionKey = (targetSong: TreeNode, workspacePath: string): string => {
-		if (targetSong.linkedSimFileId) return `simfile:${targetSong.linkedSimFileId}`;
-		return getPrimaryOutcomeKey(targetSong, workspacePath);
-	};
 	const currentPrimaryOutcomeKey = $derived(
 		getPrimaryOutcomeKey(song, $workspaceStore.path || '')
 	);
@@ -292,23 +291,14 @@
 		key: string,
 		kind: LocalSongAction['kind']
 	): LocalSongAction | undefined => {
-		if (localSongActions.has(key)) return undefined;
-		const action = { kind };
-		localSongActions = new Map(localSongActions).set(key, action);
-		return action;
+		const result = beginLocalSongActionInMap(localSongActions, key, kind);
+		if (!result) return undefined;
+		localSongActions = result.actions;
+		return result.action;
 	};
 
 	const finishLocalSongAction = (key: string, action: LocalSongAction): void => {
-		if (localSongActions.get(key) !== action) return;
-		const nextActions = new Map(localSongActions);
-		nextActions.delete(key);
-		localSongActions = nextActions;
-	};
-
-	const withoutMapKey = <T,>(source: Map<string, T>, key: string): Map<string, T> => {
-		const next = new Map(source);
-		next.delete(key);
-		return next;
+		localSongActions = finishLocalSongActionInMap(localSongActions, key, action);
 	};
 
 	const mergeSuccessfulDriveFields = (
@@ -493,7 +483,14 @@
 					targetSong.linkedSimFileId = savedSimfileId;
 					targetSong.linkedSimFile = linkedSimfile;
 					workspaceStore.linkSimFileToFolder(targetPath, linkedSimfile);
-					if (selectionGeneration === selectionToken && song.path === targetPath) {
+					if (
+						isSelectionCurrent({
+							generation: selectionGeneration,
+							token: selectionToken,
+							currentPath: song.path,
+							targetPath
+						})
+					) {
 						song = { ...targetSong };
 						primarySaveSuccess = {
 							simfileId: savedSimfileId,
@@ -524,8 +521,12 @@
 			const savedSimfileId = targetSong.linkedSimFileId || '';
 			if (
 				savedSimfileId &&
-				selectionGeneration === selectionToken &&
-				song.path === targetPath &&
+				isSelectionCurrent({
+					generation: selectionGeneration,
+					token: selectionToken,
+					currentPath: song.path,
+					targetPath
+				}) &&
 				song.linkedSimFileId === savedSimfileId
 			) {
 				driveOutcome = {
@@ -744,7 +745,14 @@
 					};
 					targetSong.linkedSimFile = updatedSimfile;
 					workspaceStore.linkSimFileToFolder(targetPath, updatedSimfile);
-					if (selectionGeneration === selectionToken && song.path === targetPath) {
+					if (
+						isSelectionCurrent({
+							generation: selectionGeneration,
+							token: selectionToken,
+							currentPath: song.path,
+							targetPath
+						})
+					) {
 						primarySaveSuccess = {
 							simfileId,
 							messageKey: published
@@ -763,8 +771,12 @@
 				throw new Error(outcome.simfileSave.error || 'Failed to update simfile');
 			}
 			if (
-				selectionGeneration === selectionToken &&
-				song.path === targetPath &&
+				isSelectionCurrent({
+					generation: selectionGeneration,
+					token: selectionToken,
+					currentPath: song.path,
+					targetPath
+				}) &&
 				song.linkedSimFileId === simfileId
 			) {
 				driveOutcome = {
@@ -873,8 +885,12 @@
 				...(forceCreateReplacement ? { forceCreateReplacement: true } : {})
 			});
 			if (
-				selectionGeneration === selectionToken &&
-				song.path === targetPath &&
+				isSelectionCurrent({
+					generation: selectionGeneration,
+					token: selectionToken,
+					currentPath: song.path,
+					targetPath
+				}) &&
 				song.linkedSimFileId === simfileId
 			) {
 				driveOutcome = {

--- a/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.test.ts
@@ -6,6 +6,9 @@ import {
 	beginLocalSongAction,
 	finishLocalSongAction,
 	isSelectionCurrent,
+	computeDriveFieldMerge,
+	getCachedDisplayId,
+	shouldSkipAutoPopulate,
 	type LocalSongAction
 } from './songDetailsActions';
 
@@ -147,5 +150,62 @@ describe('isSelectionCurrent', () => {
 				targetPath: '/ws/song'
 			})
 		).toBe(false);
+	});
+});
+
+describe('computeDriveFieldMerge', () => {
+	it('returns null when the upload failed', () => {
+		expect(computeDriveFieldMerge({ status: 'failed', errorCode: 'NETWORK' })).toBeNull();
+	});
+
+	it('returns null when skipped', () => {
+		expect(computeDriveFieldMerge({ status: 'skipped' })).toBeNull();
+	});
+
+	it('returns null on success with no relevant fields present', () => {
+		expect(computeDriveFieldMerge({ status: 'success' })).toBeNull();
+	});
+
+	it('returns only the defined fields on success', () => {
+		expect(
+			computeDriveFieldMerge({
+				status: 'success',
+				fileId: 'drive-id',
+				downloadUrl: 'https://drive.example/file'
+			})
+		).toEqual({
+			googleDriveFileId: 'drive-id',
+			downloadUrl: 'https://drive.example/file'
+		});
+	});
+
+	it('omits an undefined downloadUrl while keeping the fileId', () => {
+		expect(computeDriveFieldMerge({ status: 'success', fileId: 'drive-id' })).toEqual({
+			googleDriveFileId: 'drive-id'
+		});
+	});
+});
+
+describe('getCachedDisplayId', () => {
+	it('returns the cached value for a known path', () => {
+		const cache = new Map([['/ws/song', 42]]);
+		expect(getCachedDisplayId(cache, '/ws/song')).toBe(42);
+	});
+
+	it('returns undefined for an unknown path', () => {
+		const cache = new Map<string, number>();
+		expect(getCachedDisplayId(cache, '/ws/song')).toBeUndefined();
+	});
+});
+
+describe('shouldSkipAutoPopulate', () => {
+	it('is true when the path is already in flight', () => {
+		const inFlight = new Set(['/ws/song']);
+		expect(shouldSkipAutoPopulate(inFlight, '/ws/song')).toBe(true);
+	});
+
+	it('is false when the path is neither cached nor in flight', () => {
+		const inFlight = new Set<string>();
+		expect(shouldSkipAutoPopulate(inFlight, '/ws/song')).toBe(false);
 	});
 });

--- a/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.test.ts
@@ -10,7 +10,7 @@ import {
 	getCachedDisplayId,
 	shouldSkipAutoPopulate,
 	type LocalSongAction
-} from './songDetailsActions';
+} from '$lib/services/songDetailsActions';
 
 const nulByte = String.fromCharCode(0);
 

--- a/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.test.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+	getPrimaryOutcomeKey,
+	getLocalSongActionKey,
+	withoutMapKey,
+	beginLocalSongAction,
+	finishLocalSongAction,
+	isSelectionCurrent,
+	type LocalSongAction
+} from './songDetailsActions';
+
+const nulByte = String.fromCharCode(0);
+
+describe('getPrimaryOutcomeKey', () => {
+	it('keys by workspace path and song path, separated by a NUL byte', () => {
+		const key = getPrimaryOutcomeKey({ path: '/ws/song', name: 'song' }, '/ws');
+		expect(key).toBe(`workspace:/ws${nulByte}song:/ws/song`);
+	});
+
+	it('falls back to song name when path is missing', () => {
+		const key = getPrimaryOutcomeKey({ path: '', name: 'song' }, '/ws');
+		expect(key).toBe(`workspace:/ws${nulByte}song:song`);
+	});
+});
+
+describe('getLocalSongActionKey', () => {
+	it('keys by linked simfile id when the song is linked', () => {
+		const key = getLocalSongActionKey(
+			{ path: '/ws/song', name: 'song', linkedSimFileId: '42' },
+			'/ws'
+		);
+		expect(key).toBe('simfile:42');
+	});
+
+	it('falls back to the primary outcome key when unlinked', () => {
+		const key = getLocalSongActionKey({ path: '/ws/song', name: 'song' }, '/ws');
+		expect(key).toBe(getPrimaryOutcomeKey({ path: '/ws/song', name: 'song' }, '/ws'));
+	});
+});
+
+describe('withoutMapKey', () => {
+	it('returns a new map without the given key', () => {
+		const source = new Map([
+			['a', 1],
+			['b', 2]
+		]);
+		const result = withoutMapKey(source, 'a');
+		expect([...result.entries()]).toEqual([['b', 2]]);
+		expect(source.has('a')).toBe(true);
+	});
+
+	it('is a no-op value-wise when the key is absent', () => {
+		const source = new Map([['a', 1]]);
+		const result = withoutMapKey(source, 'missing');
+		expect([...result.entries()]).toEqual([['a', 1]]);
+		expect(result).not.toBe(source);
+	});
+});
+
+describe('beginLocalSongAction', () => {
+	it('locks a fresh key and returns a new map plus the action', () => {
+		const actions = new Map<string, LocalSongAction>();
+		const result = beginLocalSongAction(actions, 'song-a', 'create');
+		expect(result).not.toBeNull();
+		expect(result?.action).toEqual({ kind: 'create' });
+		expect(result?.actions.get('song-a')).toBe(result?.action);
+		expect(actions.size).toBe(0);
+	});
+
+	it('refuses a second concurrent action for the same key', () => {
+		const actions = new Map<string, LocalSongAction>();
+		const first = beginLocalSongAction(actions, 'song-a', 'create');
+		const second = beginLocalSongAction(first!.actions, 'song-a', 'update');
+		expect(second).toBeNull();
+	});
+
+	it('allows a concurrent action for a different key', () => {
+		const actions = new Map<string, LocalSongAction>();
+		const first = beginLocalSongAction(actions, 'song-a', 'create');
+		const second = beginLocalSongAction(first!.actions, 'song-b', 'create');
+		expect(second).not.toBeNull();
+		expect(second?.actions.get('song-a')).toBe(first?.action);
+		expect(second?.actions.get('song-b')).toBe(second?.action);
+	});
+});
+
+describe('finishLocalSongAction', () => {
+	it('removes the key when the action reference matches', () => {
+		const actions = new Map<string, LocalSongAction>();
+		const begun = beginLocalSongAction(actions, 'song-a', 'update')!;
+		const result = finishLocalSongAction(begun.actions, 'song-a', begun.action);
+		expect(result.has('song-a')).toBe(false);
+	});
+
+	it('is a no-op when a stale finish races a newer action for the same key', () => {
+		const actions = new Map<string, LocalSongAction>();
+		const staleBegun = beginLocalSongAction(actions, 'song-a', 'update')!;
+		const finished = finishLocalSongAction(staleBegun.actions, 'song-a', staleBegun.action);
+		const newerBegun = beginLocalSongAction(finished, 'song-a', 'drive')!;
+
+		const staleFinishResult = finishLocalSongAction(
+			newerBegun.actions,
+			'song-a',
+			staleBegun.action
+		);
+
+		expect(staleFinishResult).toBe(newerBegun.actions);
+		expect(staleFinishResult.get('song-a')).toBe(newerBegun.action);
+	});
+
+	it('is a no-op when the key was never present', () => {
+		const actions = new Map<string, LocalSongAction>();
+		const result = finishLocalSongAction(actions, 'song-a', { kind: 'create' });
+		expect(result).toBe(actions);
+	});
+});
+
+describe('isSelectionCurrent', () => {
+	it('is true when generation matches the token and paths match', () => {
+		expect(
+			isSelectionCurrent({
+				generation: 1,
+				token: 1,
+				currentPath: '/ws/song',
+				targetPath: '/ws/song'
+			})
+		).toBe(true);
+	});
+
+	it('is false once the generation has advanced past the token', () => {
+		expect(
+			isSelectionCurrent({
+				generation: 2,
+				token: 1,
+				currentPath: '/ws/song',
+				targetPath: '/ws/song'
+			})
+		).toBe(false);
+	});
+
+	it('is false once the selected path diverges from the target path', () => {
+		expect(
+			isSelectionCurrent({
+				generation: 1,
+				token: 1,
+				currentPath: '/ws/other-song',
+				targetPath: '/ws/song'
+			})
+		).toBe(false);
+	});
+});

--- a/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.ts
@@ -1,4 +1,4 @@
-import type { SongSaveOutcome } from './googleDriveService';
+import type { SongSaveOutcome } from '$lib/services/googleDriveService';
 
 export type LocalSongAction = {
 	kind: 'create' | 'update' | 'drive';

--- a/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.ts
@@ -1,0 +1,52 @@
+export type LocalSongAction = {
+	kind: 'create' | 'update' | 'drive';
+};
+
+type SongIdentity = {
+	path?: string | null;
+	name?: string | null;
+	linkedSimFileId?: string | null;
+};
+
+export const getPrimaryOutcomeKey = (song: SongIdentity, workspacePath: string): string =>
+	`workspace:${workspacePath}${String.fromCharCode(0)}song:${song.path || song.name}`;
+
+export const getLocalSongActionKey = (song: SongIdentity, workspacePath: string): string => {
+	if (song.linkedSimFileId) return `simfile:${song.linkedSimFileId}`;
+	return getPrimaryOutcomeKey(song, workspacePath);
+};
+
+export const withoutMapKey = <T>(source: Map<string, T>, key: string): Map<string, T> => {
+	const next = new Map(source);
+	next.delete(key);
+	return next;
+};
+
+export const beginLocalSongAction = (
+	actions: Map<string, LocalSongAction>,
+	key: string,
+	kind: LocalSongAction['kind']
+): { actions: Map<string, LocalSongAction>; action: LocalSongAction } | null => {
+	if (actions.has(key)) return null;
+	const action: LocalSongAction = { kind };
+	const nextActions = new Map(actions).set(key, action);
+	return { actions: nextActions, action };
+};
+
+export const finishLocalSongAction = (
+	actions: Map<string, LocalSongAction>,
+	key: string,
+	action: LocalSongAction
+): Map<string, LocalSongAction> => {
+	if (actions.get(key) !== action) return actions;
+	const nextActions = new Map(actions);
+	nextActions.delete(key);
+	return nextActions;
+};
+
+export const isSelectionCurrent = (params: {
+	generation: number;
+	token: number;
+	currentPath: string;
+	targetPath: string;
+}): boolean => params.generation === params.token && params.currentPath === params.targetPath;

--- a/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.ts
+++ b/packages/dtx-desktop/src/renderer/src/services/songDetailsActions.ts
@@ -1,3 +1,5 @@
+import type { SongSaveOutcome } from './googleDriveService';
+
 export type LocalSongAction = {
 	kind: 'create' | 'update' | 'drive';
 };
@@ -50,3 +52,23 @@ export const isSelectionCurrent = (params: {
 	currentPath: string;
 	targetPath: string;
 }): boolean => params.generation === params.token && params.currentPath === params.targetPath;
+
+export const computeDriveFieldMerge = (
+	outcome: SongSaveOutcome['driveUpload']
+): { googleDriveFileId?: string; downloadUrl?: string } | null => {
+	if (outcome.status !== 'success') return null;
+
+	const fields = {
+		...(outcome.fileId === undefined ? {} : { googleDriveFileId: outcome.fileId }),
+		...(outcome.downloadUrl === undefined ? {} : { downloadUrl: outcome.downloadUrl })
+	};
+	if (Object.keys(fields).length === 0) return null;
+
+	return fields;
+};
+
+export const getCachedDisplayId = (cache: Map<string, number>, path: string): number | undefined =>
+	cache.get(path);
+
+export const shouldSkipAutoPopulate = (inFlightPaths: Set<string>, path: string): boolean =>
+	inFlightPaths.has(path);


### PR DESCRIPTION
## Summary
This branch continues the HPA-616 refactor work:

- **common / Preview**
  - Extract pure timing/measure-offset/cell-height calculations into `previewCalculations.ts` with standalone unit tests.
  - Extract sound-cache-key, WAV blob encoding, and XA decode/blob preparation into `soundChipPreparation.ts` with standalone unit tests.
  - Wire `Preview.ts` to both helpers and replace the deferred `currentSoundChip` subscription with an explicit guard, eliminating the 100 ms `setTimeout` while preserving observable behavior.

- **desktop / SongDetails & Rust**
  - Extract the duplicated `local_files` snippet into `LocalAssetFilesSection.svelte`.
  - Move migrated simfile Tauri commands (`fetch_user_simfiles`, `get_next_display_id`, `fetch_cloud_song`, `update_simfile_record`, `create_simfile_record`) and their tests from `api.rs` into a new `simfile.rs` module.
  - Extract `SongDetails` action locking/selection guard and outcome-transition/field-merge decisions into `songDetailsActions.ts` with unit tests.

## Test plan
- [x] `bun run --filter=@dtx/common test -- previewCalculations.test.ts soundChipPreparation.test.ts Preview.test.ts` — passed
- [x] `bun run --filter=dtx-desktop test` — 1037 passed
- [x] `cargo test --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml` — 1039 passed
- [x] `cargo fmt --check --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml` — passed
- [x] `cargo clippy --manifest-path packages/dtx-desktop/src-tauri/Cargo.toml` — passed

> Note: the full `@dtx/common` test suite currently fails in this local environment because `xa_decoder` is not installed, but the Preview/refactor tests directly covering these changes pass.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sound-chip audio preparation and caching, including XA audio conversion.
  * Added simfile listing, creation, updating, cloud-song retrieval, and display ID functionality.
  * Added local asset file loading with error handling and retry support.

* **Bug Fixes**
  * Improved audio playback reliability and cache reuse.
  * Prevented stale song actions from updating the interface after selection changes.
  * Improved preview timing and measurements across BPM changes.
  * Strengthened preview-file access validation within the workspace.

* **Tests**
  * Expanded coverage for audio, previews, simfile operations, and song-detail actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->