### PR TITLE
Add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,21 @@
+{
+	"name": "Drumery",
+	"user": "ubuntu",
+	"install": "bash .cursor/install.sh",
+	"terminals": [
+		{
+			"name": "api",
+			"description": "Local GraphQL API (dtx-api) on http://localhost:8787, run with `wrangler dev` in local mode (Miniflare D1/R2/KV). GraphiQL is enabled and CORS allows the web dev origin.",
+			"command": "export PATH=\"$HOME/.bun/bin:$PATH\"; cd packages/dtx-api && exec bunx wrangler dev --local --port 8787 --env-file ../../.env --var GRAPHIQL:true --var CORS_ALLOWED_ORIGINS:http://localhost:5173 --var AUTH_COOKIE_DOMAIN:"
+		},
+		{
+			"name": "web",
+			"description": "SvelteKit web app (dtx-web) on http://localhost:5173, pointed at the local API via PUBLIC_DTX_API_URL=http://localhost:8787.",
+			"command": "export PATH=\"$HOME/.bun/bin:$PATH\"; exec bun run --filter=dtx-web dev:local-api"
+		}
+	],
+	"ports": [
+		{ "name": "web", "port": 5173 },
+		{ "name": "api", "port": 8787 }
+	]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Cloud Agent bootstrap for the Drumery monorepo.
+# Idempotent: safe to run repeatedly and against a warm snapshot.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# The base image ships Node (>=22.18, with TypeScript type-stripping) and the
+# Rust toolchain, but not Bun. Bun is the package manager and runtime for this
+# repo, so install the pinned version when it is missing.
+BUN_VERSION="1.3.9"
+if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version 2>/dev/null)" != "$BUN_VERSION" ]; then
+	curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+fi
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# Local development secrets/config (.env is gitignored). Seed it from the
+# committed example so the API dev server has values to run against.
+if [ ! -f .env ]; then
+	cp .env.example .env
+fi
+
+# Install all workspace dependencies from the committed lockfile.
+bun install --frozen-lockfile
+
+# @dtx/ui-components and @dtx/common are consumed by the other packages through
+# their built dist/ exports (and their generated type declarations), so build
+# them once here. Other packages are built on demand.
+bun run --filter=@dtx/ui-components build
+bun run --filter=@dtx/common build
+
+# Prepare the local (Miniflare) D1 database for the API so a local
+# `wrangler dev` serves real queries. Idempotent: wrangler skips applied
+# migrations.
+(cd packages/dtx-api && bunx wrangler d1 migrations apply dtx-web --local)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for the Drumery monorepo and verifies the app runs end-to-end.

The base image already provides Node (≥22.18, with TypeScript type-stripping — this matters for `dtx-api`'s Supabase-migration CLI test) and the Rust toolchain, but not Bun (the repo's package manager/runtime). The new config installs the pinned Bun, restores dependencies, builds the library packages other packages consume, seeds local dev config, prepares the local D1 database, and launches the API + web dev servers.

## Changes

- `.cursor/environment.json`
  - `install`: runs `.cursor/install.sh`.
  - `terminals`: `api` (`wrangler dev` local mode on `:8787` with Miniflare D1/R2/KV, GraphiQL enabled, CORS allowing the web origin) and `web` (SvelteKit dev on `:5173`, pointed at the local API).
  - `ports`: exposes `5173` (web) and `8787` (api).
- `.cursor/install.sh` (idempotent):
  - Installs Bun `1.3.9` when missing.
  - Seeds `.env` from `.env.example` (`.env` is gitignored).
  - `bun install --frozen-lockfile`.
  - Builds `@dtx/ui-components` and `@dtx/common` (both are consumed via their `dist/` exports and generated type declarations).
  - Applies local D1 migrations for the API (`wrangler d1 migrations apply dtx-web --local`).

## Verification

- `bun install` — 1360 packages, lockfile unchanged.
- Tests: `@dtx/common` 1361 passed, `dtx-web` 888 passed, `dtx-api` 407 passed (the one initially-failing API test was only failing under an older `/exec-daemon` Node 22.14 that lacks unflagged type-stripping; it passes under the login-shell Node 22.22.2 the environment actually uses).
- Builds: `@dtx/common` and `@dtx/ui-components` build clean; `bun run check` passes for `@dtx/common`/`@dtx/ui-components` (one pre-existing `dtx-web` type error in a test file is unrelated to this change and not a CI gate).
- Ran the full stack locally: GraphQL API on `:8787` (introspection + a live `simfiles(scope: PUBLISHED)` query against local D1 returning `count: 0`) and the web app on `:5173`, and navigated homepage → charts → editor in the browser.
- **Fresh-pod environment build succeeded** (`bld-20260827-675fb645-…`): a clean checkout + `.cursor/install.sh` completed on a new pod — Bun 1.3.9, 1360 packages installed, both library builds, all D1 migrations applied, snapshot ready.
- Re-ran `.cursor/install.sh` to confirm idempotency.

[drumery_web_app_walkthrough.mp4](https://cursor.com/agents/bc-13836f0d-68ae-4d2d-9fff-013a66c7e5a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdrumery_web_app_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13836f0d-68ae-4d2d-9fff-013a66c7e5a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13836f0d-68ae-4d2d-9fff-013a66c7e5a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

